### PR TITLE
fix: simplify code only deleting 'else'

### DIFF
--- a/packages/botonic-react/src/components/button.jsx
+++ b/packages/botonic-react/src/components/button.jsx
@@ -38,8 +38,8 @@ export const Button = props => {
     else if (props.payload) sendPayload(props.payload)
     else if (props.url) {
       window.open(props.url)
-      props.onClick()
-    } else if (props.onClick) props.onClick()
+    }
+    if (props.onClick) props.onClick()
   }
 
   const renderBrowser = () => {


### PR DESCRIPTION
I was using more code that I needed, the logic of this is for buttons of the persistent menu that once clicked the menu has to be closed