### PR TITLE
fix(react): msgsToBotonic bug for empty text

### DIFF
--- a/packages/botonic-react/src/msg-to-botonic.jsx
+++ b/packages/botonic-react/src/msg-to-botonic.jsx
@@ -42,7 +42,7 @@ export function msgToBotonic(msg, customMessageTypes) {
           {buttons_parse(msg.buttons)}
         </Text>
       )
-    return <Text {...msg}>{msg.data.text || msg.data}</Text>
+    return <Text {...msg}>{txt}</Text>
   } else if (msg.type === 'carousel') {
     let elements = msg.elements || msg.data.elements
     return <Carousel {...msg}>{elements_parse(elements)}</Carousel>

--- a/packages/botonic-react/tests/msgToBotonic.test.jsx
+++ b/packages/botonic-react/tests/msgToBotonic.test.jsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { msgsToBotonic } from '../src/msg-to-botonic'
 import { Text } from '../src/components/text'
 import { Reply } from '../src/components/reply'
+import { Button } from '../src/components/button'
 
-describe('msgsToBotonic', () => {
-  test('', () => {
+describe('msgsToBotonic text', () => {
+
+  test('with replies', () => {
     const msg = {
       type: 'text',
       data: {
@@ -25,7 +27,53 @@ describe('msgsToBotonic', () => {
             button text
           </Reply>,
         ]}
-      </Text>
+      </Text>,
     )
+  })
+
+  test('with buttons', () => {
+    const msg = {
+      type: 'text',
+      data: {
+        text: 'The verbose text',
+      },
+      buttons: [
+        {
+          payload: 'payload1',
+          title: 'button text',
+        },
+      ],
+    }
+    expect(msgsToBotonic(msg)).toEqual(
+      <Text {...msg}>
+        The verbose text
+        {[
+          <Button key='0' payload='payload1'>
+            button text
+          </Button>,
+        ]}
+      </Text>,
+    )
+  })
+
+  test('without replies nor buttons', () => {
+    // normal text
+    let msg = { type: 'text', data: { text: 'texto' } }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>texto</Text>)
+
+    // no text
+    msg = { type: 'text', data: { text: '' }, replies: [] }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>{''}</Text>)// empty replies field
+
+    msg = { type: 'text', data: { text: 'texto' }, replies: [] }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>texto</Text>)
+  })
+
+  test('no text', () => {
+    let msg = { type: 'text', data: { text: '' } }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>{''}</Text>)
+
+    msg = { type: 'text', data: 'no text field', replies: [] }
+    expect(msgsToBotonic(msg)).toEqual(<Text {...msg}>no text field</Text>)
   })
 })


### PR DESCRIPTION
When a Text had empty text and no buttons nor replies,
it generated a bad React object, which caused runtime error:
"Objects are not valid as a React child"
![image](https://user-images.githubusercontent.com/1954955/72262805-e60d4b00-3617-11ea-9d19-a6a89d0458bd.png)
