### PR TITLE
Fix/migrate dialogflow to v2

### DIFF
--- a/packages/botonic-plugin-dialogflow/package-lock.json
+++ b/packages/botonic-plugin-dialogflow/package-lock.json
@@ -8,7 +8,6 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
       "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -45,9 +44,14 @@
       }
     },
     "is-buffer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+    },
+    "jsrsasign": {
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.12.tgz",
+      "integrity": "sha1-Iqu5ZW00owuVMENnIINeicLlwxY="
     },
     "ms": {
       "version": "2.0.0",
@@ -57,8 +61,12 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-      "dev": true
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     }
   }
 }

--- a/packages/botonic-plugin-dialogflow/package.json
+++ b/packages/botonic-plugin-dialogflow/package.json
@@ -3,10 +3,12 @@
   "version": "0.8.3",
   "main": "src/index.js",
   "dependencies": {
-    "axios": "latest"
+    "@babel/runtime": "^7.4.2",
+    "axios": "latest",
+    "jsrsasign": "^8.0.12",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
-    "@babel/runtime": "^7.4.2",
     "core-js": "^3.1.4"
   }
 }

--- a/packages/botonic-plugin-dialogflow/package.json
+++ b/packages/botonic-plugin-dialogflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-dialogflow",
-  "version": "0.8.3",
+  "version": "0.9.0-beta.1",
   "main": "src/index.js",
   "dependencies": {
     "@babel/runtime": "^7.4.2",

--- a/packages/botonic-plugin-dialogflow/src/index.js
+++ b/packages/botonic-plugin-dialogflow/src/index.js
@@ -7,10 +7,14 @@ export default class BotonicPluginDialogflow {
     this.projectID = creds.project_id
     this.sessionID = uuid.v4()
     this.creds = creds
-    return (async () => {
-      this.token = await this.generateToken(creds)
-      return this
-    })()
+    this.token = null
+  }
+
+  async getToken() {
+    if (!this.token) {
+      this.token = await this.generateToken(this.creds)
+    }
+    return this.token
   }
 
   async pre({ input, session, lastRoutePath }) {
@@ -61,7 +65,7 @@ export default class BotonicPluginDialogflow {
       method: 'post',
       url: `https://dialogflow.googleapis.com/v2/projects/${this.projectID}/agent/sessions/${this.sessionID}:detectIntent`,
       headers: {
-        Authorization: `Bearer ${this.token}`,
+        Authorization: `Bearer ${await this.getToken()}`,
         'Content-Type': 'application/json'
       },
       data: {


### PR DESCRIPTION
Hi all!

I've just migrated the plugin for Dialogflow to V2. Now it's working with the new api version of Dialogflow.
The endpoint that we used was `/query`. From now on the endpoint is `/detectIntent`[ref](https://cloud.google.com/dialogflow/docs/reference/rest/v2beta1/projects.agent.sessions/detectIntent). In order to avoid using a Node.JS SDK for doing the authorization of the calls, I've used [JWT](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#jwt-auth).
If you want to try the plugin, you should go to [Dialogflow console](https://dialogflow.cloud.google.com/), and click on the settings wheel for an agent (top-left). Then you need to click on your `Service Account` under `Google Projects` label. Once clicked, you should see the option `Create Key` which generates a .json. You need to copy this json inside the bot's project and use it in `plugins.js` as this:
```javascript
import dialogflowCredentials from './newagent-1cdbd-f226af5569ac.json'
export const plugins = [
  {
    id: 'dialogflow',
    resolve: require('@botonic/plugin-dialogflow'),
    options: dialogflowCredentials
  }
]
```
After that, it should work! I've tested that the plugin is working by declaring the intent inside routes, and also using the plugin inside an action.