### PR TITLE
Feat/animations flag and send button

### DIFF
--- a/packages/botonic-react/src/assets/send-button.svg
+++ b/packages/botonic-react/src/assets/send-button.svg
@@ -1,0 +1,1 @@
+<svg fill="#adadad" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"></path><path d="M0 0h24v24H0z" fill="none"></path></svg>

--- a/packages/botonic-react/src/components/attachment.jsx
+++ b/packages/botonic-react/src/components/attachment.jsx
@@ -10,7 +10,10 @@ export const Attachment = ({ onChange, accept }) => (
     }}
   >
     <label htmlFor='attachment'>
-      <img src={staticAsset(AttachmentIcon)} style={{ cursor: 'pointer' }} />
+      <img
+        src={staticAsset(AttachmentIcon)}
+        style={{ cursor: 'pointer', marginTop: 4 }}
+      />
     </label>
     <input
       type='file'

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react'
 import uuid from 'uuid/v4'
 import { isBrowser, isNode } from '@botonic/core'
-import { staticAsset, getProperty } from '../utils'
+import { staticAsset, ConditionalWrapper } from '../utils'
 import { WebchatContext, RequestContext } from '../contexts'
 import { Button } from './button'
 import { Reply } from './reply'
@@ -32,6 +32,8 @@ export const Message = props => {
   const [state, setState] = useState({
     id: props.id || uuid(),
   })
+
+  const animationsEnabled = getThemeProperty('animations.enable', true)
 
   const replies = React.Children.toArray(children).filter(e => e.type === Reply)
   const buttons = React.Children.toArray(children).filter(
@@ -122,7 +124,10 @@ export const Message = props => {
     if (botMsgImg !== undefined) BotMessageImage = botMsgImg
 
     return (
-      <Fade>
+      <ConditionalWrapper
+        condition={animationsEnabled}
+        wrapper={children => <Fade>{children}</Fade>}
+      >
         <div
           style={{
             display: 'flex',
@@ -205,7 +210,7 @@ export const Message = props => {
             )}
           </div>
         </div>
-      </Fade>
+      </ConditionalWrapper>
     )
   }
 

--- a/packages/botonic-react/src/components/send-button.jsx
+++ b/packages/botonic-react/src/components/send-button.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import SendButtonIcon from '../assets/send-button.svg'
 import { staticAsset } from '../utils'
-export const SendButton = ({ onClick }) => (
+export const SendButton = () => (
   <div
     style={{
       display: 'flex',
@@ -9,10 +9,6 @@ export const SendButton = ({ onClick }) => (
       paddingRight: 15,
     }}
   >
-    <img
-      src={staticAsset(SendButtonIcon)}
-      style={{ cursor: 'pointer' }}
-      onClick={onClick}
-    />
+    <img src={staticAsset(SendButtonIcon)} style={{ cursor: 'pointer' }} />
   </div>
 )

--- a/packages/botonic-react/src/components/send-button.jsx
+++ b/packages/botonic-react/src/components/send-button.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import SendButtonIcon from '../assets/send-button.svg'
+import { staticAsset } from '../utils'
+export const SendButton = ({ onClick }) => (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      paddingRight: 15,
+    }}
+  >
+    <img
+      src={staticAsset(SendButtonIcon)}
+      style={{ cursor: 'pointer' }}
+      onClick={onClick}
+    />
+  </div>
+)

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -41,6 +41,7 @@ export const CUSTOM_WEBCHAT_PROPERTIES = {
   textPlaceholder: 'userInput.box.placeholder',
   emojiPicker: 'userInput.emojiPicker',
   enableAttachments: 'userInput.attachments.enable',
+  enableSendButton: 'userInput.sendButton.enable',
   persistentMenu: 'userInput.persistentMenu',
   blockInputs: 'userInput.blockInputs',
   scrollbar: 'scrollbar',

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -1,5 +1,6 @@
 export const CUSTOM_WEBCHAT_PROPERTIES = {
   webviewStyle: 'webview.style',
+  enableAnimations: 'animations.enable',
   webviewHeaderStyle: 'webview.header.style',
   brandColor: 'brand.color',
   brandImage: 'brand.image',

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -39,7 +39,7 @@ export const CUSTOM_WEBCHAT_PROPERTIES = {
   userInputStyle: 'userInput.style',
   userInputBoxStyle: 'userInput.box.style',
   textPlaceholder: 'userInput.box.placeholder',
-  emojiPicker: 'userInput.emojiPicker',
+  enableEmojiPicker: 'userInput.emojiPicker.enable',
   enableAttachments: 'userInput.attachments.enable',
   enableSendButton: 'userInput.sendButton.enable',
   persistentMenu: 'userInput.persistentMenu',

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -42,6 +42,7 @@ export const CUSTOM_WEBCHAT_PROPERTIES = {
   enableEmojiPicker: 'userInput.emojiPicker.enable',
   enableAttachments: 'userInput.attachments.enable',
   enableSendButton: 'userInput.sendButton.enable',
+  customSendButton: 'userInput.sendButton.custom',
   persistentMenu: 'userInput.persistentMenu',
   blockInputs: 'userInput.blockInputs',
   scrollbar: 'scrollbar',

--- a/packages/botonic-react/src/dev-app.jsx
+++ b/packages/botonic-react/src/dev-app.jsx
@@ -10,7 +10,7 @@ export class DevApp extends WebchatApp {
     theme = {},
     persistentMenu,
     blockInputs,
-    emojiPicker,
+    enableEmojiPicker,
     enableAttachments,
     onInit,
     onOpen,
@@ -22,7 +22,7 @@ export class DevApp extends WebchatApp {
       theme,
       persistentMenu,
       blockInputs,
-      emojiPicker,
+      enableEmojiPicker,
       enableAttachments,
       onInit,
       onOpen,
@@ -39,7 +39,7 @@ export class DevApp extends WebchatApp {
       theme = {},
       persistentMenu,
       blockInputs,
-      emojiPicker,
+      enableEmojiPicker,
       enableAttachments,
       onInit,
       onOpen,
@@ -50,7 +50,7 @@ export class DevApp extends WebchatApp {
     theme = { ...this.theme, ...theme }
     persistentMenu = persistentMenu || this.persistentMenu
     blockInputs = blockInputs || this.blockInputs
-    emojiPicker = emojiPicker || this.emojiPicker
+    enableEmojiPicker = enableEmojiPicker || this.enableEmojiPicker
     enableAttachments = enableAttachments || this.enableAttachments
     this.onInit = onInit || this.onInit
     this.onOpen = onOpen || this.onOpen
@@ -63,7 +63,7 @@ export class DevApp extends WebchatApp {
         theme={theme}
         persistentMenu={persistentMenu}
         blockInputs={blockInputs}
-        emojiPicker={emojiPicker}
+        enableEmojiPicker={enableEmojiPicker}
         enableAttachments={enableAttachments}
         getString={(stringId, session) => this.bot.getString(stringId, session)}
         setLocale={(locale, session) => this.bot.setLocale(locale, session)}

--- a/packages/botonic-react/src/utils.js
+++ b/packages/botonic-react/src/utils.js
@@ -61,3 +61,6 @@ export const _getThemeProperty = theme => (
     }
   }
 }
+
+export const ConditionalWrapper = ({ condition, wrapper, children }) =>
+  condition ? wrapper(children) : children

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -10,7 +10,7 @@ export class WebchatApp {
     theme = {},
     persistentMenu,
     blockInputs,
-    emojiPicker,
+    enableEmojiPicker,
     enableAttachments,
     defaultDelay,
     defaultTyping,
@@ -23,7 +23,7 @@ export class WebchatApp {
     this.theme = theme
     this.persistentMenu = persistentMenu
     this.blockInputs = blockInputs
-    this.emojiPicker = emojiPicker
+    this.enableEmojiPicker = enableEmojiPicker
     this.enableAttachments = enableAttachments
     this.defaultDelay = defaultDelay
     this.defaultTyping = defaultTyping
@@ -128,7 +128,7 @@ export class WebchatApp {
       persistentMenu,
       blockInputs,
       enableAttachments,
-      emojiPicker,
+      enableEmojiPicker,
       defaultDelay,
       defaultTyping,
       onInit,
@@ -141,7 +141,7 @@ export class WebchatApp {
     theme = { ...this.theme, ...theme }
     persistentMenu = persistentMenu || this.persistentMenu
     blockInputs = blockInputs || this.blockInputs
-    emojiPicker = emojiPicker || this.emojiPicker
+    enableEmojiPicker = enableEmojiPicker || this.enableEmojiPicker
     enableAttachments = enableAttachments || this.enableAttachments
     defaultDelay = defaultDelay || this.defaultDelay
     defaultTyping = defaultTyping || this.defaultTyping
@@ -157,7 +157,7 @@ export class WebchatApp {
         theme={theme}
         persistentMenu={persistentMenu}
         blockInputs={blockInputs}
-        emojiPicker={emojiPicker}
+        enableEmojiPicker={enableEmojiPicker}
         enableAttachments={enableAttachments}
         defaultDelay={defaultDelay}
         defaultTyping={defaultTyping}

--- a/packages/botonic-react/src/webchat/header.jsx
+++ b/packages/botonic-react/src/webchat/header.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import { WebchatContext } from '../contexts'
-import { staticAsset, getProperty } from '../utils'
+import { staticAsset, ConditionalWrapper } from '../utils'
 import styled from 'styled-components'
 import Logo from '../assets/botonic_react_logo100x100.png'
 import { Flex } from 'rebass'
@@ -44,6 +44,7 @@ const StyledHeaderTitle = styled(Flex)`
 
 export const DefaultHeader = props => {
   const { getThemeProperty } = props
+  const animationsEnabled = getThemeProperty('animations.enable', true)
   let HeaderImage = Logo
   /*
   brand.image, brandImage, headerImage and header.image
@@ -56,6 +57,7 @@ export const DefaultHeader = props => {
 
   let headerTitle = getThemeProperty('header.title') || 'Botonic'
   let headerSubtitle = getThemeProperty('header.subtitle') || ''
+
   return (
     <Diffuse
       color={props.color}
@@ -78,9 +80,14 @@ export const DefaultHeader = props => {
         </HeaderTitle>
         <Subtitle>{headerSubtitle}</Subtitle>
       </StyledHeaderTitle>
-      <motion.div whileHover={{ scale: 1.2 }}>
+      <ConditionalWrapper
+        condition={animationsEnabled}
+        wrapper={children => (
+          <motion.div whileHover={{ scale: 1.2 }}>{children}</motion.div>
+        )}
+      >
         <CloseHeader onClick={props.onCloseClick}>⨯</CloseHeader>
-      </motion.div>
+      </ConditionalWrapper>
     </Diffuse>
   )
 }

--- a/packages/botonic-react/src/webchat/message-list.jsx
+++ b/packages/botonic-react/src/webchat/message-list.jsx
@@ -1,11 +1,12 @@
 import React, { useContext } from 'react'
 import { WebchatContext } from '../contexts'
 import { StyledScrollbar } from './styled-scrollbar'
-import { staticAsset } from '../utils'
+import { staticAsset, ConditionalWrapper } from '../utils'
 import Fade from 'react-reveal/Fade'
 
 export const WebchatMessageList = props => {
   const { webchatState, getThemeProperty } = useContext(WebchatContext)
+  const animationsEnabled = getThemeProperty('animations.enable', true)
   const CustomIntro = getThemeProperty('intro.custom')
   const introImage = getThemeProperty('intro.image')
   const introStyle = getThemeProperty('intro.style')
@@ -38,7 +39,12 @@ export const WebchatMessageList = props => {
         overflowX: 'hidden',
       }}
     >
-      <Fade>{CustomIntro ? <CustomIntro /> : DefaultIntro}</Fade>
+      <ConditionalWrapper
+        condition={animationsEnabled}
+        wrapper={children => <Fade>{children}</Fade>}
+      >
+        {CustomIntro ? <CustomIntro /> : DefaultIntro}
+      </ConditionalWrapper>
       {webchatState.messagesComponents.map((e, i) => (
         <div
           style={{

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -506,6 +506,7 @@ export const Webchat = forwardRef((props, ref) => {
     'userInput.sendButton.enable',
     true
   )
+  const CustomSendButton = getThemeProperty('userInput.sendButton.custom')
   const inputUserArea = () => {
     return (
       userInputEnabled && (
@@ -588,7 +589,7 @@ export const Webchat = forwardRef((props, ref) => {
                 />
               </ConditionalWrapper>
             )}
-            {sendButtonEnabled && (
+            {(sendButtonEnabled || CustomSendButton) && (
               <ConditionalWrapper
                 condition={animationsEnabled}
                 wrapper={children => (
@@ -597,7 +598,9 @@ export const Webchat = forwardRef((props, ref) => {
                   </motion.div>
                 )}
               >
-                <SendButton onClick={sendTextAreaText} />
+                <div onClick={sendTextAreaText}>
+                  {CustomSendButton ? <CustomSendButton /> : <SendButton />}
+                </div>
               </ConditionalWrapper>
             )}
           </div>

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -499,7 +499,7 @@ export const Webchat = forwardRef((props, ref) => {
   )
   const userInputEnabled = getThemeProperty('userInput.enable', true)
   const emojiPickerEnabled =
-    getThemeProperty('userInput.emojiPicker.enable') || props.emojiPicker
+    getThemeProperty('userInput.emojiPicker.enable') || props.enableEmojiPicker
   const attachmentsEnabled =
     getThemeProperty('userInput.attachments.enable') || props.enableAttachments
   const sendButtonEnabled = getThemeProperty(

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -18,6 +18,7 @@ import { useWebchat, useTyping, usePrevious } from './hooks'
 import { WebchatHeader } from './header'
 import { PersistentMenu } from '../components/persistent-menu'
 import { Attachment } from '../components/attachment'
+import { SendButton } from '../components/send-button'
 import { WebchatMessageList } from './message-list'
 import { WebchatReplies } from './replies'
 import { WebviewContainer } from './webview'
@@ -390,11 +391,15 @@ export const Webchat = forwardRef((props, ref) => {
     }
   }
 
+  const sendTextAreaText = () => {
+    sendText(textArea.current.value)
+    textArea.current.value = ''
+  }
+
   const onKeyDown = event => {
     if (event.keyCode == 13 && event.shiftKey == false) {
       event.preventDefault()
-      sendText(textArea.current.value)
-      textArea.current.value = ''
+      sendTextAreaText()
     }
   }
 
@@ -496,6 +501,10 @@ export const Webchat = forwardRef((props, ref) => {
   const emojiPickerEnabled = getThemeProperty('userInput.emojiPicker', false)
   const attachmentsEnabled =
     getThemeProperty('userInput.attachments.enable') || props.enableAttachments
+  const sendButtonEnabled = getThemeProperty(
+    'userInput.sendButton.enable',
+    true
+  )
   const inputUserArea = () => {
     return (
       userInputEnabled && (
@@ -576,6 +585,18 @@ export const Webchat = forwardRef((props, ref) => {
                     .map(v => v.join(','))
                     .join(',')}
                 />
+              </ConditionalWrapper>
+            )}
+            {sendButtonEnabled && (
+              <ConditionalWrapper
+                condition={animationsEnabled}
+                wrapper={children => (
+                  <motion.div whileHover={{ scale: 1.2 }}>
+                    {children}
+                  </motion.div>
+                )}
+              >
+                <SendButton onClick={sendTextAreaText} />
               </ConditionalWrapper>
             )}
           </div>

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -498,7 +498,8 @@ export const Webchat = forwardRef((props, ref) => {
     </div>
   )
   const userInputEnabled = getThemeProperty('userInput.enable', true)
-  const emojiPickerEnabled = getThemeProperty('userInput.emojiPicker', false)
+  const emojiPickerEnabled =
+    getThemeProperty('userInput.emojiPicker.enable') || props.emojiPicker
   const attachmentsEnabled =
     getThemeProperty('userInput.attachments.enable') || props.enableAttachments
   const sendButtonEnabled = getThemeProperty(

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -22,7 +22,12 @@ import { WebchatMessageList } from './message-list'
 import { WebchatReplies } from './replies'
 import { WebviewContainer } from './webview'
 import { msgToBotonic } from '../msg-to-botonic'
-import { isDev, staticAsset, _getThemeProperty } from '../utils'
+import {
+  isDev,
+  staticAsset,
+  _getThemeProperty,
+  ConditionalWrapper,
+} from '../utils'
 import Logo from '../assets/botonic_react_logo100x100.png'
 import EmojiPicker from 'emoji-picker-react'
 import LogoMenu from '../assets/menuButton.svg'
@@ -206,12 +211,17 @@ export const Webchat = forwardRef((props, ref) => {
       />
     </div>
   )
-
+  const animationsEnabled = getThemeProperty('animations.enable', true)
   const persistentMenuOptions =
     getThemeProperty('userInput.persistentMenu') || props.persistentMenu
 
   const persistentMenuLogo = () => (
-    <motion.div whileHover={{ scale: 1.2 }}>
+    <ConditionalWrapper
+      condition={animationsEnabled}
+      wrapper={children => (
+        <motion.div whileHover={{ scale: 1.2 }}>{children}</motion.div>
+      )}
+    >
       <div
         style={{
           display: 'flex',
@@ -225,7 +235,7 @@ export const Webchat = forwardRef((props, ref) => {
       >
         <img src={staticAsset(LogoMenu)} />
       </div>
-    </motion.div>
+    </ConditionalWrapper>
   )
 
   const checkBlockInput = input => {
@@ -540,19 +550,33 @@ export const Webchat = forwardRef((props, ref) => {
             }}
           >
             {emojiPickerEnabled && (
-              <motion.div whileHover={{ scale: 1.2 }}>
+              <ConditionalWrapper
+                condition={animationsEnabled}
+                wrapper={children => (
+                  <motion.div whileHover={{ scale: 1.2 }}>
+                    {children}
+                  </motion.div>
+                )}
+              >
                 <EmojiPickerComponent />
-              </motion.div>
+              </ConditionalWrapper>
             )}
             {attachmentsEnabled && (
-              <motion.div whileHover={{ scale: 1.2 }}>
+              <ConditionalWrapper
+                condition={animationsEnabled}
+                wrapper={children => (
+                  <motion.div whileHover={{ scale: 1.2 }}>
+                    {children}
+                  </motion.div>
+                )}
+              >
                 <Attachment
                   onChange={handleAttachment}
                   accept={Object.values(MIME_WHITELIST)
                     .map(v => v.join(','))
                     .join(',')}
                 />
-              </motion.div>
+              </ConditionalWrapper>
             )}
           </div>
         </div>


### PR DESCRIPTION
Just added a pair of configurable properties, `userInput.sendButton.enable` and `animations.enable`, both inside the `theme` object of webchat, as shown below:
```
userInput: {
      sendButton:{
        enable:true, // set it to false to disable send button (enabled by default)
        custom: CustomSendButton // React Component
      }
    },
```
```
    animations: {
      enable: true // set it to false to disable animations (enabled by default)
    },
```
**breaking change (for enabling/disabling) emojiPicker**: 
`userInput.emojiPicker` --> `userInput.emojiPicker.enable`, 
and instead of (alternative api):
`emojiPicker` --> `enableEmojiPicker`


<img width="423" alt="Screenshot 2020-02-05 at 21 12 28" src="https://user-images.githubusercontent.com/35448568/73879574-0c13bd00-485d-11ea-81cc-866986691b07.png">
