### PR TITLE
feature(react): call new Plugin's init method from loaded

### DIFF
--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.9.0-beta.1",
+  "version": "0.9.0-beta.2",
   "description": "Build Chatbots using React",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/botonic-react/src/utils.js
+++ b/packages/botonic-react/src/utils.js
@@ -75,6 +75,11 @@ export function loadPlugins(plugins) {
     let id = plugins[i].id || `${instance.constructor.name}`
     _plugins[id] = instance
   }
+  for (let _plugin of Object.values(_plugins)) {
+    if (_plugin.init) {
+      _plugin.init(_plugins)
+    }
+  }
   return _plugins
 }
 


### PR DESCRIPTION
Proposal to allow one plugin to use other plugins.

Plugin would be able to implement an "init(pluginInstances)" method so that they can store them and use them when necessary.
I think it could be interesting that the init method was async so that the plugin can done some async initialization (like connecting to an external service), so that it does not need to be in a lazy fashion. But not implemented because it was not required here.
In the future it would be nice also to pass the bot_id to this method, in case the plugin requires different configuration for each bot integration. 