### PR TITLE
add(react): close webchat button for default headers

### DIFF
--- a/packages/botonic-react/src/webchat/header.jsx
+++ b/packages/botonic-react/src/webchat/header.jsx
@@ -27,7 +27,7 @@ const Diffuse = styled(Flex)`
   height: 55px;
   border-radius: 6px 6px 0px 0px;
 `
-const CrossHeader = styled(Flex)`
+const CloseHeader = styled(Flex)`
   position: absolute;
   right: 10px;
   top: 14px;
@@ -63,14 +63,14 @@ export const DefaultHeader = props => {
         <HeaderTitle>{headerTitle}</HeaderTitle>
         <Subtitle>{headerSubtitle}</Subtitle>
       </Flex>
-      <CrossHeader onClick={props.onChange}>X</CrossHeader>}
+      <CloseHeader onClick={props.onChange}>X</CloseHeader>}
     </Diffuse>
   )
 }
 
 export const WebchatHeader = () => {
   const { webchatState } = useContext(WebchatContext)
-  const handleCloseWebchat = () => {
+  const handleCloseWebchat = event => {
     props.onChange(event.target.value)
   }
   if (webchatState.theme.customHeader) {

--- a/packages/botonic-react/src/webchat/header.jsx
+++ b/packages/botonic-react/src/webchat/header.jsx
@@ -6,6 +6,7 @@ import { Flex } from '@rebass/grid'
 
 const HeaderTitle = styled.h1`
   @import url('https://fonts.googleapis.com/css?family=Noto+Sans+JP');
+  font-family: Arial, Helvetica, sans-serif;
   font-size: 15px;
   line-height: 22px;
   color: #ffffff;
@@ -13,6 +14,7 @@ const HeaderTitle = styled.h1`
 
 const Subtitle = styled.h1`
   @import url('https://fonts.googleapis.com/css?family=Noto+Sans+JP');
+  font-family: Arial, Helvetica, sans-serif;
   font-size: 11px;
   line-height: 16px;
   /* identical to box height */
@@ -24,6 +26,16 @@ const Diffuse = styled(Flex)`
   width: 100%;
   height: 55px;
   border-radius: 6px 6px 0px 0px;
+`
+const CrossHeader = styled(Flex)`
+  position: absolute;
+  right: 10px;
+  top: 14px;
+  padding: 5px;
+  cursor: pointer;
+  color: white;
+  font-family: sans-serif;
+  font-size: 18px;
 `
 
 export const DefaultHeader = props => {
@@ -51,13 +63,16 @@ export const DefaultHeader = props => {
         <HeaderTitle>{headerTitle}</HeaderTitle>
         <Subtitle>{headerSubtitle}</Subtitle>
       </Flex>
+      <CrossHeader onClick={props.onChange}>X</CrossHeader>}
     </Diffuse>
   )
 }
 
 export const WebchatHeader = () => {
   const { webchatState } = useContext(WebchatContext)
-
+  const handleCloseWebchat = event => {
+    props.onChange(event.target.value)
+  }
   if (webchatState.theme.customHeader) {
     let CustomHeader = webchatState.theme.customHeader
     return <CustomHeader />
@@ -67,6 +82,7 @@ export const WebchatHeader = () => {
     <DefaultHeader
       webchatState={webchatState}
       color={webchatState.theme.brandColor}
+      onChange={handleCloseWebchat}
     />
   )
 }

--- a/packages/botonic-react/src/webchat/header.jsx
+++ b/packages/botonic-react/src/webchat/header.jsx
@@ -67,7 +67,7 @@ export const DefaultHeader = props => {
     </Diffuse>
   )
 }
-export const WebchatHeader = () => {
+export const WebchatHeader = props => {
   const { webchatState } = useContext(WebchatContext)
   const handleCloseWebchat = event => {
     props.onCloseClick(event.target.value)

--- a/packages/botonic-react/src/webchat/header.jsx
+++ b/packages/botonic-react/src/webchat/header.jsx
@@ -70,7 +70,7 @@ export const DefaultHeader = props => {
 
 export const WebchatHeader = () => {
   const { webchatState } = useContext(WebchatContext)
-  const handleCloseWebchat = event => {
+  const handleCloseWebchat = () => {
     props.onChange(event.target.value)
   }
   if (webchatState.theme.customHeader) {

--- a/packages/botonic-react/src/webchat/header.jsx
+++ b/packages/botonic-react/src/webchat/header.jsx
@@ -63,15 +63,14 @@ export const DefaultHeader = props => {
         <HeaderTitle>{headerTitle}</HeaderTitle>
         <Subtitle>{headerSubtitle}</Subtitle>
       </Flex>
-      <CloseHeader onClick={props.onChange}>X</CloseHeader>}
+      <CloseHeader onClick={props.onCloseClick}>X</CloseHeader>}
     </Diffuse>
   )
 }
-
 export const WebchatHeader = () => {
   const { webchatState } = useContext(WebchatContext)
   const handleCloseWebchat = event => {
-    props.onChange(event.target.value)
+    props.onCloseClick(event.target.value)
   }
   if (webchatState.theme.customHeader) {
     let CustomHeader = webchatState.theme.customHeader
@@ -82,7 +81,7 @@ export const WebchatHeader = () => {
     <DefaultHeader
       webchatState={webchatState}
       color={webchatState.theme.brandColor}
-      onChange={handleCloseWebchat}
+      onCloseClick={handleCloseWebchat}
     />
   )
 }

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -378,7 +378,6 @@ export const Webchat = forwardRef((props, ref) => {
               height: 36,
               flex: 'none'
             }}
-            value={true}
             onChange={() => {
               toggleWebchat(false)
             }}

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -378,7 +378,7 @@ export const Webchat = forwardRef((props, ref) => {
               height: 36,
               flex: 'none'
             }}
-            onChange={() => {
+            onCloseClick={() => {
               toggleWebchat(false)
             }}
           />

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -378,15 +378,7 @@ export const Webchat = forwardRef((props, ref) => {
               height: 36,
               flex: 'none'
             }}
-<<<<<<< HEAD
-<<<<<<< HEAD
             onCloseClick={() => {
-=======
-            value={true}
-=======
->>>>>>> fix(react): issues from PR
-            onChange={() => {
->>>>>>> add(react): close webchat button for default headers
               toggleWebchat(false)
             }}
           />

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -379,9 +379,12 @@ export const Webchat = forwardRef((props, ref) => {
               flex: 'none'
             }}
 <<<<<<< HEAD
+<<<<<<< HEAD
             onCloseClick={() => {
 =======
             value={true}
+=======
+>>>>>>> fix(react): issues from PR
             onChange={() => {
 >>>>>>> add(react): close webchat button for default headers
               toggleWebchat(false)

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -378,7 +378,12 @@ export const Webchat = forwardRef((props, ref) => {
               height: 36,
               flex: 'none'
             }}
+<<<<<<< HEAD
             onCloseClick={() => {
+=======
+            value={true}
+            onChange={() => {
+>>>>>>> add(react): close webchat button for default headers
               toggleWebchat(false)
             }}
           />

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -378,6 +378,10 @@ export const Webchat = forwardRef((props, ref) => {
               height: 36,
               flex: 'none'
             }}
+            value={true}
+            onChange={() => {
+              toggleWebchat(false)
+            }}
           />
           <WebchatMessageList
             style={{ flex: 1 }}

--- a/packages/botonic-react/src/webchat/webchatDev.jsx
+++ b/packages/botonic-react/src/webchat/webchatDev.jsx
@@ -85,11 +85,11 @@ export const WebchatDev = forwardRef((props, ref) => {
             showSessionView: false
           }}
         />
-        {webchatState.isWebchatOpen && !webchatState.theme.customHeader && (
+        {webchatState.isWebchatOpen && (
           <div
             style={{
               position: 'absolute',
-              right: 28,
+              right: 32,
               top: 12,
               padding: 5,
               cursor: 'pointer',


### PR DESCRIPTION
- header.jsx: add a styled component button for closing the webchat when is a default header

- webhcat.jsx: Here we send to child component(header.jsx) the method for closing the webchat.

- webchatDev.jsx: When we want to serve our webchat instead of passing a custom header we want to see the dropdown menu with the options "Show session" & "Keep session on reload"