### PR TITLE
refactor(react/style): change size of bot icon and adapt carousel

### DIFF
--- a/packages/botonic-react/src/components/carousel.jsx
+++ b/packages/botonic-react/src/components/carousel.jsx
@@ -6,6 +6,7 @@ import { isBrowser, isNode } from '@botonic/core'
 
 const Box = styled.div`
   padding-top: 10px;
+  margin-left: -13px;
   display: flex;
   flex-direction: row;
   overflow-x: auto;

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -125,13 +125,13 @@ export const Message = props => {
           {isFromBot() && webchatState.theme.botLogoChat ? (
             <webchatState.theme.botLogoChat />
           ) : (
-            isFromBot() && <img style={{ width: 30 }} src={Logo} />
+            isFromBot() && <img style={{ width: 24 }} src={Logo} />
           )}
         </div>
 
         <DefaultMessage
           style={{
-            left: isFromBot() ? 30 : 0,
+            left: isFromBot() ? 22 : 0,
             top: isFromBot() ? 5 : 0,
             backgroundColor: getBgColor(),
             color:
@@ -175,7 +175,7 @@ export const Message = props => {
           {isFromBot() && blob && (
             <div
               style={{
-                ...pointerStyles,
+                //...pointerStyles,
                 left: 0,
                 borderLeft: 0,
                 borderRightColor: getBgColor(),

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -175,7 +175,6 @@ export const Message = props => {
           {isFromBot() && blob && (
             <div
               style={{
-                //...pointerStyles,
                 left: 0,
                 borderLeft: 0,
                 borderRightColor: getBgColor(),


### PR DESCRIPTION
In this branch I've adjusted the size of the bot icon because it was too big. I also have deleted the pointerStyles from bot because the logo have it.
Because the reduction of the icon I've had to move a little bit the carousel to the left.