### PR TITLE
Cli/deploy improvements

### DIFF
--- a/packages/botonic-cli/src/botonicAPIService.ts
+++ b/packages/botonic-cli/src/botonicAPIService.ts
@@ -123,7 +123,8 @@ export class BotonicAPIService {
       var build_out = await exec(`npm run ${npmCommand}`)
     } catch (error) {
       spinner.fail()
-      console.log(colors.red(`Build error ${error}`))
+      console.log(`${error.stdout}` +
+        colors.red(`\n\nBuild error:\n${error}`))
       return false
     }
     spinner.succeed()

--- a/packages/botonic-cli/src/botonicAPIService.ts
+++ b/packages/botonic-cli/src/botonicAPIService.ts
@@ -114,13 +114,13 @@ export class BotonicAPIService {
     return hash.hash
   }
 
-  async build() {
+  async build(npmCommand: string = 'build') {
     let spinner = new ora({
       text: 'Building...',
       spinner: 'bouncingBar'
     }).start()
     try {
-      var build_out = await exec('npm run build')
+      var build_out = await exec(`npm run ${npmCommand}`)
     } catch (error) {
       spinner.fail()
       console.log(colors.red(`Build error ${error}`))
@@ -130,11 +130,11 @@ export class BotonicAPIService {
     return true
   }
 
-  async buildIfChanged() {
+  async buildIfChanged(npmCommand?: string) {
     let hash = await this.getCurrentBuildHash()
     if (hash != this.lastBuildHash) {
       this.lastBuildHash = hash
-      return await this.build()
+      return await this.build(npmCommand)
     }
     return true
   }

--- a/packages/botonic-cli/src/botonicAPIService.ts
+++ b/packages/botonic-cli/src/botonicAPIService.ts
@@ -108,7 +108,7 @@ export class BotonicAPIService {
   async getCurrentBuildHash() {
     const options = {
       folders: { exclude: ['.*', 'node_modules', 'dist'] },
-      files: { include: ['*.js', '*.css'] }
+      files: { include: ['*.js', '*.jsx', '*.ts', '*.tsx', '*.css', '*.scss'] }
     }
     let hash = await hashElement('.', options)
     return hash.hash

--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -11,6 +11,7 @@ import { BotonicAPIService } from '../botonicAPIService'
 import { track, sleep } from '../utils'
 
 var force = false
+var npmCommand: string
 
 export default class Run extends Command {
   static description = 'Deploy Botonic project to hubtype.com'
@@ -26,7 +27,11 @@ Uploading...
   static flags = {
     force: flags.boolean({
       char: 'f',
-      description: 'Force deploy despite of no changes. Disabled by default'
+      description: 'Force deploy despite of no changes. Disabled by default',
+    }),
+    command: flags.string({
+      char: 'c',
+      description: 'Command to execute from the package "scripts" object',
     }),
     botName: flags.string()
   }
@@ -40,6 +45,7 @@ Uploading...
     track('Deployed Botonic CLI')
 
     force = flags.force ? flags.force : false
+    npmCommand = flags.command
     let botName = flags.botName ? flags.botName : false
 
     if (!this.botonicApiService.oauth) await this.signupFlow()
@@ -251,7 +257,7 @@ Uploading...
   }
 
   async deploy() {
-    let build_out = await this.botonicApiService.buildIfChanged()
+    let build_out = await this.botonicApiService.buildIfChanged(npmCommand)
     if (!build_out) {
       track('Deploy Botonic Build Error')
       console.log(colors.red('There was a problem building the bot'))


### PR DESCRIPTION
Improvements on "botonic deploy"
* hash also typescript and scss files for rebuild check
* add flag to customize "npm run" build command. Eg. Useful to build with different command when deploying in staging environment
* When "npm run build" fails, it was not showing why