### PR TITLE
fix(contentful): TimeRange to support ending at 24h

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -12,7 +12,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -12,7 +12,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/botonic-plugin-contentful/src/time/schedule.ts
+++ b/packages/botonic-plugin-contentful/src/time/schedule.ts
@@ -107,15 +107,20 @@ class ExceptionSchedule {
 }
 
 export class TimeRange {
+  readonly from: HourAndMinute
+  readonly to: HourAndMinute
   /**
    * @param from inclusive
-   * @param to exclusive
+   * @param to exclusive if 00:00, it will be interpreted as 24:00
    */
-  constructor(readonly from: HourAndMinute, readonly to: HourAndMinute) {
-    if (from.compare(to) >= 0) {
+  constructor(from: HourAndMinute, to: HourAndMinute) {
+    this.from = from
+    this.to = to.isMidnight() ? new HourAndMinute(to.zone, 24, 0) : to
+    if (this.from.compare(this.to) >= 0) {
       throw new Error(`${from.toString()} should be before ${to.toString()}`)
     }
   }
+
   contains(date: Date): boolean {
     if (this.from.compareToDate(date) > 0) {
       return false
@@ -137,6 +142,10 @@ export class HourAndMinute {
     const dateUtc = date.getUTCHours() * 60 + date.getUTCMinutes()
 
     return HourAndMinute.compareNumber(hourAndMinuteUtc, dateUtc)
+  }
+
+  isMidnight(): boolean {
+    return this.hour === 0 && this.minute === 0
   }
 
   private static compareNumber(first: number, second: number): number {

--- a/packages/botonic-plugin-contentful/src/time/schedule.ts
+++ b/packages/botonic-plugin-contentful/src/time/schedule.ts
@@ -138,7 +138,10 @@ export class HourAndMinute {
 
   compareToDate(date: Date): number {
     const hourAndMinuteOffset = this.zone.utcOffset(date.getTime())
-    const hourAndMinuteUtc = this.toMinutes() + hourAndMinuteOffset
+    let hourAndMinuteUtc = this.toMinutes() + hourAndMinuteOffset
+    if (hourAndMinuteUtc <= 0) {
+      hourAndMinuteUtc += 24 * 60
+    }
     const dateUtc = date.getUTCHours() * 60 + date.getUTCMinutes()
 
     return HourAndMinute.compareNumber(hourAndMinuteUtc, dateUtc)

--- a/packages/botonic-plugin-contentful/tests/time/schedule.test.ts
+++ b/packages/botonic-plugin-contentful/tests/time/schedule.test.ts
@@ -132,6 +132,58 @@ test('TEST: addException', () => {
   expect(sut.contains(date12h)).toBeTruthy()
 })
 
+test('TEST: addException start day', () => {
+  const sut = new Schedule('Europe/Madrid')
+  sut.addDaySchedule(
+    WeekDay.FRIDAY,
+    new DaySchedule([
+      new TimeRange(sut.createHourAndMinute(10), sut.createHourAndMinute(12)),
+    ])
+  )
+
+  sut.addException(
+    new Date(2019, MARCH, 29),
+    new DaySchedule([
+      new TimeRange(sut.createHourAndMinute(0), sut.createHourAndMinute(1)),
+      new TimeRange(sut.createHourAndMinute(11), sut.createHourAndMinute(13)),
+    ])
+  )
+  expect(sut.contains(new Date(2019, MARCH, 28, 23, 59))).toBeFalsy()
+  expect(sut.contains(new Date(2019, MARCH, 29, 0, 0))).toBeTruthy()
+  expect(sut.contains(new Date(2019, MARCH, 29, 0, 15))).toBeTruthy()
+  expect(sut.contains(new Date(2019, MARCH, 29, 1, 0))).toBeFalsy()
+  expect(sut.contains(new Date(2019, MARCH, 29, 1, 1))).toBeFalsy()
+  expect(sut.contains(new Date(2019, MARCH, 29, 23, 59))).toBeFalsy()
+  expect(sut.contains(new Date(2019, MARCH, 30, 0, 0))).toBeFalsy()
+})
+
+test('TEST: addException end day', () => {
+  const sut = new Schedule('Europe/Madrid')
+  sut.addDaySchedule(
+    WeekDay.FRIDAY,
+    new DaySchedule([
+      new TimeRange(sut.createHourAndMinute(10), sut.createHourAndMinute(12)),
+    ])
+  )
+
+  sut.addException(
+    new Date(2019, MARCH, 29),
+    new DaySchedule([
+      new TimeRange(
+        sut.createHourAndMinute(23),
+        sut.createHourAndMinute(23, 30)
+      ),
+    ])
+  )
+  expect(sut.contains(new Date(2019, MARCH, 28, 23, 15))).toBeFalsy()
+  expect(sut.contains(new Date(2019, MARCH, 29, 22, 59))).toBeFalsy()
+  expect(sut.contains(new Date(2019, MARCH, 29, 23, 0))).toBeTruthy()
+  expect(sut.contains(new Date(2019, MARCH, 29, 23, 29))).toBeTruthy()
+  expect(sut.contains(new Date(2019, MARCH, 29, 23, 30))).toBeFalsy()
+  expect(sut.contains(new Date(2019, MARCH, 30, 0, 0))).toBeFalsy()
+  expect(sut.contains(new Date(2019, MARCH, 30, 23, 15))).toBeFalsy()
+})
+
 test('TEST: time.toString ', () => {
   // tz does not affect toString
   const zone = momentTz.tz.zone('Europe/London')

--- a/packages/botonic-plugin-contentful/tests/time/schedule.test.ts
+++ b/packages/botonic-plugin-contentful/tests/time/schedule.test.ts
@@ -10,6 +10,7 @@ import momentTz from 'moment-timezone'
 
 const MARCH = 2
 const APRIL = 3
+const NOVEMBER = 10
 
 test('TEST ScheduleAlwaysOn', () => {
   const sut = new ScheduleAlwaysOn()
@@ -91,6 +92,20 @@ test('TEST: timeInThisTimezone ', () => {
 
   const date = new Date(2019, 5, 29, 0, 51)
   expect(sut.timeInThisTimezone('es', date)).toEqual('23:51:00')
+})
+
+test('TEST: ends at midnight', () => {
+  const sut = new Schedule('Europe/Madrid')
+  sut.addDaySchedule(
+    WeekDay.WEDNESDAY,
+    new DaySchedule([
+      new TimeRange(sut.createHourAndMinute(10), sut.createHourAndMinute(0)),
+    ])
+  )
+  const date9h = new Date(2019, NOVEMBER, 27, 9)
+  expect(sut.contains(date9h)).toBeFalsy()
+  const date23h = new Date(2019, NOVEMBER, 27, 23, 59)
+  expect(sut.contains(date23h)).toBeTruthy()
 })
 
 test('TEST: addException', () => {


### PR DESCRIPTION
Contentful TimeRange model did not allow entering 24:00 and our code did not accept 00:00 as the end of a range.
So we modified the code so that when the end of a range is 0, it's transformed into 24:00

Also there was a bug where timeranges just after midnight could not be correctly compared