### PR TITLE
feat: unread messages

### DIFF
--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -44,6 +44,18 @@ export class WebchatApp {
     this.hubtypeService.postMessage(user, input)
   }
 
+  onStateChange({ user, messagesJSON }) {
+    if (!this.hubtypeService && user) {
+      let lastMessage = messagesJSON[messagesJSON.length - 1]
+      this.hubtypeService = new HubtypeService({
+        appId: this.appId,
+        user,
+        lastMessageId: lastMessage && lastMessage.id,
+        onEvent: event => this.onServiceEvent(event)
+      })
+    }
+  }
+
   onServiceEvent(event) {
     if (event.isError)
       this.webchatRef.current.setError({ message: event.errorMessage })
@@ -114,10 +126,6 @@ export class WebchatApp {
     this.onClose = onClose || this.onClose
     this.onMessage = onMessage || this.onMessage
     this.appId = appId || this.appId
-    this.hubtypeService = new HubtypeService({
-      appId: this.appId,
-      onEvent: event => this.onServiceEvent(event)
-    })
     render(
       <Webchat
         ref={this.webchatRef}
@@ -129,6 +137,7 @@ export class WebchatApp {
         onOpen={(...args) => this.onOpenWebchat(...args)}
         onClose={(...args) => this.onCloseWebchat(...args)}
         onUserInput={(...args) => this.onUserInput(...args)}
+        onStateChange={webchatState => this.onStateChange(webchatState)}
       />,
       dest
     )

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -60,7 +60,7 @@ export const Webchat = forwardRef((props, ref) => {
     openWebviewT,
     closeWebviewT
   } = props.webchatHooks || useWebchat()
-  const { initialSession, initialDevSettings } = props
+  const { initialSession, initialDevSettings, onStateChange } = props
   const [botonicState, saveState, deleteState] = useLocalStorage('botonicState')
   const [menuIsOpened, setMenuIsOpened] = useState(false)
   const [emojiIsOpened, setemojiIsOpened] = useState(false)
@@ -105,6 +105,8 @@ export const Webchat = forwardRef((props, ref) => {
   }, [webchatState.isWebchatOpen])
 
   useEffect(() => {
+    if (onStateChange && typeof onStateChange === 'function')
+      onStateChange(webchatState)
     saveState(
       JSON.stringify({
         user: webchatState.user,


### PR DESCRIPTION
The goal of this PR is to enable our webchat to get messages sent from the server while the user has been offline.
In order to achieve this we need to store the ID (in localstorage) of the latest message we got and send it on pusher startup.