### PR TITLE
Contentful/keep stems tokens

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,18 +14,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
-      "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.0.tgz",
+      "integrity": "sha512-Bb1NjZCaiwTQC/ARL+MwDpgocdnwWDCaugvkGt6cxfBzQa8Whv1JybBoUEiBDKl8Ni3H3c7Fykwk7QChUsHRlg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.4",
-        "@babel/helpers": "^7.6.2",
-        "@babel/parser": "^7.6.4",
-        "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.3",
-        "@babel/types": "^7.6.3",
+        "@babel/generator": "^7.7.0",
+        "@babel/helpers": "^7.7.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/template": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
@@ -59,12 +59,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-      "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.0.tgz",
+      "integrity": "sha512-1wdJ6UxHyL1XoJQ119JmvuRX27LRih7iYStMPZOWAjQqeAabFg3dYXKMpgihma+to+0ADsTVVt6oRyUxWZw6Mw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.6.3",
+        "@babel/types": "^7.7.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -79,23 +79,23 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
+      "integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "^7.7.0",
+        "@babel/template": "^7.7.0",
+        "@babel/types": "^7.7.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
+      "integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.7.0"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -105,23 +105,23 @@
       "dev": true
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
+      "integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4"
+        "@babel/types": "^7.7.0"
       }
     },
     "@babel/helpers": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
-      "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
+      "integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.2",
-        "@babel/types": "^7.6.0"
+        "@babel/template": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0"
       }
     },
     "@babel/highlight": {
@@ -136,9 +136,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+      "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
       "dev": true
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -160,28 +160,28 @@
       }
     },
     "@babel/template": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
+      "integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.0"
+        "@babel/parser": "^7.7.0",
+        "@babel/types": "^7.7.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-      "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.0.tgz",
+      "integrity": "sha512-ea/3wRZc//e/uwCpuBX2itrhI0U9l7+FsrKWyKGNyvWbuMcCG7ATKY2VI4wlg2b2TA39HHwIxnvmXvtiKsyn7w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.3",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.6.3",
-        "@babel/types": "^7.6.3",
+        "@babel/generator": "^7.7.0",
+        "@babel/helper-function-name": "^7.7.0",
+        "@babel/helper-split-export-declaration": "^7.7.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/types": "^7.7.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -205,9 +205,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-      "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
+      "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -1459,9 +1459,9 @@
       }
     },
     "bser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
-      "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
@@ -1773,9 +1773,9 @@
       }
     },
     "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -3480,9 +3480,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5740,9 +5740,9 @@
       "dev": true
     },
     "jsdom": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.0.tgz",
-      "integrity": "sha512-+hRyEfjRPFwTYMmSQ3/f7U9nP8ZNZmbkmUek760ZpxnCPWJIhaaLRuUSvpJ36fZKCGENxLwxClzwpOpnXNfChQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+      "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
       "dev": true,
       "requires": {
         "abab": "^2.0.0",
@@ -5755,7 +5755,7 @@
         "domexception": "^1.0.1",
         "escodegen": "^1.11.1",
         "html-encoding-sniffer": "^1.0.2",
-        "nwsapi": "^2.1.4",
+        "nwsapi": "^2.2.0",
         "parse5": "5.1.0",
         "pn": "^1.1.0",
         "request": "^2.88.0",
@@ -6369,9 +6369,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
-      "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
     "oauth-sign": {
@@ -7033,21 +7033,21 @@
       }
     },
     "request-promise-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.15"
       }
     },
     "request-promise-native": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+      "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
       "dev": true,
       "requires": {
-        "request-promise-core": "1.1.2",
+        "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       },
@@ -7625,9 +7625,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -8309,9 +8309,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz",
+      "integrity": "sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -12,7 +12,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/botonic-plugin-contentful/src/nlp/locales.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/locales.ts
@@ -1,6 +1,12 @@
 import { stemmerFor } from './stemmer'
 
+// TODO convert to string enum?
 export type Locale = string
+export const SPANISH = 'es'
+export const CATALAN = 'ca'
+export const ENGLIGH = 'en'
+export const PORTUGUESE = 'pt'
+export const POLISH = 'pl'
 
 export function checkLocale(locale?: Locale): Locale {
   if (!locale) {

--- a/packages/botonic-plugin-contentful/src/search/search-by-keywords.ts
+++ b/packages/botonic-plugin-contentful/src/search/search-by-keywords.ts
@@ -6,6 +6,7 @@ import {
   checkLocale,
   Normalizer,
   NormalizedUtterance,
+  Word,
 } from '../nlp'
 import { SearchResult } from './search-result'
 
@@ -47,23 +48,23 @@ export class SearchByKeywords {
    * @return which contents must be displayed
    */
   public filterChitchat(
-    tokens: string[],
-    callbacks: SearchResult[]
+    words: Word[],
+    results: SearchResult[]
   ): SearchResult[] {
     const isChitChat = (cc: SearchResult) => cc.getCallbackIfChitchat()
 
-    const chitchats = callbacks.filter(isChitChat)
+    const chitchats = results.filter(isChitChat)
     if (chitchats.length == 0) {
-      return callbacks
+      return results
     }
-    if (chitchats.length < callbacks.length) {
-      const noChitchats = callbacks.filter(c => !isChitChat(c))
+    if (chitchats.length < results.length) {
+      const noChitchats = results.filter(c => !isChitChat(c))
       if (chitchats[0].match!.length - noChitchats[0].match!.length < 2) {
         return noChitchats
       }
     }
     // all are chitchats
-    const estimatedNoChitchatWords = tokens.length - chitchats.length * 2
+    const estimatedNoChitchatWords = words.length - chitchats.length * 2
     if (estimatedNoChitchatWords > 2) {
       // avoid that a sentence with chitchat and a question without recognized keywords is answered as chitchat
       return []

--- a/packages/botonic-plugin-contentful/src/search/search.ts
+++ b/packages/botonic-plugin-contentful/src/search/search.ts
@@ -24,12 +24,12 @@ export class Search {
   ): Promise<SearchResult[]> {
     const locale = checkLocale(context.locale)
     const utterance = this.normalizer.normalize(locale, inputText)
-    const contents = await this.search.searchContentsFromInput(
+    const results = await this.search.searchContentsFromInput(
       utterance,
       matchType,
       context
     )
-    return this.search.filterChitchat(utterance.stems, contents)
+    return this.search.filterChitchat(utterance.words, results)
   }
 
   async respondFoundContents(

--- a/packages/botonic-plugin-contentful/src/tools/keyword-tools.ts
+++ b/packages/botonic-plugin-contentful/src/tools/keyword-tools.ts
@@ -1,5 +1,5 @@
 import { CMS } from '../cms'
-import { Locale, Normalizer } from '../nlp'
+import { Keyword, Locale, Normalizer } from '../nlp'
 
 export class StemmedKeyword {
   constructor(readonly rawKeyword: string, readonly stemmedKeyword: string[]) {}
@@ -20,17 +20,13 @@ export class KeywordsTool {
     readonly normalizer: Normalizer
   ) {}
 
-  async dumpKeywords(): Promise<Map<string, StemmedKeyword[]>> {
-    const keywords = new Map<string, StemmedKeyword[]>()
+  async dumpKeywords(): Promise<Map<string, Keyword[]>> {
+    const keywords = new Map<string, Keyword[]>()
     const context = { locale: this.locale }
     const results = await this.cms.contentsWithKeywords(context)
     for (const res of results) {
-      const stemmed = res.common.keywords.map(
-        kw =>
-          new StemmedKeyword(
-            kw,
-            this.normalizer.normalize(context.locale, kw).stems
-          )
+      const stemmed = res.common.keywords.map(kw =>
+        Keyword.fromUtterance(kw, context.locale, this.normalizer)
       )
       keywords.set(res.common.name, stemmed)
     }

--- a/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
@@ -4,6 +4,7 @@ import {
   StemmingBlackList,
   Locale,
   NormalizedUtterance,
+  Word,
 } from '../../src/nlp'
 
 test('TEST: sut.normalize stopWord', () => {
@@ -12,19 +13,35 @@ test('TEST: sut.normalize stopWord', () => {
 })
 
 test.each<any>([
-  ['es', 'ponerse un toro', ['ponerse', 'un', 'toro'], ['pon', 'tor']],
+  [
+    'es',
+    'ponerse un toro',
+    [new Word('ponerse', 'pon'), Word.StopWord('un'), new Word('toro', 'tor')],
+  ],
 
-  ['en', "you can't", ['you', 'ca', 'not'], ['ca', 'not']],
+  [
+    'en',
+    "you can't",
+    [Word.StopWord('you'), new Word('ca', 'ca'), new Word('not', 'not')],
+  ],
 
-  ['pt', 'depois disse-me', ['depois', 'disse', 'me'], ['diss']],
+  [
+    'pt',
+    'depois disse-me',
+    [Word.StopWord('depois'), new Word('disse', 'diss'), Word.StopWord('me')],
+  ],
 
-  ['pl', 'gdziekolwiek JeŚć', ['gdziekolwiek', 'jesc'], ['je']],
+  [
+    'pl',
+    'gdziekolwiek JeŚć',
+    [Word.StopWord('gdziekolwiek'), new Word('jesc', 'je')],
+  ],
 ])(
   'TEST: stemmer removes stopwords (%s) =>%j',
-  (locale: string, raw: string, tokens: string[], stems: string[]) => {
+  (locale: string, raw: string, words: Word[]) => {
     const sut = new Normalizer()
     expect(sut.normalize(locale, raw)).toEqual(
-      new NormalizedUtterance(raw.toLowerCase(), tokens, stems, false)
+      new NormalizedUtterance(raw.toLowerCase(), words, false)
     )
   }
 )
@@ -80,7 +97,7 @@ test.each<any>([['es'], ['ca'], ['en']])(
       const normalized = sut.normalize(locale, stopWord)
       expect(normalized.hasOnlyStopWords()).toEqual(true)
       expect(replaceI18nChars(stopWord, locale)).toStartWith(
-        normalized.stems[0]
+        normalized.words[0].token
       )
       expect(sut.normalize(locale, stopWord + ' abcdex').stems).toEqual([
         'abcdex',

--- a/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
@@ -8,7 +8,7 @@ import {
   SimilarWordFinder,
   SimilarWordResult,
 } from '../../src/nlp/similar-words'
-import { NormalizedUtterance } from '../../src/nlp'
+import { NormalizedUtterance, Word } from '../../src/nlp'
 import { SimilarSearch } from 'node-nlp/lib/util'
 
 test('hack because webstorm does not recognize test.each', () => {})
@@ -26,7 +26,11 @@ function candidate(
 }
 
 function kw(kw: string, hasOnlyStopWords = false) {
-  return new Keyword(`${kw}`, kw, hasOnlyStopWords)
+  return new Keyword(
+    `${kw}`,
+    kw.split(' ').map(w => new Word(w, w)),
+    hasOnlyStopWords
+  )
 }
 
 const CAND_HOLA = candidate(['buenos dias', 'güenas', 'ey'])
@@ -47,7 +51,7 @@ function res(
 }
 
 function ut(text: string): NormalizedUtterance {
-  return new NormalizedUtterance(text, [text], text.split(' '))
+  return new NormalizedUtterance(text, text.split(' ').map(w => new Word(w, w)))
 }
 
 test.each<any>([

--- a/packages/botonic-plugin-contentful/tests/search/filter-chitchat.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/filter-chitchat.test.ts
@@ -36,7 +36,7 @@ test.each<any>([
     expect(contents).toHaveLength(numChitchats)
 
     // act
-    const filtered = keywords.filterChitchat(normalized.stems, contents)
+    const filtered = keywords.filterChitchat(normalized.words, contents)
 
     // assert
     expect(filtered).toHaveLength(1)
@@ -66,7 +66,7 @@ test('TEST treatChitChat: chitchat and other keywords detected', async () => {
   expect(parsedKeywords).toHaveLength(2)
 
   // act
-  const filtered = keywords.filterChitchat(normalized.stems, parsedKeywords)
+  const filtered = keywords.filterChitchat(normalized.words, parsedKeywords)
 
   // assert
   expect(filtered).toHaveLength(1)
@@ -99,7 +99,7 @@ test.each<any>([
     expect(contents).toHaveLength(numChitChats)
 
     // act
-    const filtered = keywords.filterChitchat(normalized.stems, contents)
+    const filtered = keywords.filterChitchat(normalized.words, contents)
 
     // assert
     expect(filtered).toEqual([])
@@ -128,7 +128,7 @@ test('TEST treatChitChat: no chitchat detected', async () => {
   expect(contents).toHaveLength(1)
 
   // act
-  const filtered = keywords.filterChitchat(normalized.stems, contents)
+  const filtered = keywords.filterChitchat(normalized.words, contents)
 
   // assert
   expect(filtered).toBe(contents)
@@ -136,22 +136,29 @@ test('TEST treatChitChat: no chitchat detected', async () => {
 
 test('TEST treatChitChat: keyword is a stopword', async () => {
   const keywords = keywordsWithMockCms(
-    [chitchatContent(['hola']), chitchatContent(['buenos dias'])],
+    [
+      chitchatContent(['hola']),
+      chitchatContent(['adios']),
+      chitchatContent(['buenos dias']),
+    ],
     CONTEXT
   )
 
-  // hola is a stopword
-  const normalized = keywords.normalizer.normalize(LOCALE, 'Hola, buenos días.')
+  // it matches hola with holi even when it's a stopword
+  const normalized = keywords.normalizer.normalize(
+    LOCALE,
+    'Holi, adios, buenos días.'
+  )
   const contents = await keywords.searchContentsFromInput(
     normalized,
     MatchType.KEYWORDS_AND_OTHERS_FOUND,
     { locale: LOCALE }
   )
-  expect(contents).toHaveLength(1)
+  expect(contents).toHaveLength(3)
 
   // act
-  const filtered = keywords.filterChitchat(normalized.stems, contents)
+  const filtered = keywords.filterChitchat(normalized.words, contents)
 
   // assert
-  expect(filtered).toEqual(contents)
+  expect(filtered).toEqual([contents[0]])
 })

--- a/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
@@ -80,7 +80,7 @@ test('TEST: searchContentsFromInput with stem blacklist', async () => {
 
   // act
   let contents = await keywords.searchContentsFromInput(
-    keywords.normalizer.normalize('es', 'querida pedida bonita'),
+    keywords.normalizer.normalize('es', 'pedí que me llamarais'),
     MatchType.KEYWORDS_AND_OTHERS_FOUND,
     ES_CONTEXT
   )

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1430,6 +1430,11 @@
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
+    "can-use-dom": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
+      "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
+    },
     "caniuse-lite": {
       "version": "1.0.30000999",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
@@ -2914,10 +2919,25 @@
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
       "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.flow": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
       "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -3681,6 +3701,11 @@
       "dev": true,
       "optional": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
@@ -3757,6 +3782,35 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
+    "simplebar": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
+      "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
+      "requires": {
+        "can-use-dom": "^0.1.0",
+        "core-js": "^3.0.1",
+        "lodash.debounce": "^4.0.8",
+        "lodash.memoize": "^4.1.2",
+        "lodash.throttle": "^4.1.1",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.6.tgz",
+          "integrity": "sha512-u4oM8SHwmDuh5mWZdDg9UwNVq5s1uqq6ZDLLIs07VY+VJU91i3h4f3K/pgFvtUQPGdeStrZ+odKyfyt4EnKHfA=="
+        }
+      }
+    },
+    "simplebar-react": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
+      "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
+      "requires": {
+        "prop-types": "^15.6.1",
+        "simplebar": "^4.2.3"
+      }
     },
     "slash": {
       "version": "2.0.0",


### PR DESCRIPTION
Refactor Keyword and NormalizedUtterance so that we keep both the token and the stem.
This allows:
* We now match similar words to words which in the stemming blacklist
* Now we can match keywords which only contain stopwords when input contains other (no stopwords) words
 