### PR TITLE
feature(cli): rebuild with -f

### DIFF
--- a/packages/botonic-cli/src/botonicAPIService.ts
+++ b/packages/botonic-cli/src/botonicAPIService.ts
@@ -131,9 +131,9 @@ export class BotonicAPIService {
     return true
   }
 
-  async buildIfChanged(npmCommand?: string) {
+  async buildIfChanged(force: boolean, npmCommand?: string) {
     let hash = await this.getCurrentBuildHash()
-    if (hash != this.lastBuildHash) {
+    if (force || hash != this.lastBuildHash) {
       this.lastBuildHash = hash
       return await this.build(npmCommand)
     }

--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -257,7 +257,7 @@ Uploading...
   }
 
   async deploy() {
-    let build_out = await this.botonicApiService.buildIfChanged(npmCommand)
+    let build_out = await this.botonicApiService.buildIfChanged(force, npmCommand)
     if (!build_out) {
       track('Deploy Botonic Build Error')
       console.log(colors.red('There was a problem building the bot'))

--- a/packages/botonic-cli/src/commands/new.ts
+++ b/packages/botonic-cli/src/commands/new.ts
@@ -107,7 +107,7 @@ Creating...
     let dependencyCommand = `npm install`
     let dependency = await exec(dependencyCommand)
     spinner.succeed()
-    await this.botonicApiService.buildIfChanged()
+    await this.botonicApiService.buildIfChanged(false)
     this.botonicApiService.beforeExit()
     await exec('mv ../.botonic.json .')
     let cd_cmd = colors.bold(`cd ${args.name}`)


### PR DESCRIPTION
So far there was no way to force a rebuild when there were no changes on the bot code.
This is necessary eg. when a dependency changes