### PR TITLE
Contentful/keyword match improvements

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -12,7 +12,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/botonic-plugin-contentful/src/contentful/index.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/index.ts
@@ -14,7 +14,7 @@ import {
   TopContent
 } from '../cms';
 import { ButtonDelivery } from './button';
-import { DeliveryApi} from './delivery-api';
+import { DeliveryApi } from './delivery-api';
 import { CarouselDelivery } from './carousel';
 import { StartUpDelivery } from './startup';
 import { TextDelivery } from './text';

--- a/packages/botonic-plugin-contentful/src/nlp/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/keywords.ts
@@ -2,6 +2,9 @@ import { SimilarWordFinder, SimilarWordResult } from './similar-words';
 import { NormalizedUtterance, Normalizer } from './normalizer';
 import { Locale } from './locales';
 
+/**
+ * May contain multiple words
+ */
 export class Keyword {
   constructor(
     readonly raw: string,

--- a/packages/botonic-plugin-contentful/src/nlp/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/keywords.ts
@@ -47,7 +47,7 @@ export enum SortType {
 export class KeywordsOptions {
   constructor(
     readonly maxDistance = 1,
-    readonly similarWordsMinLength = 3,
+    readonly similarWordsMinMatchLength = 3,
     readonly resultsSortType = SortType.LENGTH
   ) {}
 }
@@ -64,7 +64,7 @@ export class KeywordsParser<M> {
   ) {
     this.similar = new SimilarWordFinder<M>(
       true,
-      options.similarWordsMinLength
+      options.similarWordsMinMatchLength
     );
   }
 

--- a/packages/botonic-plugin-contentful/src/nlp/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/keywords.ts
@@ -83,27 +83,18 @@ export class KeywordsParser<M> {
   findCandidatesWithKeywordsAt(
     utterance: NormalizedUtterance
   ): SimilarWordResult<M>[] {
-    let results: SimilarWordResult<M>[] = [];
-    switch (this.matchType) {
-      case MatchType.ONLY_KEYWORDS_FOUND:
-        results = this.similar.findIfOnlyWordsFromKeyword(
-          utterance,
-          this.options.maxDistance
-        );
-        break;
-      case MatchType.KEYWORDS_AND_OTHERS_FOUND:
-        results = this.similar.findSubstring(
-          utterance,
-          this.options.maxDistance
-        );
-        break;
-      case MatchType.ALL_WORDS_IN_KEYWORDS_MIXED_UP:
-        results = this.mixedUp(utterance);
-    }
+    const results: SimilarWordResult<M>[] =
+      this.matchType === MatchType.ALL_WORDS_IN_KEYWORDS_MIXED_UP
+        ? this.mixedUp(utterance)
+        : this.similar.find(
+            this.matchType,
+            utterance,
+            this.options.maxDistance
+          );
     return this.sort(results);
   }
 
-  private mixedUp(utterance: NormalizedUtterance) {
+  mixedUp(utterance: NormalizedUtterance) {
     if (this.options.maxDistance > 0) {
       throw new Error(
         'ALL_WORDS_IN_KEYWORDS_MIXED_UP does not support distance> 0'

--- a/packages/botonic-plugin-contentful/src/nlp/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/keywords.ts
@@ -86,7 +86,7 @@ export class KeywordsParser<M> {
     let results: SimilarWordResult<M>[] = [];
     switch (this.matchType) {
       case MatchType.ONLY_KEYWORDS_FOUND:
-        results = this.similar.findSimilarKeyword(
+        results = this.similar.findIfOnlyWordsFromKeyword(
           utterance,
           this.options.maxDistance
         );

--- a/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
@@ -37,7 +37,7 @@ export class NormalizedUtterance {
    *
    * @param raw
    * @param tokens lowercase, with i18n characters converted to ascii
-   * @param stems lowercase, stemmed
+   * @param stems lowercase, stemmed. Equal to tokens if onlyStopWords==true
    * @param onlyStopWords tokens are all stop words
    */
   constructor(
@@ -101,7 +101,7 @@ export class Normalizer {
       stems = stems.concat(...tokenStems);
     }
     if (stems.length == 0) {
-      console.log(`'${txt}' only contains stopwords. Not removing them`);
+      // console.log(`'${txt}' only contains stopwords. Not removing them`);
       return new NormalizedUtterance(txt, tokens, tokens, true);
     }
     return new NormalizedUtterance(txt, tokens, stems, false);

--- a/packages/botonic-plugin-contentful/src/nlp/similar-words.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/similar-words.ts
@@ -50,7 +50,7 @@ export class SimilarWordFinder<M> {
     this.candidates.push(candidate);
   }
 
-  findSimilarKeyword(
+  findIfOnlyWordsFromKeyword(
     utterance: NormalizedUtterance,
     maxDistance: number
   ): SimilarWordResult<M>[] {
@@ -65,6 +65,36 @@ export class SimilarWordFinder<M> {
         if (distance != TOO_DISTANT) {
           results.push(
             new SimilarWordResult<M>(candidate.owner, keyword, match, distance)
+          );
+        }
+      }
+    }
+
+    return this.getLongestResultPerCandidate(results);
+  }
+
+  findSubstring(
+    sentence: NormalizedUtterance,
+    maxDistance = 1
+  ): SimilarWordResult<M>[] {
+    const results: SimilarWordResult<M>[] = [];
+    const wordPositions = this.similar.getWordPositions(sentence.joinedStems);
+    for (const candidate of this.candidates) {
+      for (const keyword of candidate.keywords) {
+        const partialMatch = this.findKeyword(
+          keyword,
+          sentence,
+          maxDistance,
+          wordPositions
+        );
+        if (partialMatch) {
+          results.push(
+            new SimilarWordResult<M>(
+              candidate.owner,
+              keyword,
+              partialMatch.match,
+              partialMatch.distance
+            )
           );
         }
       }
@@ -132,37 +162,7 @@ export class SimilarWordFinder<M> {
     return uniq;
   }
 
-  findSubstring(
-    sentence: NormalizedUtterance,
-    maxDistance = 1
-  ): SimilarWordResult<M>[] {
-    const results: SimilarWordResult<M>[] = [];
-    const wordPositions = this.similar.getWordPositions(sentence.joinedStems);
-    for (const candidate of this.candidates) {
-      for (const keyword of candidate.keywords) {
-        const partialMatch = this.findKeyword(
-          keyword,
-          sentence,
-          maxDistance,
-          wordPositions
-        );
-        if (partialMatch) {
-          results.push(
-            new SimilarWordResult<M>(
-              candidate.owner,
-              keyword,
-              partialMatch.match,
-              partialMatch.distance
-            )
-          );
-        }
-      }
-    }
-
-    return this.getLongestResultPerCandidate(results);
-  }
-
-  findKeyword(
+  private findKeyword(
     keyword: Keyword,
     sentence: NormalizedUtterance,
     maxDistance: number,

--- a/packages/botonic-plugin-contentful/src/nlp/similar-words.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/similar-words.ts
@@ -282,8 +282,8 @@ class FindMixedUp extends CandidateFinder {
       }
       // in case the space between the words in the keyword is missing
       if (
-        !submatches ||
-        (submatches.length == 0 && keyword.raw.includes(' '))
+        (!submatches || submatches.length == 0) &&
+        keyword.raw.includes(' ')
       ) {
         const wordsWithoutSpace = this.substring.findKeyword(
           keyword,

--- a/packages/botonic-plugin-contentful/src/tools/index.ts
+++ b/packages/botonic-plugin-contentful/src/tools/index.ts
@@ -1,1 +1,2 @@
 export * from './keyword-tools';
+export * from './regression-tools';

--- a/packages/botonic-plugin-contentful/src/tools/regression-tools.ts
+++ b/packages/botonic-plugin-contentful/src/tools/regression-tools.ts
@@ -1,0 +1,42 @@
+import { Locale, MatchType } from '../nlp';
+import BotonicPluginContentful from '../plugin';
+import { ContentCallback } from '../cms';
+
+export type SearchEvaluator = (
+  /** Starting with 0. Undefined if not found */
+  matchPosition: number | undefined,
+  numResults: number
+) => number;
+
+export class GroundTruth {
+  constructor(readonly utterance: string, readonly contentId: string) {}
+}
+
+export class SearchRegression {
+  constructor(
+    readonly plugin: BotonicPluginContentful,
+    readonly evaluator: SearchEvaluator
+  ) {}
+
+  async run(
+    matchType: MatchType,
+    groundTruths: Iterable<GroundTruth>,
+    locale: Locale
+  ): Promise<number> {
+    let sumEvals = 0;
+    let count = 0;
+    for (const gt of groundTruths) {
+      count++;
+      const res = await this.plugin.search.searchByKeywords(
+        gt.utterance,
+        matchType,
+        { locale }
+      );
+      const pos = res.findIndex(
+        res => (res.callback as ContentCallback).id == gt.contentId
+      );
+      sumEvals += this.evaluator(pos >= 0 ? pos : undefined, res.length);
+    }
+    return sumEvals / count;
+  }
+}

--- a/packages/botonic-plugin-contentful/tests/contentful/keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/keywords.test.ts
@@ -42,8 +42,8 @@ test('TEST: contentful contentsWithKeywords', async () => {
   expect(postFaq1!.common.shortText).toEqual('Find my command');
   expect(postFaq1!.priority).toEqual(100);
   expect(postFaq1!.common.keywords).toIncludeSameMembers([
-    'no encuentro mi pedido',
-    'donde esta mi pedido'
+    "can't find my order",
+    'where is my order'
   ]);
 });
 

--- a/packages/botonic-plugin-contentful/tests/nlp/keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/keywords.test.ts
@@ -170,3 +170,11 @@ test.each<any>([
   'TEST: find keywords of "%s" with ALL_WORDS_IN_KEYWORDS_MIXED_UP',
   testFindKeywords('es', MatchType.ALL_WORDS_IN_KEYWORDS_MIXED_UP)
 );
+
+test('ALL_WORDS_IN_KEYWORDS_MIXED_UP', () => {
+  testFindKeywords('es', MatchType.ALL_WORDS_IN_KEYWORDS_MIXED_UP)(
+    'sobre',
+    { ONLY_STOPWORD: ['kw1', 'Sobre'] },
+    ['ONLY_STOPWORD']
+  );
+});

--- a/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
@@ -1,4 +1,8 @@
-import { CandidateWithKeywords, Keyword } from '../../src/nlp/keywords';
+import {
+  CandidateWithKeywords,
+  Keyword,
+  MatchType
+} from '../../src/nlp/keywords';
 import {
   SimilarWordFinder,
   SimilarWordResult
@@ -15,6 +19,7 @@ function candidate(...kws: string[]): CandidateWithKeywords<TestCandidate> {
     kws.map(kw)
   );
 }
+
 function kw(kw: string) {
   return new Keyword(`raw ${kw}`, kw, false);
 }
@@ -58,24 +63,32 @@ test.each<any>([
     const sut = new SimilarWordFinder<TestCandidate>(false);
     sut.addCandidate(CAND_ADIOS);
     sut.addCandidate(CAND_HOLA);
-    const result = sut.findIfOnlyWordsFromKeyword(ut(needle), maxDistance);
+    const result = sut.find(
+      MatchType.ONLY_KEYWORDS_FOUND,
+      ut(needle),
+      maxDistance
+    );
     expect(result[0]).toEqual(expectedResult);
   }
 );
 
-test('TEST: findSimilarKeyword() missing space', () => {
+test('TEST: ONLY_KEYWORDS_FOUND missing space', () => {
   const sut = new SimilarWordFinder<TestCandidate>(true);
   sut.addCandidate(CAND_ADIOS);
   sut.addCandidate(CAND_HOLA);
-  const result = sut.findIfOnlyWordsFromKeyword(ut('buenosdias'), 1);
+  const result = sut.find(MatchType.ONLY_KEYWORDS_FOUND, ut('buenosdias'), 1);
   expect(result[0].candidate).toEqual(CAND_HOLA.owner);
 });
 
-test('TEST: findSimilarKeyword() stemmed checks all words in keyword', () => {
+test('TEST: ONLY_KEYWORDS_FOUND stemmed checks all words in keyword', () => {
   const sut = new SimilarWordFinder<TestCandidate>(true);
   sut.addCandidate(candidate('realiz ped'));
-  expect(sut.findIfOnlyWordsFromKeyword(ut('realiz'), 1)).toHaveLength(0);
-  expect(sut.findIfOnlyWordsFromKeyword(ut('realizarped'), 1)).toHaveLength(1);
+  expect(sut.find(MatchType.ONLY_KEYWORDS_FOUND, ut('realiz'), 1)).toHaveLength(
+    0
+  );
+  expect(
+    sut.find(MatchType.ONLY_KEYWORDS_FOUND, ut('realizarped'), 1)
+  ).toHaveLength(1);
 });
 
 test.each<any>([
@@ -100,7 +113,11 @@ test.each<any>([
     const sut = new SimilarWordFinder<TestCandidate>(false);
     sut.addCandidate(CAND_ADIOS);
     sut.addCandidate(CAND_HOLA);
-    const result = sut.findSubstring(ut(needle), maxDistance);
+    const result = sut.find(
+      MatchType.KEYWORDS_AND_OTHERS_FOUND,
+      ut(needle),
+      maxDistance
+    );
     expect(result[0]).toEqual(expectedResult);
   }
 );
@@ -122,18 +139,22 @@ test.each<any>([
   }
 );
 
-test('TEST: findSubstring gets closest match', () => {
+test('TEST: KEYWORDS_AND_OTHERS_FOUND gets closest match', () => {
   const sut = new SimilarWordFinder<TestCandidate>(true);
   sut.addCandidate(candidate('abc', 'abcdef'));
-  const result = sut.findSubstring(ut('xxxx abcd'), 2);
+  const result = sut.find(
+    MatchType.KEYWORDS_AND_OTHERS_FOUND,
+    ut('xxxx abcd'),
+    2
+  );
   expect(result).toHaveLength(1);
   expect(result[0].distance).toEqual(1);
 });
 
-test('TEST: findSimilarKeyword gets closest match', () => {
+test('TEST: ONLY_KEYWORDS_FOUND gets closest match', () => {
   const sut = new SimilarWordFinder<TestCandidate>(true);
   sut.addCandidate(candidate('abc', 'abcdef'));
-  const result = sut.findIfOnlyWordsFromKeyword(ut('abcd'), 2);
+  const result = sut.find(MatchType.ONLY_KEYWORDS_FOUND, ut('abcd'), 2);
   expect(result).toHaveLength(1);
   expect(result[0].distance).toEqual(1);
 });

--- a/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
@@ -56,6 +56,7 @@ test.each<any>([
   ['aidos', 2, res(CAND_ADIOS, kw('adios'), 'aidos', 2)], // 1 letter swapped
   ['afios', 2, res(CAND_ADIOS, kw('adios'), 'afios', 1)], // 1 wrong swapped
   ['adddios', 1, undefined], // too far
+  ['arou', 2, undefined], // has distance 2 to adeu, but only 2 letters match
   ['ey', 1, res(CAND_HOLA, kw('ey'), 'ey', 0)], // short keyword
   ['el', 1, undefined] // similar to 'ey', but short keyword must be identical
 ])(
@@ -102,16 +103,13 @@ test.each<any>([
     2,
     res(CAND_HOLA, kw('buenos dias'), 'bueno dia', 2)
   ], //missing 2 letters
-  [
-    'buenosdias',
-    1,
-    res(CAND_HOLA, kw('buenos dias'), 'buenosdias', 1)
-  ], //missing 2 letters
+  ['buenosdias', 1, res(CAND_HOLA, kw('buenos dias'), 'buenosdias', 1)], //missing 2 letters
   ['vale, addios', 2, res(CAND_ADIOS, kw('adios'), 'addios', 1)], // 1 extra letter
   ['esta bien aidos', 2, res(CAND_ADIOS, kw('adios'), 'aidos', 2)], // 1 letter swapped
   ['gracias. afios', 2, res(CAND_ADIOS, kw('adios'), 'afios', 1)], // 1 wrong swapped
   ['adddios amigos', 1, undefined], // too far
   ['ey amigos', 1, res(CAND_HOLA, kw('ey'), 'ey', 0)], // short keyword
+  ['amic arou', 2, undefined], // arou has distance 2 to adeu, but only 2 letters match
   ['el coche', 1, undefined] // similar to 'ey', but short keyword must be identical
 ])(
   'TEST: findSubstring(%s)',
@@ -204,6 +202,6 @@ test.each<any>([
   (w1: string, w2: string, expected: number) => {
     const similar = new SimilarSearch({ normalize: false });
     const distance = similar.getSimilarity(w1, w2);
-    expect(getMatchLength(w1, w2, distance)).toEqual(expected);
+    expect(getMatchLength(w1.length, w2.length, distance)).toEqual(expected);
   }
 );

--- a/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
@@ -58,7 +58,7 @@ test.each<any>([
     const sut = new SimilarWordFinder<TestCandidate>(false);
     sut.addCandidate(CAND_ADIOS);
     sut.addCandidate(CAND_HOLA);
-    const result = sut.findSimilarKeyword(ut(needle), maxDistance);
+    const result = sut.findIfOnlyWordsFromKeyword(ut(needle), maxDistance);
     expect(result[0]).toEqual(expectedResult);
   }
 );
@@ -67,15 +67,15 @@ test('TEST: findSimilarKeyword() missing space', () => {
   const sut = new SimilarWordFinder<TestCandidate>(true);
   sut.addCandidate(CAND_ADIOS);
   sut.addCandidate(CAND_HOLA);
-  const result = sut.findSimilarKeyword(ut('buenosdias'), 1);
+  const result = sut.findIfOnlyWordsFromKeyword(ut('buenosdias'), 1);
   expect(result[0].candidate).toEqual(CAND_HOLA.owner);
 });
 
 test('TEST: findSimilarKeyword() stemmed checks all words in keyword', () => {
   const sut = new SimilarWordFinder<TestCandidate>(true);
   sut.addCandidate(candidate('realiz ped'));
-  expect(sut.findSimilarKeyword(ut('realiz'), 1)).toHaveLength(0);
-  expect(sut.findSimilarKeyword(ut('realizarped'), 1)).toHaveLength(1);
+  expect(sut.findIfOnlyWordsFromKeyword(ut('realiz'), 1)).toHaveLength(0);
+  expect(sut.findIfOnlyWordsFromKeyword(ut('realizarped'), 1)).toHaveLength(1);
 });
 
 test.each<any>([
@@ -133,7 +133,7 @@ test('TEST: findSubstring gets closest match', () => {
 test('TEST: findSimilarKeyword gets closest match', () => {
   const sut = new SimilarWordFinder<TestCandidate>(true);
   sut.addCandidate(candidate('abc', 'abcdef'));
-  const result = sut.findSimilarKeyword(ut('abcd'), 2);
+  const result = sut.findIfOnlyWordsFromKeyword(ut('abcd'), 2);
   expect(result).toHaveLength(1);
   expect(result[0].distance).toEqual(1);
 });

--- a/packages/botonic-plugin-contentful/tests/search/search.integration.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/search.integration.test.ts
@@ -9,11 +9,12 @@ test('TEST search: ', async () => {
     es: new KeywordsOptions(1)
   });
   const res = await sut.searchByKeywords(
-    'esta',
-    MatchType.ONLY_KEYWORDS_FOUND,
+    'mi pedido no encuentro',
+    MatchType.ALL_WORDS_IN_KEYWORDS_MIXED_UP,
     {
       locale: 'es'
     }
   );
-  console.log(res);
+  expect(res.length).toBeGreaterThanOrEqual(1);
+  expect(res.filter(res => res.common.name == 'POST_FAQ1')).toHaveLength(1);
 });


### PR DESCRIPTION
1) Avoid matching too short keywords
darme is now matching with tara because their stems are very close (dar & tar).
We should enforce at least 3 letter match.

2) Support matching similar words for matching keywords with multiple words mixed up with other words

3) tool to evaluate how good is keyword matching