### PR TITLE
docs: fix typos on custom webchat

### DIFF
--- a/docs/4.tutorials-and-examples/6.custom-webchat.mdx
+++ b/docs/4.tutorials-and-examples/6.custom-webchat.mdx
@@ -39,7 +39,7 @@ See above a template with Webchat allowed definitions. With them you can configu
 
 Let's see how we can use these objects:
 
-## theme
+## Theme
 
 These are the available styles that Botonic allows you to modify:
 ### General Styling
@@ -104,7 +104,7 @@ export default customMessage({
 })
 ```
 
-## Custom Compononent Examples
+## Custom Component Examples
 
 In this example, we are putting css styles into a custom quickreply.
 It's very important to put `{props.children}` inside the container, in this case the `<div>` tag:


### PR DESCRIPTION
This PR fixes a typo that is present on the documentation