### PR TITLE
Contentful/partitions commonField

### DIFF
--- a/packages/botonic-plugin-contentful/.eslintrc.js
+++ b/packages/botonic-plugin-contentful/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     "node/no-unsupported-features/es-syntax": "off", //babel will take care of ES compatibility
     "unicorn/no-abusive-eslint-disable" : "off",
     "@typescript-eslint/camelcase" : "warn",
+    "consistent-return": "error",
 
     // special for TYPESCRIPT
     "@typescript-eslint/explicit-function-return-type": "off", // annoying for tests
@@ -51,13 +52,14 @@ module.exports = {
     // allow public functions/classes to call private functions/classes declared below.
     // otoh, variables (typically constants) should be declared at the top
     "@typescript-eslint/no-use-before-define": ["error", { "variables": true, "functions": false, "classes": false }],
+    "@typescript-eslint/no-useless-constructor": "warn",
     "@typescript-eslint/require-await": "error",
     "no-empty-pattern" : "off",
     "no-null/no-null": "warn", // fields declared with ? are undefined, not null (be aware that React uses null)
     "unicorn/prevent-abbreviations" : "off", // the plugin removes removes type annotations from typescript code :-(
     "unicorn/filename-case" : "off", // React convention is in CamelCase
     "valid-jsdoc": "off", // function comments hide code complexity (and typescript already have type specifications),
- 
+
   },
   "overrides": [
     {

--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -11,7 +11,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/botonic-plugin-contentful/src/cms/callback.ts
+++ b/packages/botonic-plugin-contentful/src/cms/callback.ts
@@ -1,6 +1,7 @@
 import { CMS, MODEL_TYPES, ModelType } from './cms';
 import escapeStringRegexp from 'escape-string-regexp';
 import { Context } from './context';
+import { TopContent } from './contents';
 
 export class Callback {
   /**
@@ -61,7 +62,7 @@ export class ContentCallback extends Callback {
     }
   }
 
-  deliverPayloadContent(cms: CMS, context?: Context): Promise<any> {
+  deliverPayloadContent(cms: CMS, context?: Context): Promise<TopContent> {
     switch (this.model) {
       case ModelType.CAROUSEL:
         return cms.carousel(this.id, context);
@@ -81,8 +82,6 @@ export class ContentCallback extends Callback {
         return cms.schedule(this.id);
       case ModelType.DATE_RANGE:
         return cms.dateRange(this.id);
-      case ModelType.ASSET:
-        return cms.asset(this.id);
       default:
         throw new Error(
           `Type '${this.model}' not supported for callback with id '${this.id}'`

--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -106,9 +106,15 @@ export class DummyCMS implements CMS {
     const contents = this.buttonCallbacks.map(cb => {
       const button = DummyCMS.buttonFromCallback(cb);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      return new SearchResult(cb, button.name, button.text, [
-        'keyword for ' + (button.callback.payload || button.callback.url!)
-      ]);
+      return new SearchResult(
+        cb,
+        new CommonFields(button.name, {
+          shortText: button.text,
+          keywords: [
+            'keyword for ' + (button.callback.payload || button.callback.url!)
+          ]
+        })
+      );
     });
     return Promise.resolve(contents);
   }

--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -12,7 +12,8 @@ import {
   Url,
   Queue,
   Content,
-  StartUp
+  StartUp,
+  CommonFields
 } from './contents';
 import * as time from '../time';
 import { DEFAULT_CONTEXT } from './context';
@@ -32,12 +33,16 @@ export class DummyCMS implements CMS {
     const elements = this.buttonCallbacks.map(callback =>
       this.element(Math.random().toString(), callback)
     );
-    return Promise.resolve(new Carousel(id, elements));
+    return Promise.resolve(new Carousel(new CommonFields(id), elements));
   }
 
   async text(id: string, {} = DEFAULT_CONTEXT): Promise<Text> {
     return Promise.resolve(
-      new Text(id, 'Dummy text for ' + id, this.buttons(), id, ['kw1', 'kw2'])
+      new Text(
+        new CommonFields(id, { keywords: ['kw1', 'kw2'], shortText: id }),
+        'Dummy text for ' + id,
+        this.buttons()
+      )
     );
   }
 
@@ -47,7 +52,12 @@ export class DummyCMS implements CMS {
 
   async startUp(id: string, {} = DEFAULT_CONTEXT): Promise<StartUp> {
     return Promise.resolve(
-      new StartUp(id, DummyCMS.IMG, 'Dummy text for ' + id, this.buttons())
+      new StartUp(
+        new CommonFields(id),
+        DummyCMS.IMG,
+        'Dummy text for ' + id,
+        this.buttons()
+      )
     );
   }
 
@@ -67,7 +77,10 @@ export class DummyCMS implements CMS {
 
   url(id: string, {} = DEFAULT_CONTEXT): Promise<Url> {
     return Promise.resolve(
-      new Url(id, `http://url.${id}`, 'button text for' + id)
+      new Url(
+        new CommonFields(id, { shortText: 'button text for' + id }),
+        `http://url.${id}`
+      )
     );
   }
 
@@ -76,7 +89,7 @@ export class DummyCMS implements CMS {
   }
 
   queue(id: string, {} = DEFAULT_CONTEXT): Promise<Queue> {
-    return Promise.resolve(new Queue(id, id));
+    return Promise.resolve(new Queue(new CommonFields(id), id));
   }
 
   contents(model: ModelType, {} = DEFAULT_CONTEXT): Promise<Content[]> {

--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -11,9 +11,11 @@ import {
   Text,
   Url,
   Queue,
-  Content,
   StartUp,
-  CommonFields
+  CommonFields,
+  ScheduleContent,
+  DateRangeContent,
+  TopContent
 } from './contents';
 import * as time from '../time';
 import { Context, DEFAULT_CONTEXT } from './context';
@@ -85,7 +87,7 @@ export class DummyCMS implements CMS {
   }
 
   image(id: string, {} = DEFAULT_CONTEXT): Promise<Image> {
-    return Promise.resolve(new Image(id, DummyCMS.IMG));
+    return Promise.resolve(new Image(new CommonFields(id), DummyCMS.IMG));
   }
 
   queue(id: string, {} = DEFAULT_CONTEXT): Promise<Queue> {
@@ -96,7 +98,7 @@ export class DummyCMS implements CMS {
     model: ModelType,
     context?: Context,
     filter?: (cf: CommonFields) => boolean
-  ): Promise<Content[]> {
+  ): Promise<TopContent[]> {
     return Promise.resolve([]);
   }
 
@@ -111,17 +113,23 @@ export class DummyCMS implements CMS {
     return Promise.resolve(contents);
   }
 
-  schedule(id: string): Promise<time.Schedule> {
-    return Promise.resolve(new time.Schedule('Europe/Madrid'));
+  schedule(id: string): Promise<ScheduleContent> {
+    const schedule = new time.Schedule('Europe/Madrid');
+    return Promise.resolve(
+      new ScheduleContent(new CommonFields('name'), schedule)
+    );
   }
 
   asset(id: string): Promise<Asset> {
     return Promise.resolve(new Asset(`name for ${id}`, `http://url.${id}`));
   }
 
-  dateRange(id: string): Promise<time.DateRange> {
+  dateRange(id: string): Promise<DateRangeContent> {
     const now = new Date();
-    return Promise.resolve(new time.DateRange('daterange name', now, now));
+    const dateRange = new time.DateRange('daterange name', now, now);
+    return Promise.resolve(
+      new DateRangeContent(new CommonFields(dateRange.name), dateRange)
+    );
   }
 
   private buttons(): Button[] {

--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -16,7 +16,7 @@ import {
   CommonFields
 } from './contents';
 import * as time from '../time';
-import { DEFAULT_CONTEXT } from './context';
+import { Context, DEFAULT_CONTEXT } from './context';
 
 /**
  * Useful for mocking CMS, as ts-mockito does not allow mocking interfaces
@@ -92,7 +92,11 @@ export class DummyCMS implements CMS {
     return Promise.resolve(new Queue(new CommonFields(id), id));
   }
 
-  contents(model: ModelType, {} = DEFAULT_CONTEXT): Promise<Content[]> {
+  contents(
+    model: ModelType,
+    context?: Context,
+    filter?: (cf: CommonFields) => boolean
+  ): Promise<Content[]> {
     return Promise.resolve([]);
   }
 

--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -10,11 +10,12 @@ import {
   Queue,
   Content,
   StartUp,
-  CommonFields
+  CommonFields,
+  ScheduleContent,
+  DateRangeContent,
+  TopContent
 } from './contents';
 import { Context } from './context';
-
-import * as time from '../time';
 
 export class ErrorReportingCMS implements CMS {
   constructor(readonly cms: CMS) {}
@@ -86,26 +87,26 @@ export class ErrorReportingCMS implements CMS {
     model: ModelType,
     context?: Context,
     filter?: (cf: CommonFields) => boolean
-  ): Promise<Content[]> {
+  ): Promise<TopContent[]> {
     return this.cms
       .contents(model, context, filter)
       .catch(this.handleError('contents'));
   }
 
-  schedule(id: string): Promise<time.Schedule> {
+  schedule(id: string): Promise<ScheduleContent> {
     return this.cms
       .schedule(id)
       .catch(this.handleError(ModelType.SCHEDULE, id));
   }
 
-  dateRange(id: string): Promise<time.DateRange> {
+  dateRange(id: string): Promise<DateRangeContent> {
     return this.cms
       .dateRange(id)
       .catch(this.handleError(ModelType.DATE_RANGE, id));
   }
 
   asset(id: string): Promise<Asset> {
-    return this.cms.asset(id).catch(this.handleError(ModelType.ASSET, id));
+    return this.cms.asset(id).catch(this.handleError('asset', id));
   }
 
   private handleError(modelType: string, id?: string): (reason: any) => never {

--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -9,7 +9,8 @@ import {
   Chitchat,
   Queue,
   Content,
-  StartUp
+  StartUp,
+  CommonFields
 } from './contents';
 import { Context } from './context';
 
@@ -81,9 +82,13 @@ export class ErrorReportingCMS implements CMS {
       .catch(this.handleError('contentsWithKeywords'));
   }
 
-  contents(model: ModelType, context?: Context): Promise<Content[]> {
+  contents(
+    model: ModelType,
+    context?: Context,
+    filter?: (cf: CommonFields) => boolean
+  ): Promise<Content[]> {
     return this.cms
-      .contents(model, context)
+      .contents(model, context, filter)
       .catch(this.handleError('contents'));
   }
 

--- a/packages/botonic-plugin-contentful/src/cms/cms.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms.ts
@@ -10,7 +10,8 @@ import {
   Chitchat,
   Queue,
   Content,
-  StartUp
+  StartUp,
+  CommonFields
 } from './contents';
 
 export enum ModelType {
@@ -24,6 +25,20 @@ export enum ModelType {
   URL = 'url',
   SCHEDULE = 'schedule',
   STARTUP = 'startUp'
+}
+
+export function isMessageModel(model: ModelType): boolean {
+  switch (model) {
+    case ModelType.CAROUSEL:
+    case ModelType.CHITCHAT:
+    case ModelType.IMAGE:
+    case ModelType.QUEUE:
+    case ModelType.TEXT:
+    case ModelType.URL:
+    case ModelType.STARTUP:
+      return true;
+  }
+  return false;
 }
 
 export const MODEL_TYPES = Object.values(ModelType).map(m => m as ModelType);
@@ -51,9 +66,13 @@ export interface CMS {
   text(id: string, context?: Context): Promise<Text>;
   url(id: string, context?: Context): Promise<Url>;
   /**
-   * @param context If locale specified, it does not returns contents without values for the locale (even if it has value for the fallback locale)
+   * If locale specified in context, it does not return contents without values for the locale (even if it has value for the fallback locale)
    */
-  contents(model: ModelType, context?: Context): Promise<Content[]>;
+  contents(
+    model: ModelType,
+    context?: Context,
+    filter?: (cf: CommonFields) => boolean
+  ): Promise<Content[]>;
 
   /**
    * For contents with 'Seachable by' field (eg. {@link Queue}), it returns one result per each 'Seachable by' entry

--- a/packages/botonic-plugin-contentful/src/cms/cms.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms.ts
@@ -1,5 +1,4 @@
 import { SearchResult } from '../search/search-result';
-import * as time from '../time';
 import { Context } from './context';
 import {
   Asset,
@@ -9,13 +8,14 @@ import {
   Url,
   Chitchat,
   Queue,
-  Content,
   StartUp,
-  CommonFields
+  CommonFields,
+  ScheduleContent,
+  DateRangeContent,
+  TopContent
 } from './contents';
 
 export enum ModelType {
-  ASSET = 'asset',
   CAROUSEL = 'carousel',
   CHITCHAT = 'chitchat',
   DATE_RANGE = 'dateRange',
@@ -25,20 +25,6 @@ export enum ModelType {
   URL = 'url',
   SCHEDULE = 'schedule',
   STARTUP = 'startUp'
-}
-
-export function isMessageModel(model: ModelType): boolean {
-  switch (model) {
-    case ModelType.CAROUSEL:
-    case ModelType.CHITCHAT:
-    case ModelType.IMAGE:
-    case ModelType.QUEUE:
-    case ModelType.TEXT:
-    case ModelType.URL:
-    case ModelType.STARTUP:
-      return true;
-  }
-  return false;
 }
 
 export const MODEL_TYPES = Object.values(ModelType).map(m => m as ModelType);
@@ -72,14 +58,14 @@ export interface CMS {
     model: ModelType,
     context?: Context,
     filter?: (cf: CommonFields) => boolean
-  ): Promise<Content[]>;
+  ): Promise<TopContent[]>;
 
   /**
    * For contents with 'Seachable by' field (eg. {@link Queue}), it returns one result per each 'Seachable by' entry
    * @param context If locale specified, it does not return contents without values for the locale (even if it has value for the fallback locale)
    */
   contentsWithKeywords(context?: Context): Promise<SearchResult[]>;
-  schedule(id: string): Promise<time.Schedule>;
-  dateRange(id: string): Promise<time.DateRange>;
+  schedule(id: string): Promise<ScheduleContent>;
+  dateRange(id: string): Promise<DateRangeContent>;
   asset(id: string): Promise<Asset>;
 }

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -1,7 +1,6 @@
 import * as time from '../time';
 import { Callback } from './callback';
 import { SearchableBy } from './fields';
-import { DateRange } from '../time';
 
 export enum ButtonStyle {
   BUTTON = 0,
@@ -59,23 +58,23 @@ export class CommonFields {
   readonly searchableBy?: SearchableBy;
   /** Useful when contents need to be replicated according to some criteria. Eg. country, company,...
    */
-  readonly partition?: string;
-  readonly dateRange?: DateRange;
+  readonly partitions?: string[];
+  readonly dateRange?: DateRangeContent;
   constructor(
     readonly name: string,
     opt?: {
       shortText?: string;
       keywords?: string[];
       searchableBy?: SearchableBy;
-      partition?: string;
-      dateRange?: DateRange;
+      partitions?: string[];
+      dateRange?: DateRangeContent;
     }
   ) {
     if (opt) {
       this.shortText = opt.shortText;
       this.keywords = opt.keywords;
       this.searchableBy = opt.searchableBy;
-      this.partition = opt.partition;
+      this.partitions = opt.partitions;
       this.dateRange = opt.dateRange;
     }
   }

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -1,4 +1,4 @@
-import { Schedule } from '../time';
+import * as time from '../time';
 import { Callback } from './callback';
 import { SearchableBy } from './fields';
 
@@ -36,6 +36,15 @@ export abstract class Content {
       return undefined;
     }
     return invalids.join('. ');
+  }
+}
+
+/**
+ * A self-contained content to which {@link Callback} may refer
+ */
+export abstract class TopContent extends Content {
+  protected constructor(readonly common: CommonFields) {
+    super();
   }
 }
 
@@ -86,14 +95,14 @@ export class Button extends Content {
   }
 }
 
-export class StartUp extends Content {
+export class StartUp extends TopContent {
   constructor(
     readonly common: CommonFields,
     readonly imgUrl: string | undefined,
     readonly text: string | undefined,
     readonly buttons: Button[]
   ) {
-    super();
+    super(common);
   }
 
   validate(): string | undefined {
@@ -101,12 +110,12 @@ export class StartUp extends Content {
   }
 }
 
-export class Carousel extends Content {
+export class Carousel extends TopContent {
   constructor(
     readonly common: CommonFields,
     readonly elements: Element[] = []
   ) {
-    super();
+    super(common);
   }
 
   validate(): string | undefined {
@@ -132,13 +141,13 @@ export class Element extends Content {
   }
 }
 
-export class Image extends Content {
-  constructor(readonly name: string, readonly imgUrl: string) {
-    super();
+export class Image extends TopContent {
+  constructor(readonly common: CommonFields, readonly imgUrl: string) {
+    super(common);
   }
 }
 
-export class Text extends Content {
+export class Text extends TopContent {
   constructor(
     readonly common: CommonFields,
     // Full text
@@ -147,7 +156,7 @@ export class Text extends Content {
     readonly followUp?: FollowUp,
     readonly buttonsStyle = ButtonStyle.BUTTON
   ) {
-    super();
+    super(common);
   }
 
   validate(): string | undefined {
@@ -175,7 +184,7 @@ export class Text extends Content {
 
 export type Chitchat = Text;
 
-export class Url extends Content {
+export class Url extends TopContent {
   /**
    *
    * @param followup so far not defined in Contentful model, since URL's are not rendered anyway
@@ -185,17 +194,32 @@ export class Url extends Content {
     readonly url: string,
     readonly followup?: FollowUp
   ) {
-    super();
+    super(common);
   }
 }
 
-export class Queue extends Content {
+export class Queue extends TopContent {
   constructor(
     readonly common: CommonFields,
     readonly queue: string,
-    readonly schedule?: Schedule
+    readonly schedule?: time.Schedule
   ) {
-    super();
+    super(common);
+  }
+}
+
+export class DateRangeContent extends TopContent {
+  constructor(
+    readonly common: CommonFields,
+    readonly dateRange: time.DateRange
+  ) {
+    super(common);
+  }
+}
+
+export class ScheduleContent extends TopContent {
+  constructor(readonly common: CommonFields, readonly schedule: time.Schedule) {
+    super(common);
   }
 }
 

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -47,18 +47,21 @@ export class CommonFields {
   readonly shortText?: string;
   readonly keywords?: string[];
   readonly searchableBy?: SearchableBy;
+  readonly partition?: string;
   constructor(
     readonly name: string,
     opt?: {
       shortText?: string;
       keywords?: string[];
       searchableBy?: SearchableBy;
+      partition?: string;
     }
   ) {
     if (opt) {
       this.shortText = opt.shortText;
       this.keywords = opt.keywords;
       this.searchableBy = opt.searchableBy;
+      this.partition = opt.partition;
     }
   }
 }

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -54,11 +54,11 @@ export abstract class TopContent extends Content {
  */
 export class CommonFields {
   readonly shortText?: string;
-  readonly keywords?: string[];
+  readonly keywords: string[];
   readonly searchableBy?: SearchableBy;
   /** Useful when contents need to be replicated according to some criteria. Eg. country, company,...
    */
-  readonly partitions?: string[];
+  readonly partitions: string[];
   readonly dateRange?: DateRangeContent;
   constructor(
     readonly name: string,
@@ -72,10 +72,13 @@ export class CommonFields {
   ) {
     if (opt) {
       this.shortText = opt.shortText;
-      this.keywords = opt.keywords;
+      this.keywords = opt.keywords || [];
       this.searchableBy = opt.searchableBy;
-      this.partitions = opt.partitions;
+      this.partitions = opt.partitions || [];
       this.dateRange = opt.dateRange;
+    } else {
+      this.keywords = [];
+      this.partitions = [];
     }
   }
 }

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -21,13 +21,10 @@ export class Asset {
   ) {}
 }
 
+/**
+ * Any content deliverable from a CMS
+ */
 export abstract class Content {
-  /**
-   * An ID (eg. PRE_FAQ1)
-   * @param name TODO rename to id or code?
-   */
-  protected constructor(readonly name: string) {}
-
   /** @return message if any issue detected */
   validate(): string | undefined {
     return undefined;
@@ -46,10 +43,24 @@ export abstract class Content {
  * When any {@link keywords} is detected on a user input, we can use display the {@link shortText} for users
  * to confirm their interest on this content
  */
-export interface ContentWithKeywords {
-  readonly name: string;
+export class CommonFields {
   readonly shortText?: string;
   readonly keywords?: string[];
+  readonly searchableBy?: SearchableBy;
+  constructor(
+    readonly name: string,
+    opt?: {
+      shortText?: string;
+      keywords?: string[];
+      searchableBy?: SearchableBy;
+    }
+  ) {
+    if (opt) {
+      this.shortText = opt.shortText;
+      this.keywords = opt.keywords;
+      this.searchableBy = opt.searchableBy;
+    }
+  }
 }
 
 export class Button extends Content {
@@ -58,7 +69,7 @@ export class Button extends Content {
     readonly text: string,
     readonly callback: Callback
   ) {
-    super(name);
+    super();
   }
 
   validate(): string | undefined {
@@ -72,17 +83,14 @@ export class Button extends Content {
   }
 }
 
-export class StartUp extends Content implements ContentWithKeywords {
+export class StartUp extends Content {
   constructor(
-    // An ID (eg. PRE_FAQ1)
-    readonly name: string,
+    readonly common: CommonFields,
     readonly imgUrl: string | undefined,
     readonly text: string | undefined,
-    readonly buttons: Button[],
-    readonly shortText?: string,
-    readonly keywords: string[] = []
+    readonly buttons: Button[]
   ) {
-    super(name);
+    super();
   }
 
   validate(): string | undefined {
@@ -90,14 +98,12 @@ export class StartUp extends Content implements ContentWithKeywords {
   }
 }
 
-export class Carousel extends Content implements ContentWithKeywords {
+export class Carousel extends Content {
   constructor(
-    readonly name: string, // Useful to display in buttons or reports
-    readonly elements: Element[] = [],
-    readonly shortText?: string,
-    readonly keywords: string[] = []
+    readonly common: CommonFields,
+    readonly elements: Element[] = []
   ) {
-    super(name);
+    super();
   }
 
   validate(): string | undefined {
@@ -107,13 +113,15 @@ export class Carousel extends Content implements ContentWithKeywords {
 
 /** Part of a carousel */
 export class Element extends Content {
+  readonly name: string;
   constructor(
     readonly buttons: Button[],
     readonly title?: string,
     readonly subtitle?: string,
     readonly imgUrl?: string
   ) {
-    super(title || '');
+    super();
+    this.name = title || '';
   }
 
   validate(): string | undefined {
@@ -123,24 +131,20 @@ export class Element extends Content {
 
 export class Image extends Content {
   constructor(readonly name: string, readonly imgUrl: string) {
-    super(name);
+    super();
   }
 }
 
-export class Text extends Content implements ContentWithKeywords {
+export class Text extends Content {
   constructor(
-    // An ID (eg. PRE_FAQ1)
-    readonly name: string,
+    readonly common: CommonFields,
     // Full text
     readonly text: string,
     readonly buttons: Button[],
-    // Useful to display in buttons or reports
-    readonly shortText?: string,
-    readonly keywords: string[] = [],
     readonly followUp?: FollowUp,
     readonly buttonsStyle = ButtonStyle.BUTTON
   ) {
-    super(name);
+    super();
   }
 
   validate(): string | undefined {
@@ -168,31 +172,27 @@ export class Text extends Content implements ContentWithKeywords {
 
 export type Chitchat = Text;
 
-export class Url extends Content implements ContentWithKeywords {
+export class Url extends Content {
   /**
    *
    * @param followup so far not defined in Contentful model, since URL's are not rendered anyway
    */
   constructor(
-    readonly name: string,
+    readonly common: CommonFields,
     readonly url: string,
-    readonly shortText?: string,
-    readonly keywords: string[] = [],
     readonly followup?: FollowUp
   ) {
-    super(name);
+    super();
   }
 }
 
-export class Queue extends Content implements ContentWithKeywords {
+export class Queue extends Content {
   constructor(
-    readonly name: string,
+    readonly common: CommonFields,
     readonly queue: string,
-    readonly shortText?: string,
-    readonly schedule?: Schedule,
-    readonly searchableBy: SearchableBy = new SearchableBy()
+    readonly schedule?: Schedule
   ) {
-    super(name);
+    super();
   }
 }
 

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -1,6 +1,7 @@
 import * as time from '../time';
 import { Callback } from './callback';
 import { SearchableBy } from './fields';
+import { DateRange } from '../time';
 
 export enum ButtonStyle {
   BUTTON = 0,
@@ -56,7 +57,10 @@ export class CommonFields {
   readonly shortText?: string;
   readonly keywords?: string[];
   readonly searchableBy?: SearchableBy;
+  /** Useful when contents need to be replicated according to some criteria. Eg. country, company,...
+   */
   readonly partition?: string;
+  readonly dateRange?: DateRange;
   constructor(
     readonly name: string,
     opt?: {
@@ -64,6 +68,7 @@ export class CommonFields {
       keywords?: string[];
       searchableBy?: SearchableBy;
       partition?: string;
+      dateRange?: DateRange;
     }
   ) {
     if (opt) {
@@ -71,6 +76,7 @@ export class CommonFields {
       this.keywords = opt.keywords;
       this.searchableBy = opt.searchableBy;
       this.partition = opt.partition;
+      this.dateRange = opt.dateRange;
     }
   }
 }

--- a/packages/botonic-plugin-contentful/src/cms/factories.ts
+++ b/packages/botonic-plugin-contentful/src/cms/factories.ts
@@ -1,4 +1,11 @@
-import { Button, ButtonStyle, FollowUp, Content, Text } from './contents';
+import {
+  Button,
+  ButtonStyle,
+  FollowUp,
+  Content,
+  Text,
+  CommonFields
+} from './contents';
 
 abstract class ModelBuilder {
   protected constructor(readonly name: string) {}
@@ -47,11 +54,12 @@ export class TextBuilder extends ModelBuilder {
 
   build(): Text {
     return new Text(
-      this.name,
+      new CommonFields(this.name, {
+        shortText: this.shortText,
+        keywords: this.keywords
+      }),
       this.text,
       this.buttons,
-      this.shortText,
-      this.keywords,
       this.followUp,
       this.buttonsStyle
     );

--- a/packages/botonic-plugin-contentful/src/contentful/button.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/button.ts
@@ -3,10 +3,7 @@ import { DeliveryApi } from '.';
 import { ModelType } from '../cms';
 import * as cms from '../cms';
 import { CarouselFields } from './carousel';
-import {
-  ContentWithKeywordsFields,
-  ContentWithNameFields
-} from './delivery-api';
+import { CommonEntryFields, ContentWithNameFields } from './delivery-api';
 import { TextFields } from './text';
 import { UrlFields } from './url';
 
@@ -30,7 +27,7 @@ export class ButtonDelivery {
       case cms.ModelType.TEXT:
       case cms.ModelType.URL:
         return ButtonDelivery.fromContent(entry as contentful.Entry<
-          ContentWithKeywordsFields
+          CommonEntryFields
         >);
       case ButtonDelivery.BUTTON_CONTENT_TYPE: {
         const buttonEntry = entry as contentful.Entry<ButtonFields>;
@@ -49,7 +46,7 @@ export class ButtonDelivery {
   }
 
   private static fromContent(
-    entry: contentful.Entry<ContentWithKeywordsFields>
+    entry: contentful.Entry<CommonEntryFields>
   ): cms.Button {
     const fields = entry.fields;
     let text = fields.shortText;

--- a/packages/botonic-plugin-contentful/src/contentful/carousel.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/carousel.ts
@@ -18,6 +18,13 @@ export class CarouselDelivery extends DeliveryWithFollowUp {
     const entry: contentful.Entry<
       CarouselFields
     > = await this.delivery.getEntry(id, context);
+    return this.fromEntry(entry, context);
+  }
+
+  async fromEntry(
+    entry: contentful.Entry<CarouselFields>,
+    context: cms.Context
+  ) {
     const elements = entry.fields.elements.map(async entry => {
       return this.elementFromEntry(entry, context);
     });

--- a/packages/botonic-plugin-contentful/src/contentful/carousel.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/carousel.ts
@@ -2,7 +2,11 @@ import * as contentful from 'contentful';
 import { DeliveryWithFollowUp } from './follow-up';
 import { ButtonDelivery } from './button';
 import * as cms from '../cms';
-import { DeliveryApi, ContentWithKeywordsFields } from './delivery-api';
+import {
+  DeliveryApi,
+  CommonEntryFields,
+  commonFieldsFromEntry
+} from './delivery-api';
 
 // TODO remove DeliveryWithFollowUp
 export class CarouselDelivery extends DeliveryWithFollowUp {
@@ -18,12 +22,7 @@ export class CarouselDelivery extends DeliveryWithFollowUp {
       return this.elementFromEntry(entry, context);
     });
     const e = await Promise.all(elements);
-    return new cms.Carousel(
-      entry.fields.name,
-      e,
-      entry.fields.shortText,
-      entry.fields.keywords
-    );
+    return new cms.Carousel(commonFieldsFromEntry(entry), e);
   }
 
   /**
@@ -58,6 +57,6 @@ interface ElementFields {
   buttons: contentful.Entry<any>[];
 }
 
-export interface CarouselFields extends ContentWithKeywordsFields {
+export interface CarouselFields extends CommonEntryFields {
   elements: contentful.Entry<ElementFields>[];
 }

--- a/packages/botonic-plugin-contentful/src/contentful/date-range.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/date-range.ts
@@ -1,20 +1,25 @@
 import * as contentful from 'contentful/index';
-import { DEFAULT_CONTEXT, ModelType } from '../cms';
+import { DateRangeContent, DEFAULT_CONTEXT, ModelType } from '../cms';
 import * as time from '../time';
 import { ContentDelivery } from './content-delivery';
-import { CommonEntryFields, DeliveryApi } from './delivery-api';
+import {
+  CommonEntryFields,
+  commonFieldsFromEntry,
+  DeliveryApi
+} from './delivery-api';
 
 export class DateRangeDelivery extends ContentDelivery {
   constructor(delivery: DeliveryApi) {
     super(ModelType.DATE_RANGE, delivery);
   }
 
-  async dateRange(id: string): Promise<time.DateRange> {
+  async dateRange(id: string): Promise<DateRangeContent> {
     const entry: contentful.Entry<DateRangeFields> = await this.getEntry(
       id,
       DEFAULT_CONTEXT
     );
-    return DateRangeDelivery.fromEntry(entry);
+    const dateRange = DateRangeDelivery.fromEntry(entry);
+    return new DateRangeContent(commonFieldsFromEntry(entry), dateRange);
   }
 
   static fromEntry(entry: contentful.Entry<DateRangeFields>): time.DateRange {
@@ -27,7 +32,6 @@ export class DateRangeDelivery extends ContentDelivery {
 }
 
 export interface DateRangeFields extends CommonEntryFields {
-  name: string;
   from: string;
   to: string;
 }

--- a/packages/botonic-plugin-contentful/src/contentful/date-range.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/date-range.ts
@@ -14,12 +14,10 @@ export class DateRangeDelivery extends ContentDelivery {
       id,
       DEFAULT_CONTEXT
     );
-    return DateRangeDelivery.dateRangeFromEntry(entry);
+    return DateRangeDelivery.fromEntry(entry);
   }
 
-  static dateRangeFromEntry(
-    entry: contentful.Entry<DateRangeFields>
-  ): time.DateRange {
+  static fromEntry(entry: contentful.Entry<DateRangeFields>): time.DateRange {
     return new time.DateRange(
       entry.fields.name,
       new Date(Date.parse(entry.fields.from)),

--- a/packages/botonic-plugin-contentful/src/contentful/date-range.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/date-range.ts
@@ -2,7 +2,7 @@ import * as contentful from 'contentful/index';
 import { DEFAULT_CONTEXT, ModelType } from '../cms';
 import * as time from '../time';
 import { ContentDelivery } from './content-delivery';
-import { ContentWithKeywordsFields, DeliveryApi } from './delivery-api';
+import { CommonEntryFields, DeliveryApi } from './delivery-api';
 
 export class DateRangeDelivery extends ContentDelivery {
   constructor(delivery: DeliveryApi) {
@@ -28,7 +28,7 @@ export class DateRangeDelivery extends ContentDelivery {
   }
 }
 
-export interface DateRangeFields extends ContentWithKeywordsFields {
+export interface DateRangeFields extends CommonEntryFields {
   name: string;
   from: string;
   to: string;

--- a/packages/botonic-plugin-contentful/src/contentful/date-range.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/date-range.ts
@@ -18,16 +18,16 @@ export class DateRangeDelivery extends ContentDelivery {
       id,
       DEFAULT_CONTEXT
     );
-    const dateRange = DateRangeDelivery.fromEntry(entry);
-    return new DateRangeContent(commonFieldsFromEntry(entry), dateRange);
+    return DateRangeDelivery.fromEntry(entry);
   }
 
-  static fromEntry(entry: contentful.Entry<DateRangeFields>): time.DateRange {
-    return new time.DateRange(
+  static fromEntry(entry: contentful.Entry<DateRangeFields>): DateRangeContent {
+    const dateRange = new time.DateRange(
       entry.fields.name,
       new Date(Date.parse(entry.fields.from)),
       new Date(Date.parse(entry.fields.to))
     );
+    return new DateRangeContent(commonFieldsFromEntry(entry), dateRange);
   }
 }
 

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -3,11 +3,11 @@ import * as cms from '../cms';
 import {
   Callback,
   CommonFields,
-  Content,
   ContentCallback,
   Context,
   ModelType,
-  SearchableBy
+  SearchableBy,
+  TopContent
 } from '../cms';
 import { QueueDelivery } from './queue';
 import { UrlFields } from './url';
@@ -91,7 +91,10 @@ export class DeliveryApi {
   async contents(
     model: ModelType,
     context: Context,
-    factory: (entry: contentful.Entry<any>, ctxt: Context) => Promise<Content>,
+    factory: (
+      entry: contentful.Entry<any>,
+      ctxt: Context
+    ) => Promise<TopContent>,
     filter?: (cf: CommonFields) => boolean
   ) {
     const entries: EntryCollection<CommonEntryFields> = await this.getEntries(
@@ -118,7 +121,7 @@ export class DeliveryApi {
 }
 
 export interface ContentWithNameFields {
-  // An ID (eg. PRE_FAQ1)
+  // The content code (eg. PRE_FAQ1) Not called Id to differentiate from contentful automatic Id
   name: string;
 }
 

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -132,7 +132,7 @@ export interface CommonEntryFields extends ContentWithNameFields {
   shortText: string;
   keywords?: string[];
   searchableBy?: contentful.Entry<SearchableByKeywordsFields>[];
-  partition?: string;
+  partitions?: string[];
   dateRange?: contentful.Entry<DateRangeFields>;
 }
 
@@ -155,7 +155,7 @@ export function commonFieldsFromEntry(
   return new CommonFields(fields.name, {
     keywords: fields.keywords,
     shortText: fields.shortText,
-    partition: fields.partition,
+    partitions: fields.partitions,
     searchableBy,
     dateRange
   });

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -1,8 +1,20 @@
 import * as contentful from 'contentful';
 import * as cms from '../cms';
-import { Callback, Content, ContentCallback, Context, ModelType } from '../cms';
+import {
+  Callback,
+  CommonFields,
+  Content,
+  ContentCallback,
+  Context,
+  ModelType,
+  SearchableBy
+} from '../cms';
 import { QueueDelivery, QueueFields } from './queue';
 import { UrlFields } from './url';
+import {
+  SearchableByKeywordsDelivery,
+  SearchableByKeywordsFields
+} from './searchable-by';
 
 export class DeliveryApi {
   private client: contentful.ContentfulClientApi;
@@ -104,8 +116,25 @@ export interface ContentWithNameFields {
   name: string;
 }
 
-export interface ContentWithKeywordsFields extends ContentWithNameFields {
+export interface CommonEntryFields extends ContentWithNameFields {
   // Useful to display in buttons or reports
   shortText: string;
-  keywords: string[];
+  keywords?: string[];
+  searchableBy?: contentful.Entry<SearchableByKeywordsFields>[];
+}
+
+export function commonFieldsFromEntry(fields: CommonEntryFields): CommonFields {
+  const searchableBy =
+    fields.searchableBy &&
+    new SearchableBy(
+      fields.searchableBy.map(searchableBy =>
+        SearchableByKeywordsDelivery.fromEntry(searchableBy)
+      )
+    );
+
+  return new CommonFields(fields.name, {
+    keywords: fields.keywords,
+    shortText: fields.shortText,
+    searchableBy: searchableBy
+  });
 }

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -1,5 +1,6 @@
 import * as contentful from 'contentful';
 import * as cms from '../cms';
+
 import {
   Callback,
   CommonFields,
@@ -17,6 +18,7 @@ import {
 } from './searchable-by';
 import { ScheduleDelivery } from './schedule';
 import { Entry, EntryCollection } from 'contentful';
+import { DateRangeDelivery, DateRangeFields } from './date-range';
 
 export class DeliveryApi {
   private client: contentful.ContentfulClientApi;
@@ -130,12 +132,15 @@ export interface CommonEntryFields extends ContentWithNameFields {
   shortText: string;
   keywords?: string[];
   searchableBy?: contentful.Entry<SearchableByKeywordsFields>[];
+  partition?: string;
+  dateRange?: contentful.Entry<DateRangeFields>;
 }
 
 export function commonFieldsFromEntry(
   entry: Entry<CommonEntryFields>
 ): CommonFields {
   const fields = entry.fields;
+
   const searchableBy =
     fields.searchableBy &&
     new SearchableBy(
@@ -144,9 +149,14 @@ export function commonFieldsFromEntry(
       )
     );
 
+  const dateRange =
+    fields.dateRange && DateRangeDelivery.fromEntry(fields.dateRange);
+
   return new CommonFields(fields.name, {
     keywords: fields.keywords,
     shortText: fields.shortText,
-    searchableBy: searchableBy
+    partition: fields.partition,
+    searchableBy,
+    dateRange
   });
 }

--- a/packages/botonic-plugin-contentful/src/contentful/follow-up.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/follow-up.ts
@@ -21,8 +21,7 @@ type FollowUpFields = TextFields | CarouselFields | ImageFields;
 export class FollowUpDelivery {
   constructor(
     private readonly carousel: CarouselDelivery,
-    private readonly text: TextDelivery,
-    private readonly image: ImageDelivery
+    private readonly text: TextDelivery
   ) {}
 
   // TODO we should detect cycles to avoid infinite recursion
@@ -38,10 +37,10 @@ export class FollowUpDelivery {
         // here followUp already has its fields set, but not yet its element fields
         return this.carousel.carousel(followUp.sys.id, context);
       case cms.ModelType.TEXT:
-        return this.text.textFromEntry(followUp as Entry<TextFields>, context);
+        return this.text.fromEntry(followUp as Entry<TextFields>, context);
       case cms.ModelType.IMAGE:
         return Promise.resolve(
-          this.image.imageFromEntry(followUp as Entry<ImageFields>)
+          ImageDelivery.fromEntry(followUp as Entry<ImageFields>)
         );
       default:
         throw new Error(`Unexpected followUp type ${followUp.sys.type}`);

--- a/packages/botonic-plugin-contentful/src/contentful/image.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/image.ts
@@ -14,10 +14,10 @@ export class ImageDelivery extends ContentDelivery {
       id,
       context
     );
-    return this.imageFromEntry(entry);
+    return ImageDelivery.fromEntry(entry);
   }
 
-  imageFromEntry(entry: contentful.Entry<ImageFields>): cms.Image {
+  static fromEntry(entry: contentful.Entry<ImageFields>): cms.Image {
     return new cms.Image(
       entry.fields.name,
       DeliveryApi.urlFromAsset(entry.fields.image)

--- a/packages/botonic-plugin-contentful/src/contentful/image.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/image.ts
@@ -1,7 +1,7 @@
 import { Context } from '../cms';
 import * as cms from '../cms';
 import { ContentDelivery } from './content-delivery';
-import { ContentWithKeywordsFields, DeliveryApi } from './delivery-api';
+import { CommonEntryFields, DeliveryApi } from './delivery-api';
 import * as contentful from 'contentful/index';
 
 export class ImageDelivery extends ContentDelivery {
@@ -25,6 +25,6 @@ export class ImageDelivery extends ContentDelivery {
   }
 }
 
-export interface ImageFields extends ContentWithKeywordsFields {
+export interface ImageFields extends CommonEntryFields {
   image: contentful.Asset;
 }

--- a/packages/botonic-plugin-contentful/src/contentful/image.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/image.ts
@@ -1,7 +1,11 @@
 import { Context } from '../cms';
 import * as cms from '../cms';
 import { ContentDelivery } from './content-delivery';
-import { CommonEntryFields, DeliveryApi } from './delivery-api';
+import {
+  CommonEntryFields,
+  commonFieldsFromEntry,
+  DeliveryApi
+} from './delivery-api';
 import * as contentful from 'contentful/index';
 
 export class ImageDelivery extends ContentDelivery {
@@ -19,7 +23,7 @@ export class ImageDelivery extends ContentDelivery {
 
   static fromEntry(entry: contentful.Entry<ImageFields>): cms.Image {
     return new cms.Image(
-      entry.fields.name,
+      commonFieldsFromEntry(entry),
       DeliveryApi.urlFromAsset(entry.fields.image)
     );
   }

--- a/packages/botonic-plugin-contentful/src/contentful/index.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/index.ts
@@ -6,7 +6,13 @@ import { ImageDelivery } from './image';
 import { ScheduleDelivery } from './schedule';
 import { KeywordsDelivery } from './keywords';
 import { FollowUpDelivery } from './follow-up';
-import { CommonFields, Content, isMessageModel, ModelType } from '../cms';
+import {
+  CommonFields,
+  DateRangeContent,
+  ModelType,
+  ScheduleContent,
+  TopContent
+} from '../cms';
 import { ButtonDelivery } from './button';
 import { DeliveryApi } from './delivery-api';
 import { CarouselDelivery } from './carousel';
@@ -14,7 +20,6 @@ import { StartUpDelivery } from './startup';
 import { TextDelivery } from './text';
 import { UrlDelivery } from './url';
 import * as cms from '../cms';
-import * as time from '../time';
 import { QueueDelivery } from './queue';
 import * as contentful from 'contentful';
 
@@ -83,12 +88,7 @@ export default class Contentful implements cms.CMS {
     model: ModelType,
     context = DEFAULT_CONTEXT,
     filter?: (cf: CommonFields) => boolean
-  ): Promise<Content[]> {
-    if (!isMessageModel(model)) {
-      throw new Error(
-        `contents() can only be used for message models but '${model}' is not`
-      );
-    }
+  ): Promise<TopContent[]> {
     return this._delivery.contents(
       model,
       context,
@@ -101,7 +101,7 @@ export default class Contentful implements cms.CMS {
   async fromEntry(
     entry: contentful.Entry<any>,
     context: Context
-  ): Promise<Content> {
+  ): Promise<TopContent> {
     const model: ModelType = DeliveryApi.getContentModel(entry);
     switch (model) {
       case ModelType.CAROUSEL:
@@ -128,7 +128,7 @@ export default class Contentful implements cms.CMS {
     return this._keywords.contentsWithKeywords(context);
   }
 
-  async schedule(id: string): Promise<time.Schedule> {
+  async schedule(id: string): Promise<ScheduleContent> {
     return this._schedule.schedule(id);
   }
 
@@ -136,7 +136,7 @@ export default class Contentful implements cms.CMS {
     return this._asset.asset(id);
   }
 
-  dateRange(id: string): Promise<time.DateRange> {
+  dateRange(id: string): Promise<DateRangeContent> {
     return this._dateRange.dateRange(id);
   }
 }

--- a/packages/botonic-plugin-contentful/src/contentful/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/keywords.ts
@@ -3,7 +3,7 @@ import { Context } from '../cms';
 import * as cms from '../cms';
 import { ModelType } from '../cms';
 import { SearchResult } from '../search';
-import { ContentWithKeywordsFields, DeliveryApi } from './delivery-api';
+import { CommonEntryFields, DeliveryApi } from './delivery-api';
 import { QueueFields } from './queue';
 
 export class KeywordsDelivery {
@@ -63,7 +63,7 @@ export class KeywordsDelivery {
 
   private entriesWithKeywords(context: Context): Promise<SearchResult[]> {
     const getWithKeywords = (contentType: cms.ModelType) =>
-      this.delivery.getEntries<ContentWithKeywordsFields>(context, {
+      this.delivery.getEntries<CommonEntryFields>(context, {
         // eslint-disable-next-line @typescript-eslint/camelcase
         content_type: contentType,
         'fields.keywords[exists]': true,
@@ -79,7 +79,7 @@ export class KeywordsDelivery {
     }
     return Promise.all(promises).then(entryCollections =>
       KeywordsDelivery.flatMapEntryCollection(entryCollections).map(entry =>
-        KeywordsDelivery.resultFromEntry(entry, entry.fields.keywords)
+        KeywordsDelivery.resultFromEntry(entry, entry.fields.keywords || [])
       )
     );
   }

--- a/packages/botonic-plugin-contentful/src/contentful/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/keywords.ts
@@ -1,5 +1,5 @@
 import { Entry, EntryCollection } from 'contentful';
-import { Context } from '../cms';
+import { CommonFields, Context } from '../cms';
 import * as cms from '../cms';
 import { ModelType } from '../cms';
 import { SearchResult } from '../search';
@@ -29,9 +29,10 @@ export class KeywordsDelivery {
     const callback = DeliveryApi.callbackFromEntry(entry);
     return new SearchResult(
       callback,
-      entry.fields.name,
-      entry.fields.shortText,
-      keywords,
+      new CommonFields(entry.fields.name, {
+        shortText: entry.fields.shortText,
+        keywords
+      }),
       priority
     );
   }

--- a/packages/botonic-plugin-contentful/src/contentful/queue.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/queue.ts
@@ -2,12 +2,12 @@ import { Context } from '../cms';
 import * as cms from '../cms';
 import * as contentful from 'contentful';
 import { ContentDelivery } from './content-delivery';
-import { ContentWithNameFields, DeliveryApi } from './delivery-api';
-import { ScheduleFields, ScheduleDelivery } from './schedule';
 import {
-  SearchableByKeywordsDelivery,
-  SearchableByKeywordsFields
-} from './searchable-by';
+  commonFieldsFromEntry,
+  CommonEntryFields,
+  DeliveryApi
+} from './delivery-api';
+import { ScheduleFields, ScheduleDelivery } from './schedule';
 
 export class QueueDelivery extends ContentDelivery {
   static REFERENCES_INCLUDE = ScheduleDelivery.REFERENCES_INCLUDE + 1;
@@ -27,30 +27,15 @@ export class QueueDelivery extends ContentDelivery {
 
   static fromEntry(entry: contentful.Entry<QueueFields>): cms.Queue {
     const fields = entry.fields;
-    const name = fields.name;
-    console.log('sched del', fields.schedule);
 
     const schedule =
       fields.schedule && ScheduleDelivery.scheduleFromEntry(fields.schedule);
 
-    const searchableBy =
-      fields.searchableBy &&
-      fields.searchableBy.map(searchableBy =>
-        SearchableByKeywordsDelivery.fromEntry(searchableBy)
-      );
-    return new cms.Queue(
-      name,
-      fields.shortText,
-      fields.queue,
-      schedule,
-      new cms.SearchableBy(searchableBy)
-    );
+    return new cms.Queue(commonFieldsFromEntry(entry), fields.queue, schedule);
   }
 }
 
-export interface QueueFields extends ContentWithNameFields {
-  shortText: string;
+export interface QueueFields extends CommonEntryFields {
   queue: string;
   schedule?: contentful.Entry<ScheduleFields>;
-  searchableBy?: contentful.Entry<SearchableByKeywordsFields>[];
 }

--- a/packages/botonic-plugin-contentful/src/contentful/queue.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/queue.ts
@@ -29,7 +29,7 @@ export class QueueDelivery extends ContentDelivery {
     const fields = entry.fields;
 
     const schedule =
-      fields.schedule && ScheduleDelivery.scheduleFromEntry(fields.schedule);
+      fields.schedule && ScheduleDelivery.fromEntry(fields.schedule);
 
     return new cms.Queue(commonFieldsFromEntry(entry), fields.queue, schedule);
   }

--- a/packages/botonic-plugin-contentful/src/contentful/queue.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/queue.ts
@@ -31,7 +31,11 @@ export class QueueDelivery extends ContentDelivery {
     const schedule =
       fields.schedule && ScheduleDelivery.fromEntry(fields.schedule);
 
-    return new cms.Queue(commonFieldsFromEntry(entry), fields.queue, schedule);
+    return new cms.Queue(
+      commonFieldsFromEntry(entry),
+      fields.queue,
+      schedule && schedule.schedule
+    );
   }
 }
 

--- a/packages/botonic-plugin-contentful/src/contentful/schedule.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/schedule.ts
@@ -15,10 +15,10 @@ export class ScheduleDelivery extends ContentDelivery {
     const f = await this.getEntry<ScheduleFields>(id, DEFAULT_CONTEXT, {
       include: ScheduleDelivery.REFERENCES_INCLUDE
     });
-    return ScheduleDelivery.scheduleFromEntry(f);
+    return ScheduleDelivery.fromEntry(f);
   }
 
-  static scheduleFromEntry(f: Entry<ScheduleFields>): time.Schedule {
+  static fromEntry(f: Entry<ScheduleFields>): time.Schedule {
     const schedule = new time.Schedule(time.Schedule.TZ_CET); // TODO allow configuration
     ScheduleDelivery.addDaySchedules(schedule, f.fields);
     ScheduleDelivery.addExceptions(schedule, f.fields.exceptions);

--- a/packages/botonic-plugin-contentful/src/contentful/schedule.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/schedule.ts
@@ -1,8 +1,13 @@
 import { Entry } from 'contentful';
-import { DEFAULT_CONTEXT, ModelType } from '../cms';
+import { DEFAULT_CONTEXT, ModelType, ScheduleContent } from '../cms';
 import * as time from '../time';
 import { ContentDelivery } from './content-delivery';
-import { ContentWithNameFields, DeliveryApi } from './delivery-api';
+import {
+  CommonEntryFields,
+  commonFieldsFromEntry,
+  ContentWithNameFields,
+  DeliveryApi
+} from './delivery-api';
 
 export class ScheduleDelivery extends ContentDelivery {
   static REFERENCES_INCLUDE = 2;
@@ -11,18 +16,18 @@ export class ScheduleDelivery extends ContentDelivery {
     super(ModelType.SCHEDULE, delivery);
   }
 
-  async schedule(id: string): Promise<time.Schedule> {
+  async schedule(id: string): Promise<ScheduleContent> {
     const f = await this.getEntry<ScheduleFields>(id, DEFAULT_CONTEXT, {
       include: ScheduleDelivery.REFERENCES_INCLUDE
     });
     return ScheduleDelivery.fromEntry(f);
   }
 
-  static fromEntry(f: Entry<ScheduleFields>): time.Schedule {
+  static fromEntry(entry: Entry<ScheduleFields>): ScheduleContent {
     const schedule = new time.Schedule(time.Schedule.TZ_CET); // TODO allow configuration
-    ScheduleDelivery.addDaySchedules(schedule, f.fields);
-    ScheduleDelivery.addExceptions(schedule, f.fields.exceptions);
-    return schedule;
+    ScheduleDelivery.addDaySchedules(schedule, entry.fields);
+    ScheduleDelivery.addExceptions(schedule, entry.fields.exceptions);
+    return new ScheduleContent(commonFieldsFromEntry(entry), schedule);
   }
 
   private static addDaySchedules(
@@ -84,7 +89,7 @@ export class ScheduleDelivery extends ContentDelivery {
     }
   }
 }
-export interface ScheduleFields extends ContentWithNameFields {
+export interface ScheduleFields extends CommonEntryFields {
   mondays?: Entry<HourRangeFields>[];
   tuesdays?: Entry<HourRangeFields>[];
   wednesdays?: Entry<HourRangeFields>[];

--- a/packages/botonic-plugin-contentful/src/contentful/schedule.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/schedule.ts
@@ -89,6 +89,7 @@ export class ScheduleDelivery extends ContentDelivery {
     }
   }
 }
+
 export interface ScheduleFields extends CommonEntryFields {
   mondays?: Entry<HourRangeFields>[];
   tuesdays?: Entry<HourRangeFields>[];

--- a/packages/botonic-plugin-contentful/src/contentful/startup.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/startup.ts
@@ -23,10 +23,10 @@ export class StartUpDelivery extends DeliveryWithFollowUp {
       context
     );
     // .. so we need to fetch the buttons
-    return this.startUpFromEntry(entry, context);
+    return this.fromEntry(entry, context);
   }
 
-  async startUpFromEntry(
+  async fromEntry(
     entry: contentful.Entry<StartUpFields>,
     context: cms.Context
   ): Promise<cms.StartUp> {

--- a/packages/botonic-plugin-contentful/src/contentful/startup.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/startup.ts
@@ -1,7 +1,11 @@
 import * as contentful from 'contentful';
 import * as cms from '../cms';
 import { ButtonDelivery } from './button';
-import { DeliveryApi, ContentWithKeywordsFields } from './delivery-api';
+import {
+  DeliveryApi,
+  CommonEntryFields,
+  commonFieldsFromEntry
+} from './delivery-api';
 import { DeliveryWithFollowUp } from './follow-up';
 
 export class StartUpDelivery extends DeliveryWithFollowUp {
@@ -33,17 +37,15 @@ export class StartUpDelivery extends DeliveryWithFollowUp {
     const buttons = await Promise.all(promises);
     const img = fields.pic ? DeliveryApi.urlFromAsset(fields.pic) : undefined;
     return new cms.StartUp(
-      fields.name,
+      commonFieldsFromEntry(entry),
       img,
       fields.text,
-      buttons,
-      fields.shortText,
-      fields.keywords
+      buttons
     );
   }
 }
 
-export interface StartUpFields extends ContentWithKeywordsFields {
+export interface StartUpFields extends CommonEntryFields {
   pic?: contentful.Asset;
   text?: string;
   // typed as any because we might only get the entry.sys but not the fields

--- a/packages/botonic-plugin-contentful/src/contentful/text.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/text.ts
@@ -24,10 +24,10 @@ export class TextDelivery extends DeliveryWithFollowUp {
       context
     );
     // .. so we need to fetch the buttons
-    return this.textFromEntry(entry, context);
+    return this.fromEntry(entry, context);
   }
 
-  async textFromEntry(
+  async fromEntry(
     entry: contentful.Entry<TextFields>,
     context: cms.Context
   ): Promise<cms.Text> {

--- a/packages/botonic-plugin-contentful/src/contentful/text.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/text.ts
@@ -2,7 +2,11 @@ import * as contentful from 'contentful';
 import * as cms from '../cms';
 import { ButtonDelivery } from './button';
 import { CarouselFields } from './carousel';
-import { DeliveryApi, ContentWithKeywordsFields } from './delivery-api';
+import {
+  DeliveryApi,
+  CommonEntryFields,
+  commonFieldsFromEntry
+} from './delivery-api';
 import { DeliveryWithFollowUp } from './follow-up';
 
 export class TextDelivery extends DeliveryWithFollowUp {
@@ -41,11 +45,9 @@ export class TextDelivery extends DeliveryWithFollowUp {
       const followUp = followUpAndButtons.shift() as (cms.Text | undefined);
       const buttons = followUpAndButtons as cms.Button[];
       return new cms.Text(
-        fields.name,
+        commonFieldsFromEntry(entry),
         fields.text,
         buttons,
-        fields.shortText,
-        fields.keywords,
         followUp,
         fields.buttonsStyle == 'QuickReplies'
           ? cms.ButtonStyle.QUICK_REPLY
@@ -55,7 +57,7 @@ export class TextDelivery extends DeliveryWithFollowUp {
   }
 }
 
-export interface TextFields extends ContentWithKeywordsFields {
+export interface TextFields extends CommonEntryFields {
   // Full text
   text: string;
   // typed as any because we might only get the entry.sys but not the fields

--- a/packages/botonic-plugin-contentful/src/contentful/url.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/url.ts
@@ -4,7 +4,11 @@ import { DeliveryWithFollowUp } from './follow-up';
 import { TextFields } from './text';
 import * as cms from '../cms';
 import * as contentful from 'contentful';
-import { ContentWithKeywordsFields, DeliveryApi } from './delivery-api';
+import {
+  commonFieldsFromEntry,
+  CommonEntryFields,
+  DeliveryApi
+} from './delivery-api';
 
 export class UrlDelivery extends DeliveryWithFollowUp {
   constructor(delivery: DeliveryApi) {
@@ -14,19 +18,14 @@ export class UrlDelivery extends DeliveryWithFollowUp {
   async url(id: string, context: Context): Promise<cms.Url> {
     const entry: contentful.Entry<UrlFields> = await this.getEntry(id, context);
     const fields = entry.fields;
-    const followUp = await this.followUp!.fromFields(fields.followup!, context);
-    const name = fields.name || fields.url;
-    return new cms.Url(
-      name,
-      fields.url,
-      fields.shortText,
-      fields.keywords,
-      followUp
-    );
+    const followUp = fields.followup
+      ? await this.followUp!.fromFields(fields.followup, context)
+      : undefined;
+    return new cms.Url(commonFieldsFromEntry(entry), fields.url, followUp);
   }
 }
 
-export interface UrlFields extends ContentWithKeywordsFields {
+export interface UrlFields extends CommonEntryFields {
   url: string;
   followup?: contentful.Entry<TextFields | CarouselFields>;
 }

--- a/packages/botonic-plugin-contentful/src/contentful/url.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/url.ts
@@ -17,6 +17,10 @@ export class UrlDelivery extends DeliveryWithFollowUp {
 
   async url(id: string, context: Context): Promise<cms.Url> {
     const entry: contentful.Entry<UrlFields> = await this.getEntry(id, context);
+    return this.fromEntry(entry, context);
+  }
+
+  async fromEntry(entry: contentful.Entry<UrlFields>, context: Context) {
     const fields = entry.fields;
     const followUp = fields.followup
       ? await this.followUp!.fromFields(fields.followup, context)

--- a/packages/botonic-plugin-contentful/src/nlp/stemmer.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/stemmer.ts
@@ -8,6 +8,9 @@ import { tokenizerPerLocale } from './tokens';
 
 // see https://github.com/axa-group/nlp.js/blob/HEAD/docs/language-support.md
 // and https://stackoverflow.com/a/11210358/145289
+// snowball algorithm inspired from https://github.com/MihaiValentin/lunr-languages, based on
+// https://github.com/fortnightlabs/snowball-js/blob/master/stemmer/src/ext/SpanishStemmer.js based on
+// java version at http://snowball.tartarus.org/download.html
 export const stemmers: { [key: string]: BaseStemmer } = {
   ca: new CatalanStemmer(tokenizerPerLocale('ca')),
   en: new EnglishStemmer(tokenizerPerLocale('en')),

--- a/packages/botonic-plugin-contentful/src/search/search-by-keywords.ts
+++ b/packages/botonic-plugin-contentful/src/search/search-by-keywords.ts
@@ -30,7 +30,7 @@ export class SearchByKeywords {
       this.keywordsOptions[locale] || new KeywordsOptions()
     );
     contentsWithKeywords.forEach(content =>
-      kws.addCandidate(content, content.keywords!)
+      kws.addCandidate(content, content.common.keywords!)
     );
     const results = kws.findCandidatesWithKeywordsAt(inputText);
     return results.map(res => {

--- a/packages/botonic-plugin-contentful/src/search/search-result.ts
+++ b/packages/botonic-plugin-contentful/src/search/search-result.ts
@@ -1,6 +1,7 @@
 import {
   Button,
   Callback,
+  CommonFields,
   ContentCallback,
   ModelType,
   PRIORITY_MAX,
@@ -17,25 +18,23 @@ export class SearchResult {
    */
   constructor(
     readonly callback: Callback,
-    readonly name: string,
-    readonly shortText?: string,
-    readonly keywords: string[] = [],
+    readonly common: CommonFields,
     readonly priority = PRIORITY_MAX,
     readonly score = SCORE_MAX,
     readonly match?: string
   ) {}
 
   toButton(): Button {
-    let shortText = this.shortText;
+    let shortText = this.common.shortText;
     if (!shortText) {
-      shortText = this.name;
+      shortText = this.common.name;
       console.error(
         `${JSON.stringify(this.callback)} ${
-          this.name
+          this.common.name
         } without shortText. Assigning name to button text`
       );
     }
-    return new Button(this.name, shortText, this.callback);
+    return new Button(this.common.name, shortText, this.callback);
   }
 
   getCallbackIfContentIs(modelType: ModelType): ContentCallback | undefined {
@@ -53,7 +52,7 @@ export class SearchResult {
       return undefined;
     }
     if (
-      this.shortText !== SearchResult.CHITCHAT_SHORT_TEXT &&
+      this.common.shortText !== SearchResult.CHITCHAT_SHORT_TEXT &&
       this.callback.model !== ModelType.CHITCHAT
     ) {
       return undefined;

--- a/packages/botonic-plugin-contentful/src/search/search.ts
+++ b/packages/botonic-plugin-contentful/src/search/search.ts
@@ -50,8 +50,8 @@ export class Search {
       if (urlCallback) {
         const url = await this.cms.url(urlCallback.id, context);
         return new Button(
-          result.name,
-          result.shortText!,
+          result.common.name,
+          result.common.shortText!,
           Callback.ofUrl(url.url)
         );
       }

--- a/packages/botonic-plugin-contentful/src/time/schedule.ts
+++ b/packages/botonic-plugin-contentful/src/time/schedule.ts
@@ -70,6 +70,15 @@ export class Schedule {
   }
 }
 
+export class ScheduleAlwaysOn extends Schedule {
+  constructor() {
+    super('UTC');
+  }
+  contains(date: Date): boolean {
+    return true;
+  }
+}
+
 export class DaySchedule {
   constructor(readonly ranges: TimeRange[]) {}
 

--- a/packages/botonic-plugin-contentful/src/tools/keyword-tools.ts
+++ b/packages/botonic-plugin-contentful/src/tools/keyword-tools.ts
@@ -25,14 +25,14 @@ export class KeywordsTool {
     const context = { locale: this.locale };
     const results = await this.cms.contentsWithKeywords(context);
     for (const res of results) {
-      const stemmed = res.keywords.map(
+      const stemmed = res.common.keywords.map(
         kw =>
           new StemmedKeyword(
             kw,
             this.normalizer.normalize(context.locale, kw).stems
           )
       );
-      keywords.set(res.name, stemmed);
+      keywords.set(res.common.name, stemmed);
     }
     return keywords;
   }

--- a/packages/botonic-plugin-contentful/tests/contentful/carousel.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/carousel.test.ts
@@ -25,8 +25,8 @@ test('TEST: contentful carousel', async () => {
 
   // assert
   expect(carousel.elements).toHaveLength(3);
-  expect(carousel.name).toEqual('INICIO');
-  expect(carousel.keywords).toEqual(['Inicio', 'menu', 'empezar']);
-  expect(carousel.shortText).toEqual('Menú de Inicio');
+  expect(carousel.common.name).toEqual('INICIO');
+  expect(carousel.common.keywords).toEqual(['Inicio', 'menu', 'empezar']);
+  expect(carousel.common.shortText).toEqual('Menú de Inicio');
   assertElementDudasPrevias(carousel.elements[0]);
 });

--- a/packages/botonic-plugin-contentful/tests/contentful/contents.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/contents.test.ts
@@ -55,6 +55,5 @@ test('TEST: contentful contentsWithKeywords', async () => {
   expect(ofType(ModelType.SCHEDULE)).toHaveLength(0);
   expect(ofType(ModelType.DATE_RANGE)).toHaveLength(0);
   expect(ofType(ModelType.IMAGE)).toHaveLength(0);
-  expect(ofType(ModelType.ASSET)).toHaveLength(0);
   expect(ofType(ModelType.QUEUE)).toHaveLength(2);
 });

--- a/packages/botonic-plugin-contentful/tests/contentful/contents.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/contents.test.ts
@@ -1,7 +1,27 @@
-import { ContentCallback, ModelType, Queue } from '../../src/cms';
+import {
+  CommonFields,
+  ContentCallback,
+  ModelType,
+  Queue,
+  Text
+} from '../../src/cms';
 import { testContentful, testContext } from './contentful.helper';
 
-test('TEST: contentful contents', async () => {
+test('TEST: contentful contents filter', async () => {
+  const filter = (cf: CommonFields) => cf.name.startsWith('POST');
+  const texts = await testContentful().contents(
+    ModelType.TEXT,
+    { locale: 'en' },
+    filter
+  );
+  expect(texts).toSatisfyAll(
+    text => text instanceof Text && filter(text.common)
+  );
+
+  expect(texts.length).toBeGreaterThanOrEqual(8);
+});
+
+test('TEST: contentful contents no filter', async () => {
   const queues = await testContentful().contents(ModelType.QUEUE, {
     locale: 'en'
   });

--- a/packages/botonic-plugin-contentful/tests/contentful/date-range.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/date-range.test.ts
@@ -7,7 +7,7 @@ test('TEST: contentful dateRange', async () => {
     TEST_DATE_RANGE_HUBTYPE_ID
   );
 
-  expect(dateRange.name).toEqual('Test DateRange name');
-  expect(dateRange.from).toEqual(new Date(2019, 4, 26, 20, 30));
-  expect(dateRange.to).toEqual(new Date(2019, 8, 1));
+  expect(dateRange.common.name).toEqual('Test DateRange name');
+  expect(dateRange.dateRange.from).toEqual(new Date(2019, 4, 26, 20, 30));
+  expect(dateRange.dateRange.to).toEqual(new Date(2019, 8, 1));
 });

--- a/packages/botonic-plugin-contentful/tests/contentful/keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/keywords.test.ts
@@ -26,9 +26,9 @@ test('TEST: contentful contentsWithKeywords', async () => {
   expect(queues).toHaveLength(2);
   const keywordsByPrio: { [priority: number]: string[] } = {};
   for (const queue of queues) {
-    expect(queue.name).toEqual('TEST_QUEUE');
-    expect(queue.shortText).toEqual('Short Text');
-    keywordsByPrio[queue.priority] = queue.keywords;
+    expect(queue.common.name).toEqual('TEST_QUEUE');
+    expect(queue.common.shortText).toEqual('Short Text');
+    keywordsByPrio[queue.priority] = queue.common.keywords;
   }
   expect(keywordsByPrio[10]).toEqual(['low1', 'low2']);
   expect(keywordsByPrio[99]).toEqual(['high1', 'high2']);
@@ -38,10 +38,10 @@ test('TEST: contentful contentsWithKeywords', async () => {
   const postFaq1 = contentsWithKeywords.find(
     content => (content.callback as ContentCallback).id == TEST_POST_FAQ1_ID
   );
-  expect(postFaq1!.name).toEqual('POST_FAQ1');
-  expect(postFaq1!.shortText).toEqual('Encontrar mi pedido');
+  expect(postFaq1!.common.name).toEqual('POST_FAQ1');
+  expect(postFaq1!.common.shortText).toEqual('Encontrar mi pedido');
   expect(postFaq1!.priority).toEqual(100);
-  expect(postFaq1!.keywords).toIncludeSameMembers([
+  expect(postFaq1!.common.keywords).toIncludeSameMembers([
     'no encuentro mi pedido',
     'donde esta mi pedido'
   ]);

--- a/packages/botonic-plugin-contentful/tests/contentful/queue.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/queue.test.ts
@@ -1,4 +1,9 @@
-import { Queue, SearchableBy, SearchableByKeywords } from '../../src/cms';
+import {
+  CommonFields,
+  Queue,
+  SearchableBy,
+  SearchableByKeywords
+} from '../../src/cms';
 import { testContentful, testContext } from './contentful.helper';
 import { testSchedule } from './schedule.test';
 
@@ -13,11 +18,9 @@ test('TEST: contentful Queue', async () => {
   ]);
   expect(queue).toEqual(
     new Queue(
-      'TEST_QUEUE',
-      'Short Text',
+      new CommonFields('TEST_QUEUE', { shortText: 'Short Text', searchableBy }),
       'queueName',
-      testSchedule(),
-      searchableBy
+      testSchedule()
     )
   );
 });

--- a/packages/botonic-plugin-contentful/tests/contentful/schedule.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/schedule.test.ts
@@ -8,7 +8,8 @@ test('TEST: contentful schedule', async () => {
   const schedule = await sut.schedule('71twiV4wcaFwhK6tSYuIKy');
 
   // assert
-  expect(schedule).toEqual(testSchedule());
+  expect(schedule.schedule).toEqual(testSchedule());
+  expect(schedule.common.name).toEqual('SUPPORT_SCHEDULE1');
 });
 
 export function testSchedule(): Schedule {

--- a/packages/botonic-plugin-contentful/tests/contentful/startup.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/startup.test.ts
@@ -1,4 +1,10 @@
-import { Button, ContentCallback, ModelType, StartUp } from '../../src/cms';
+import {
+  Button,
+  CommonFields,
+  ContentCallback,
+  ModelType,
+  StartUp
+} from '../../src/cms';
 import { testContentful } from './contentful.helper';
 import { TEST_CAROUSEL_MAIN_ID } from './carousel.test';
 
@@ -6,7 +12,11 @@ test('TEST: contentful startUp', async () => {
   const startUp = await testContentful().startUp('PfMPIeS6zD1Rix6Px9m0u');
   expect(startUp).toEqual(
     new StartUp(
-      'BANNER',
+      new CommonFields('BANNER', {
+        shortText: 'Bienvenida',
+        keywords: ['keyword1']
+      }),
+
       'https://images.ctfassets.net/p2iyhzd1u4a7/1T0ntgNJnDUSwz59zGMZO6/ed6772d3a7b426025540c879b9d95347/red.jpg',
       'Le damos la bienvenida a su nuevo asistente virtual.',
       [
@@ -15,9 +25,7 @@ test('TEST: contentful startUp', async () => {
           'Menú de Inicio',
           new ContentCallback(ModelType.CAROUSEL, TEST_CAROUSEL_MAIN_ID)
         )
-      ],
-      'Bienvenida',
-      ['keyword1']
+      ]
     )
   );
 });

--- a/packages/botonic-plugin-contentful/tests/contentful/text.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/text.test.ts
@@ -38,7 +38,7 @@ test('TEST: contentful text with URL button with followup', async () => {
 
   // assert
   expect(text.text).toEqual('Cómo encontrar su “pedido”\n' + '...');
-  expect(text.shortText).toEqual(
+  expect(text.common.shortText).toEqual(
     ctx && ctx.locale == 'en' ? 'Find my command' : 'Encontrar mi pedido'
   );
   expect(text.buttons).toHaveLength(1);

--- a/packages/botonic-plugin-contentful/tests/contentful/url.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/url.test.ts
@@ -1,4 +1,4 @@
-import { Url } from '../../src/cms';
+import { CommonFields, Url } from '../../src/cms';
 import { testContentful } from './contentful.helper';
 
 const TEST_URL_HUBTYPE_ID = '4ceaDUEr0ay6N7aXzFRt69';
@@ -6,9 +6,12 @@ const TEST_URL_HUBTYPE_ID = '4ceaDUEr0ay6N7aXzFRt69';
 test('TEST: contentful url', async () => {
   const url = await testContentful().url(TEST_URL_HUBTYPE_ID, { locale: 'en' });
   expect(url).toEqual(
-    new Url('URL_HUBTYPE', 'https://www.hubtype.com/en', 'Web de Hubtype', [
-      'hubtypeEn',
-      'botonicEn'
-    ])
+    new Url(
+      new CommonFields('URL_HUBTYPE', {
+        shortText: 'Web de Hubtype',
+        keywords: ['hubtypeEn', 'botonicEn']
+      }),
+      'https://www.hubtype.com/en'
+    )
   );
 });

--- a/packages/botonic-plugin-contentful/tests/helpers/builders.ts
+++ b/packages/botonic-plugin-contentful/tests/helpers/builders.ts
@@ -1,6 +1,7 @@
 import {
   Button,
   ButtonStyle,
+  CommonFields,
   ContentCallback,
   ModelType,
   Text
@@ -55,7 +56,9 @@ export class RndTextBuilder extends TextBuilder {
       .build();
     this.shortText = rndStr();
     this.keywords = this.keywordsBuilder.build();
-    this.followUp = rndBool() ? undefined : new Text(rndStr(), rndStr(), []);
+    this.followUp = rndBool()
+      ? undefined
+      : new Text(new CommonFields(rndStr()), rndStr(), []);
     this.buttonsStyle = rndBool()
       ? ButtonStyle.QUICK_REPLY
       : ButtonStyle.BUTTON;

--- a/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
@@ -7,10 +7,7 @@ import {
 
 test('TEST: sut.normalize stopWord', () => {
   const sut = new Normalizer(undefined, { es: ['stopWórd'] });
-  expect(sut.normalize('es', 'no digas STOPword').stems).toEqual([
-    'no',
-    'dig'
-  ]);
+  expect(sut.normalize('es', 'no digas STOPword').stems).toEqual(['no', 'dig']);
 });
 
 test('TEST: sut.normalize es', () => {

--- a/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
@@ -7,7 +7,8 @@ import {
   DummyCMS,
   ModelType,
   SearchByKeywords,
-  Context
+  Context,
+  CommonFields
 } from '../../src';
 import { SearchResult as CallbackToContentWithKeywords1 } from '../../src/search/search-result';
 import { Normalizer, StemmingBlackList, MatchType } from '../../src/nlp';
@@ -100,9 +101,10 @@ test('TEST: searchContentsFromInput with stem blacklist', async () => {
 export function contentWithKeyword(callback: Callback, keywords: string[]) {
   return new SearchResult(
     callback,
-    callback.payload!,
-    'shortText' + callback.payload,
-    keywords
+    new CommonFields(callback.payload!, {
+      shortText: 'shortText' + callback.payload,
+      keywords
+    })
   );
 }
 
@@ -110,9 +112,7 @@ export function chitchatContent(keywords: string[]) {
   const id = Math.random().toString();
   return new SearchResult(
     new ContentCallback(ModelType.TEXT, id),
-    id,
-    'chitchat',
-    keywords
+    new CommonFields(id, { shortText: 'chitchat', keywords })
   );
 }
 

--- a/packages/botonic-plugin-contentful/tests/search/search.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/search.test.ts
@@ -21,16 +21,12 @@ test('TEST: respondFoundContents text with buttons', async () => {
 
   const urlContent = new SearchResult(
     new ContentCallback(ModelType.URL, 'urlCmsId'),
-    'name',
-    'url shortText',
-    []
+    new CommonFields('name', { shortText: 'url shortText' })
   );
 
   const textContent = new SearchResult(
     new ContentCallback(ModelType.TEXT, 'textCmsId'),
-    'name',
-    'text shortText',
-    []
+    new CommonFields('name', { shortText: 'text shortText' })
   );
 
   // sut
@@ -64,9 +60,7 @@ test('TEST: respondFoundContents text with chitchat', async () => {
   when(cms.chitchat('chitchatCmsId', CONTEXT)).thenResolve(chitchat);
   const chitchatCallback = new SearchResult(
     new ContentCallback(ModelType.CHITCHAT, 'chitchatCmsId'),
-    'name',
-    'chitchat',
-    []
+    new CommonFields('name', { shortText: 'chitchat' })
   );
 
   when(cms.text('foundId', CONTEXT)).thenResolve(

--- a/packages/botonic-plugin-contentful/tests/search/search.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/search.test.ts
@@ -1,5 +1,12 @@
 import { instance, mock, when } from 'ts-mockito';
-import { ContentCallback, DummyCMS, ModelType, Text, Url } from '../../src/cms';
+import {
+  CommonFields,
+  ContentCallback,
+  DummyCMS,
+  ModelType,
+  Text,
+  Url
+} from '../../src/cms';
 import { Search, SearchResult } from '../../src/search';
 import { Normalizer } from '../../src/nlp';
 
@@ -8,7 +15,7 @@ const CONTEXT = { locale: 'es' };
 test('TEST: respondFoundContents text with buttons', async () => {
   const cms = mock(DummyCMS);
   when(cms.url('urlCmsId', CONTEXT)).thenResolve(
-    new Url('url', 'http:/mocked_url')
+    new Url(new CommonFields('url'), 'http:/mocked_url')
   );
   const sut = new Search(instance(cms), instance(mock(Normalizer)));
 
@@ -28,7 +35,7 @@ test('TEST: respondFoundContents text with buttons', async () => {
 
   // sut
   when(cms.text('foundId', CONTEXT)).thenResolve(
-    new Text('foundName', 'foundText', [])
+    new Text(new CommonFields('foundName'), 'foundText', [])
   );
   const response = await sut.respondFoundContents(
     [urlContent, textContent],
@@ -63,7 +70,7 @@ test('TEST: respondFoundContents text with chitchat', async () => {
   );
 
   when(cms.text('foundId', CONTEXT)).thenResolve(
-    new Text('foundName', 'foundText', [])
+    new Text(new CommonFields('foundName'), 'foundText', [])
   );
 
   //act
@@ -84,7 +91,7 @@ test('TEST: respondFoundContents without contents', async () => {
 
   // sut
   when(cms.text('notFoundId', CONTEXT)).thenResolve(
-    new Text('notFoundName', 'notFoundText', [])
+    new Text(new CommonFields('notFoundName'), 'notFoundText', [])
   );
   const response = await sut.respondFoundContents(
     [],

--- a/packages/botonic-plugin-contentful/tests/time/schedule.test.ts
+++ b/packages/botonic-plugin-contentful/tests/time/schedule.test.ts
@@ -2,6 +2,7 @@ import {
   DaySchedule,
   HourAndMinute,
   Schedule,
+  ScheduleAlwaysOn,
   TimeRange,
   WeekDay
 } from '../../src/time/schedule';
@@ -9,6 +10,11 @@ import momentTz from 'moment-timezone';
 
 const MARCH = 2;
 const APRIL = 3;
+
+test('TEST ScheduleAlwaysOn', () => {
+  const sut = new ScheduleAlwaysOn();
+  expect(sut.contains(new Date())).toEqual(true);
+});
 
 test.each<any>([
   // Friday winter time

--- a/packages/botonic-plugin-contentful/tsconfig.json
+++ b/packages/botonic-plugin-contentful/tsconfig.json
@@ -5,6 +5,7 @@
     "src/**/*.tsx"
   ],
   "compilerOptions": {
+    "allowUnreachableCode": false,
     "baseUrl": "src",
     "paths": {
       "*": [

--- a/packages/botonic-plugin-dynamodb/.eslintrc.js
+++ b/packages/botonic-plugin-dynamodb/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
   rules: {
     // style. Soon a precommit githook will fix prettier errors
     "prettier/prettier": "error",
-    "filenames/match-regex": [2, "^[a-z-.]+$", true],
+    "filenames/match-regex": ["error", "^[a-z-.]+$", true],
 
 
     // In typescript we must use obj.field when we have the types, and obj['field'] when we don't
@@ -35,6 +35,8 @@ module.exports = {
     // e.g. "@typescript-eslint/explicit-function-return-type": "off",
     "node/no-unsupported-features/es-syntax": "off", //babel will take care of ES compatibility
     "unicorn/no-abusive-eslint-disable" : "off",
+    "@typescript-eslint/camelcase" : "warn",
+    "consistent-return": "error",
 
     // special for TYPESCRIPT
     "@typescript-eslint/explicit-function-return-type": "off", // annoying for tests

--- a/packages/botonic-plugin-dynamodb/package-lock.json
+++ b/packages/botonic-plugin-dynamodb/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-dynamodb",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-dynamodb/package.json
+++ b/packages/botonic-plugin-dynamodb/package.json
@@ -11,7 +11,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-dynamodb",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {
@@ -24,7 +24,7 @@
     "@aws/dynamodb-data-mapper": "^0.7.3",
     "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
     "@babel/runtime": "^7.5.5",
-    "aws-sdk": "^2.479.0"
+    "aws-sdk": "^2.547.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.15",

--- a/packages/botonic-plugin-dynamodb/src/index.ts
+++ b/packages/botonic-plugin-dynamodb/src/index.ts
@@ -11,6 +11,7 @@ import { DynamoTrackStorage } from './infrastructure/dynamo';
 import time from './domain/time';
 
 export * from './domain/dummy';
+export * from './infrastructure';
 
 export default class BotonicPluginDynamoDB {
   readonly storage: TrackStorage;

--- a/packages/botonic-plugin-dynamodb/src/infrastructure/index.ts
+++ b/packages/botonic-plugin-dynamodb/src/infrastructure/index.ts
@@ -1,0 +1,1 @@
+export { Env } from './dynamo';

--- a/packages/botonic-plugin-dynamodb/tsconfig.json
+++ b/packages/botonic-plugin-dynamodb/tsconfig.json
@@ -5,6 +5,7 @@
     "src/**/*.tsx"
   ],
   "compilerOptions": {
+    "allowUnreachableCode": false,
     "baseUrl": "src",
     "paths": {
       "*": [


### PR DESCRIPTION
- name, shortText, keywords content fields moved to new CommonFields aggregate
- CMS.contents now allows a filtering lambda
- New CommonFields: 
1) dateRange: allows specifying the date availability for a content.
2) partitions: allows replicating a content for several partitions (eg. country)