### PR TITLE
Release/0.10.1

### DIFF
--- a/packages/botonic-cli/package-lock.json
+++ b/packages/botonic-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "bin": {
     "botonic": "./bin/run"
   },

--- a/packages/botonic-cli/src/botonicAPIService.ts
+++ b/packages/botonic-cli/src/botonicAPIService.ts
@@ -60,7 +60,7 @@ export class BotonicAPIService {
         this.headers = {
           Authorization: `Bearer ${this.oauth.access_token}`,
           'content-type': 'application/json',
-          'x-segment-anonymous-id': this.analytics.anonymous_id
+          'x-segment-anonymous-id': this.analytics.anonymous_id,
         }
     }
   }
@@ -95,7 +95,7 @@ export class BotonicAPIService {
       JSON.stringify({
         oauth: this.oauth,
         me: this.me,
-        analytics: this.analytics
+        analytics: this.analytics,
       })
     )
   }
@@ -118,9 +118,9 @@ export class BotonicAPIService {
           '*.scss',
           'webpack.config.js',
           '.babelrc',
-          'tsconfig.json'
-        ]
-      }
+          'tsconfig.json',
+        ],
+      },
     }
     let hash = await hashElement('.', options)
     return hash.hash
@@ -129,7 +129,7 @@ export class BotonicAPIService {
   async build(npmCommand: string = 'build') {
     let spinner = new ora({
       text: 'Building...',
-      spinner: 'bouncingBar'
+      spinner: 'bouncingBar',
     }).start()
     try {
       var build_out = await exec(`npm run ${npmCommand}`)
@@ -174,7 +174,7 @@ export class BotonicAPIService {
         url: this.baseApiUrl + path,
         headers: headers || this.headers,
         data: body,
-        params: params
+        params: params,
       })
     } catch (e) {
       if (e.response.status == 401) {
@@ -191,7 +191,7 @@ export class BotonicAPIService {
       url: this.baseApiUrl + path,
       headers: headers || this.headers,
       data: body,
-      params: params
+      params: params,
     })
   }
 
@@ -204,15 +204,15 @@ export class BotonicAPIService {
         grant_type: 'refresh_token',
         refresh_token: this.oauth.refresh_token,
         client_id: this.cliendId,
-        client_secret: this.clientSecret
-      }
+        client_secret: this.clientSecret,
+      },
     })
     if (!resp) return
     this.oauth = resp.data
     this.headers = {
       Authorization: `Bearer ${this.oauth.access_token}`,
       'content-type': 'application/json',
-      'x-segment-anonymous-id': this.analytics.anonymous_id
+      'x-segment-anonymous-id': this.analytics.anonymous_id,
     }
     await this.saveGlobalCredentials()
     return resp
@@ -227,14 +227,14 @@ export class BotonicAPIService {
         password: password,
         client_id: this.cliendId,
         client_secret: this.clientSecret,
-        grant_type: 'password'
-      }
+        grant_type: 'password',
+      },
     })
     this.oauth = resp.data
     this.headers = {
       Authorization: `Bearer ${this.oauth.access_token}`,
       'content-type': 'application/json',
-      'x-segment-anonymous-id': this.analytics.anonymous_id
+      'x-segment-anonymous-id': this.analytics.anonymous_id,
     }
     resp = await this.api('users/me')
     if (resp) this.me = resp.data
@@ -268,7 +268,7 @@ export class BotonicAPIService {
 
   async getBots() {
     return this.api('bots/bots_paginator/', null, 'get', null, {
-      organization_id: this.me.organization_id
+      organization_id: this.me.organization_id,
     })
   }
 
@@ -287,7 +287,7 @@ export class BotonicAPIService {
 
   async getProviders() {
     return this.api('provider_accounts/', null, 'get', null, {
-      bot_id: this.bot.id
+      bot_id: this.bot.id,
     })
   }
 

--- a/packages/botonic-cli/templates/blank/package.json
+++ b/packages/botonic-cli/templates/blank/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@botonic/react": "0.10.0"
+    "@botonic/react": "~0.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/packages/botonic-cli/templates/blank/src/index.js
+++ b/packages/botonic-cli/templates/blank/src/index.js
@@ -3,3 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
+export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }

--- a/packages/botonic-cli/templates/childs/package.json
+++ b/packages/botonic-cli/templates/childs/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@botonic/react": "0.10.0"
+    "@botonic/react": "~0.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/packages/botonic-cli/templates/childs/src/index.js
+++ b/packages/botonic-cli/templates/childs/src/index.js
@@ -3,3 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
+export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }

--- a/packages/botonic-cli/templates/custom-webchat/package.json
+++ b/packages/botonic-cli/templates/custom-webchat/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@botonic/react": "0.10.0",
+    "@botonic/react": "~0.10.1",
     "react-calendar": "2.19.2"
   },
   "devDependencies": {

--- a/packages/botonic-cli/templates/custom-webchat/src/index.js
+++ b/packages/botonic-cli/templates/custom-webchat/src/index.js
@@ -3,4 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
-export const config = { defaultDelay: 1, defaultTyping: 1 }
+export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }

--- a/packages/botonic-cli/templates/dynamic-carousel/package.json
+++ b/packages/botonic-cli/templates/dynamic-carousel/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@botonic/react": "0.10.0",
+    "@botonic/react": "~0.10.1",
     "isomorphic-fetch": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/botonic-cli/templates/dynamic-carousel/src/index.js
+++ b/packages/botonic-cli/templates/dynamic-carousel/src/index.js
@@ -3,3 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
+export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }

--- a/packages/botonic-cli/templates/handoff/package.json
+++ b/packages/botonic-cli/templates/handoff/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@botonic/react": "0.10.0"
+    "@botonic/react": "~0.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/packages/botonic-cli/templates/handoff/src/index.js
+++ b/packages/botonic-cli/templates/handoff/src/index.js
@@ -3,3 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
+export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }

--- a/packages/botonic-cli/templates/intent/package.json
+++ b/packages/botonic-cli/templates/intent/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@botonic/plugin-dialogflow": "^0.9.0-beta.1",
     "@babel/runtime": "^7.6.2",
-    "@botonic/react": "0.10.0"
+    "@botonic/react": "~0.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/packages/botonic-cli/templates/intent/src/index.js
+++ b/packages/botonic-cli/templates/intent/src/index.js
@@ -3,3 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
+export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }

--- a/packages/botonic-cli/templates/nlu/package.json
+++ b/packages/botonic-cli/templates/nlu/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@botonic/plugin-nlu": "alpha",
+    "@botonic/plugin-nlu": "^0.10.1",
     "@botonic/react": "~0.10.1"
   },
   "devDependencies": {

--- a/packages/botonic-cli/templates/nlu/package.json
+++ b/packages/botonic-cli/templates/nlu/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@botonic/plugin-nlu": "alpha",
-    "@botonic/react": "^0.10.0"
+    "@botonic/react": "~0.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/packages/botonic-cli/templates/nlu/src/index.js
+++ b/packages/botonic-cli/templates/nlu/src/index.js
@@ -3,3 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
+export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }

--- a/packages/botonic-cli/templates/tutorial/package.json
+++ b/packages/botonic-cli/templates/tutorial/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@botonic/react": "0.10.0"
+    "@botonic/react": "~0.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/packages/botonic-cli/templates/tutorial/src/index.js
+++ b/packages/botonic-cli/templates/tutorial/src/index.js
@@ -3,3 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
+export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }

--- a/packages/botonic-core/package-lock.json
+++ b/packages/botonic-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-core/src/router.js
+++ b/packages/botonic-core/src/router.js
@@ -8,7 +8,7 @@ export class Router {
 
   processInput(input, session = {}, lastRoutePath = null) {
     let routeParams = {}
-    this.getOnFinishParams(input)
+    let pathParams = this.getOnFinishParams(input)
     let brokenFlow = false
     let lastRoute = this.getRouteByPath(lastRoutePath, this.routes)
     if (lastRoute && lastRoute.childRoutes)
@@ -23,10 +23,10 @@ export class Router {
       routeParams = this.getRoute(input, this.routes, session)
     }
     try {
-      if (input.path.length > 1) {
+      if (pathParams) {
         let searchParams = ''
-        if (isBrowser()) searchParams = new URLSearchParams(input.path[1])
-        if (isNode()) searchParams = new url.URLSearchParams(input.path[1])
+        if (isBrowser()) searchParams = new URLSearchParams(pathParams)
+        if (isNode()) searchParams = new url.URLSearchParams(pathParams)
         for (let [key, value] of searchParams) {
           routeParams.params
             ? (routeParams.params[key] = value)
@@ -120,12 +120,17 @@ export class Router {
 
   getOnFinishParams(input) {
     try {
-      const path_params = input.payload.split('__PATH_PAYLOAD__')[1].split('?')
-      if (path_params.length > 0) {
-        input.path = path_params[0]
+      const pathParams = input.payload.split('__PATH_PAYLOAD__')[1].split('?')
+      if (pathParams.length > 0) {
+        input.path = pathParams[0]
         delete input.payload
       }
-    } catch (e) {}
+      if (pathParams.length > 1) {
+        return pathParams[1]
+      }
+    } catch (e) {
+      return undefined
+    }
   }
 
   getRoute(input, routes, session) {

--- a/packages/botonic-nlu/package-lock.json
+++ b/packages/botonic-nlu/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/nlu",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2807,25 +2807,25 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.2.11.tgz",
-      "integrity": "sha512-q1SIEMiR+Vqq8Fnmt/YGBC5tNq97LXDvUEl8SwWedhLtK1GJCpLMJXQA54JrkFXGLv5hK4dEb+1dx28TJUET2g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.5.1.tgz",
+      "integrity": "sha512-WiE+JQ3ibr5LibGiBz6HWUqLJW8HiX6ywUSCA7ehZ67vFsw4mPuVjv0WEEUfD/l47PkXYVAmWd+RYOJiuZC7Eg==",
       "requires": {
-        "@tensorflow/tfjs-converter": "1.2.11",
-        "@tensorflow/tfjs-core": "1.2.11",
-        "@tensorflow/tfjs-data": "1.2.11",
-        "@tensorflow/tfjs-layers": "1.2.11"
+        "@tensorflow/tfjs-converter": "1.5.1",
+        "@tensorflow/tfjs-core": "1.5.1",
+        "@tensorflow/tfjs-data": "1.5.1",
+        "@tensorflow/tfjs-layers": "1.5.1"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.2.11.tgz",
-      "integrity": "sha512-3Qg3k6x9ZbAFSCJTSC2anaM40Fs04+PGFw/uRvupWHmns6D5ni9RzTH2thef9hzBT2V/UHnlnHs7RYJqQNTThA=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.1.tgz",
+      "integrity": "sha512-M9tl2/ep8ntcZpmncHwKuvThsS7TaUWqJ9vJSgJmkazwTfAvlAJmZ8/p1miJ+m5sH1EJO4oTjiEmch6g8IA5IQ=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.2.11.tgz",
-      "integrity": "sha512-guqqD5bb5BTaTvUVWhG1xCXB0NuA5rv0indSEEOpMfqqBvtSwKp02heDGDcPOSUnmdB8V/HJbcyX2wRBXztQpA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.5.1.tgz",
+      "integrity": "sha512-N4fsi8mLsRwRs8UJN2cARB1rYFxyVXkLyZ4wOusiR976BwwZbCwQrTTSIPzPqYT3rwiexEUzm7sM6ZaDl5dpXA==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
@@ -2836,28 +2836,29 @@
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.2.11.tgz",
-      "integrity": "sha512-xrRekVbwWgW1Cyaqh+1x0Tq3CQkePm/G94eGLcH6IbcoBp0syKKUCD0vHkaGn7GkUGFJkej5yHXsh0ujrbxd+A==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.5.1.tgz",
+      "integrity": "sha512-eu4X0tHS1Tng+cvMO9gkMhUWX/UZQ//VpiaZfQJfa3zvUgxw6s1MHJFb0JC1T1FOnEgDVriZ8G758ysJZOybog==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.1.2"
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.2.11.tgz",
-      "integrity": "sha512-Ye/b0pwB9KVW5IbRP9UNSXPUvizP8VdaKVFzT2C6JJpUE97LznItbYDJjO60ND/Cl0uj7ttvxPwlYb7HYo+e6g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.5.1.tgz",
+      "integrity": "sha512-DyuhifqflK+bdpBRLAj3RuWm1eTVe8yNX2+WH+W+wmhpjGg7Yagnar6/66JdS2h3WUFoiplCpZRAVMVw631E5g=="
     },
     "@tensorflow/tfjs-node": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-1.2.11.tgz",
-      "integrity": "sha512-aqwYP1XK3dGOkcozh3sg9uusw6cHBlEKFJjejOBDPk68tr3Jtij0XcXN0F/9NRU9Qg7hxZPJj4OIrUdC8CBn5Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-1.5.1.tgz",
+      "integrity": "sha512-gtIVn5zTLSgHlJUThN3knzKjycXOezmgL0W5MtxunJPznGmUZQive9efuCsgKcs5YKizTG+KprTILTSbi/2Owg==",
       "requires": {
-        "@tensorflow/tfjs": "1.2.11",
+        "@tensorflow/tfjs": "1.5.1",
         "adm-zip": "^0.4.11",
+        "google-protobuf": "^3.9.2",
         "https-proxy-agent": "^2.2.1",
-        "node-pre-gyp": "0.13.0",
+        "node-pre-gyp": "0.14.0",
         "progress": "^2.0.0",
         "rimraf": "^2.6.2",
         "tar": "^4.4.6"
@@ -2945,14 +2946,14 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
     },
     "@types/node-fetch": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.2.tgz",
-      "integrity": "sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
+      "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -5041,6 +5042,11 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "google-protobuf": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.11.2.tgz",
+      "integrity": "sha512-T4fin7lcYLUPj2ChUZ4DvfuuHtg3xi1621qeRZt2J7SvOQusOzq+sDT4vbotWTCjUXJoR36CA016LlhtPy80uQ=="
+    },
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
@@ -6522,9 +6528,9 @@
       }
     },
     "node-pre-gyp": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
-      "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+      "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
       "requires": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -6535,7 +6541,7 @@
         "rc": "^1.2.7",
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
-        "tar": "^4"
+        "tar": "^4.4.2"
       }
     },
     "node-releases": {

--- a/packages/botonic-nlu/package.json
+++ b/packages/botonic-nlu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/nlu",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "main": "lib/index",
   "scripts": {
     "build": "rm -rf lib && babel src -d lib",
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@tensorflow/tfjs": "^1.2.11",
-    "@tensorflow/tfjs-node": "^1.2.11",
+    "@tensorflow/tfjs": "^1.5.1",
+    "@tensorflow/tfjs-node": "^1.5.1",
     "axios": "^0.19.0",
     "colors": "^1.3.3",
     "compromise": "^11.13.2",

--- a/packages/botonic-plugin-nlu/package-lock.json
+++ b/packages/botonic-plugin-nlu/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-nlu",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2803,25 +2803,25 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.3.2.tgz",
-      "integrity": "sha512-2QrKHtM6DraAgWL9DJwluz+/CJ5EbPN9tdNAFGq83fSUm3cNEK37UPsWdQ1QXXBqMczg1uyLEmPgFq6Lsy2/Vg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.5.1.tgz",
+      "integrity": "sha512-WiE+JQ3ibr5LibGiBz6HWUqLJW8HiX6ywUSCA7ehZ67vFsw4mPuVjv0WEEUfD/l47PkXYVAmWd+RYOJiuZC7Eg==",
       "requires": {
-        "@tensorflow/tfjs-converter": "1.3.2",
-        "@tensorflow/tfjs-core": "1.3.2",
-        "@tensorflow/tfjs-data": "1.3.2",
-        "@tensorflow/tfjs-layers": "1.3.2"
+        "@tensorflow/tfjs-converter": "1.5.1",
+        "@tensorflow/tfjs-core": "1.5.1",
+        "@tensorflow/tfjs-data": "1.5.1",
+        "@tensorflow/tfjs-layers": "1.5.1"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.3.2.tgz",
-      "integrity": "sha512-HTGT5sinSzayH/RXwoeebtc5pwTU9E3JzlcLfBa0HZVkkeKadhtzqh3QH+BFuuNsvX691AiIHv4P7SylUu1XQg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.1.tgz",
+      "integrity": "sha512-M9tl2/ep8ntcZpmncHwKuvThsS7TaUWqJ9vJSgJmkazwTfAvlAJmZ8/p1miJ+m5sH1EJO4oTjiEmch6g8IA5IQ=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.3.2.tgz",
-      "integrity": "sha512-42WlbkbD10F11qN7k+GMjdPB62DGGnz7czkvk+lT501qWUrQI8swTjZfgMijcTWyQSeJuLa97EOL9n/Gn3Yfpw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.5.1.tgz",
+      "integrity": "sha512-N4fsi8mLsRwRs8UJN2cARB1rYFxyVXkLyZ4wOusiR976BwwZbCwQrTTSIPzPqYT3rwiexEUzm7sM6ZaDl5dpXA==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
@@ -2839,9 +2839,9 @@
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.3.2.tgz",
-      "integrity": "sha512-1Ed6rb1OAcQc70jQqAN6UYch56p7FHafQ4cDzEDoS1tgfn0Of6Gb3KETa0RJMIpWvlrr/Oa5qwqDk8Tlusn7+Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.5.1.tgz",
+      "integrity": "sha512-eu4X0tHS1Tng+cvMO9gkMhUWX/UZQ//VpiaZfQJfa3zvUgxw6s1MHJFb0JC1T1FOnEgDVriZ8G758ysJZOybog==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.1.2"
@@ -2855,9 +2855,9 @@
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.3.2.tgz",
-      "integrity": "sha512-Y+zsoXlXWYopv+u3woMgE18TsEtzcRUVdgMQxuQm1FGRFAltyKxHzVO44b/nVdC59kRHIv0wrLU4G2hSQlprqA=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.5.1.tgz",
+      "integrity": "sha512-DyuhifqflK+bdpBRLAj3RuWm1eTVe8yNX2+WH+W+wmhpjGg7Yagnar6/66JdS2h3WUFoiplCpZRAVMVw631E5g=="
     },
     "@tensorflow/tfjs-node": {
       "version": "1.3.2",
@@ -2872,17 +2872,67 @@
         "progress": "^2.0.0",
         "rimraf": "^2.6.2",
         "tar": "^4.4.6"
+      },
+      "dependencies": {
+        "@tensorflow/tfjs": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.3.2.tgz",
+          "integrity": "sha512-2QrKHtM6DraAgWL9DJwluz+/CJ5EbPN9tdNAFGq83fSUm3cNEK37UPsWdQ1QXXBqMczg1uyLEmPgFq6Lsy2/Vg==",
+          "requires": {
+            "@tensorflow/tfjs-converter": "1.3.2",
+            "@tensorflow/tfjs-core": "1.3.2",
+            "@tensorflow/tfjs-data": "1.3.2",
+            "@tensorflow/tfjs-layers": "1.3.2"
+          }
+        },
+        "@tensorflow/tfjs-converter": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.3.2.tgz",
+          "integrity": "sha512-HTGT5sinSzayH/RXwoeebtc5pwTU9E3JzlcLfBa0HZVkkeKadhtzqh3QH+BFuuNsvX691AiIHv4P7SylUu1XQg=="
+        },
+        "@tensorflow/tfjs-core": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.3.2.tgz",
+          "integrity": "sha512-42WlbkbD10F11qN7k+GMjdPB62DGGnz7czkvk+lT501qWUrQI8swTjZfgMijcTWyQSeJuLa97EOL9n/Gn3Yfpw==",
+          "requires": {
+            "@types/offscreencanvas": "~2019.3.0",
+            "@types/seedrandom": "2.4.27",
+            "@types/webgl-ext": "0.0.30",
+            "@types/webgl2": "0.0.4",
+            "node-fetch": "~2.1.2",
+            "seedrandom": "2.4.3"
+          }
+        },
+        "@tensorflow/tfjs-data": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.3.2.tgz",
+          "integrity": "sha512-1Ed6rb1OAcQc70jQqAN6UYch56p7FHafQ4cDzEDoS1tgfn0Of6Gb3KETa0RJMIpWvlrr/Oa5qwqDk8Tlusn7+Q==",
+          "requires": {
+            "@types/node-fetch": "^2.1.2",
+            "node-fetch": "~2.1.2"
+          }
+        },
+        "@tensorflow/tfjs-layers": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.3.2.tgz",
+          "integrity": "sha512-Y+zsoXlXWYopv+u3woMgE18TsEtzcRUVdgMQxuQm1FGRFAltyKxHzVO44b/nVdC59kRHIv0wrLU4G2hSQlprqA=="
+        },
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        }
       }
     },
     "@types/node": {
-      "version": "12.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.8.tgz",
-      "integrity": "sha512-XLla8N+iyfjvsa0KKV+BP/iGSoTmwxsu5Ci5sM33z9TjohF72DEz95iNvD6pPmemvbQgxAv/909G73gUn8QR7w=="
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
     },
     "@types/node-fetch": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.3.tgz",
-      "integrity": "sha512-X3TNlzZ7SuSwZsMkb5fV7GrPbVKvHc2iwHmslb8bIxRKWg2iqkfm3F/Wd79RhDpOXR7wCtKAwc5Y2JE6n/ibyw==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
+      "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
       "requires": {
         "@types/node": "*"
       }

--- a/packages/botonic-plugin-nlu/package.json
+++ b/packages/botonic-plugin-nlu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-nlu",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "main": "src/index.js",
   "scripts": {
     "build": "rm -rf dist && babel src -d dist",
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@botonic/nlu": "0.9.0",
-    "@tensorflow/tfjs": "^1.2.11",
+    "@botonic/nlu": "^0.10.1",
+    "@tensorflow/tfjs": "^1.5.1",
     "axios": "latest",
     "node-fetch": "^2.6.0"
   },

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-react/src/msg-to-botonic.jsx
+++ b/packages/botonic-react/src/msg-to-botonic.jsx
@@ -42,7 +42,7 @@ export function msgToBotonic(msg, customMessageTypes) {
           {buttons_parse(msg.buttons)}
         </Text>
       )
-    return <Text {...msg}>{msg.data.text || msg.data}</Text>
+    return <Text {...msg}>{txt}</Text>
   } else if (msg.type === 'carousel') {
     let elements = msg.elements || msg.data.elements
     return <Carousel {...msg}>{elements_parse(elements)}</Carousel>

--- a/packages/botonic-react/tests/msgToBotonic.test.jsx
+++ b/packages/botonic-react/tests/msgToBotonic.test.jsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { msgsToBotonic } from '../src/msg-to-botonic'
 import { Text } from '../src/components/text'
 import { Reply } from '../src/components/reply'
+import { Button } from '../src/components/button'
 
-describe('msgsToBotonic', () => {
-  test('', () => {
+describe('msgsToBotonic text', () => {
+
+  test('with replies', () => {
     const msg = {
       type: 'text',
       data: {
@@ -25,7 +27,53 @@ describe('msgsToBotonic', () => {
             button text
           </Reply>,
         ]}
-      </Text>
+      </Text>,
     )
+  })
+
+  test('with buttons', () => {
+    const msg = {
+      type: 'text',
+      data: {
+        text: 'The verbose text',
+      },
+      buttons: [
+        {
+          payload: 'payload1',
+          title: 'button text',
+        },
+      ],
+    }
+    expect(msgsToBotonic(msg)).toEqual(
+      <Text {...msg}>
+        The verbose text
+        {[
+          <Button key='0' payload='payload1'>
+            button text
+          </Button>,
+        ]}
+      </Text>,
+    )
+  })
+
+  test('without replies nor buttons', () => {
+    // normal text
+    let msg = { type: 'text', data: { text: 'texto' } }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>texto</Text>)
+
+    // no text
+    msg = { type: 'text', data: { text: '' }, replies: [] }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>{''}</Text>)// empty replies field
+
+    msg = { type: 'text', data: { text: 'texto' }, replies: [] }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>texto</Text>)
+  })
+
+  test('no text', () => {
+    let msg = { type: 'text', data: { text: '' } }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>{''}</Text>)
+
+    msg = { type: 'text', data: 'no text field', replies: [] }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>no text field</Text>)
   })
 })


### PR DESCRIPTION
- Bump all versions for @botonic/core, @botonic/react and @botonic/cli from `0.10.0` to `0.10.1`.
- Bump all templates @botonic/react deps from `0.10.0` to `~0.10.1` in order to update always to latest patch version automatically.
- Add `config` with defaultTyping and defaultDelay by default for every template.

**Fixes**
- Allow calling dynamic routes (routes as a function) in nested routes
- Fix issue https://github.com/hubtype/botonic/issues/409

**Feats**
- Getting configuration for bots plugins
