### PR TITLE
chore(nlu/plugin-nlu): upgrade deps to tfjs 2.0

### DIFF
--- a/packages/botonic-nlu/package.json
+++ b/packages/botonic-nlu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/nlu",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "main": "lib/index",
   "scripts": {
     "build": "rm -rf lib && babel src -d lib",
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@tensorflow/tfjs": "^1.2.9",
-    "@tensorflow/tfjs-node": "^1.2.9",
+    "@tensorflow/tfjs": "^1.2.11",
+    "@tensorflow/tfjs-node": "^1.2.11",
     "axios": "^0.19.0",
     "colors": "^1.3.3",
     "compromise": "^11.13.2",

--- a/packages/botonic-plugin-nlu/package.json
+++ b/packages/botonic-plugin-nlu/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@botonic/nlu": "0.9.0",
-    "@tensorflow/tfjs": "^1.2.9",
+    "@tensorflow/tfjs": "^1.2.11",
     "axios": "latest",
     "node-fetch": "^2.6.0"
   },


### PR DESCRIPTION
Just updated tensorflow js to the latest version (2.0 or 1.2.11). I've tested it in my machine without problems.