### PR TITLE
Contentful/content id field

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -12,7 +12,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -35,13 +35,13 @@ export class DummyCMS implements CMS {
     const elements = this.buttonCallbacks.map(callback =>
       this.element(Math.random().toString(), callback)
     )
-    return Promise.resolve(new Carousel(new CommonFields(id), elements))
+    return Promise.resolve(new Carousel(new CommonFields(id, id), elements))
   }
 
   async text(id: string, {} = DEFAULT_CONTEXT): Promise<Text> {
     return Promise.resolve(
       new Text(
-        new CommonFields(id, { keywords: ['kw1', 'kw2'], shortText: id }),
+        new CommonFields(id, id, { keywords: ['kw1', 'kw2'], shortText: id }),
         'Dummy text for ' + id,
         this.buttons()
       )
@@ -55,7 +55,7 @@ export class DummyCMS implements CMS {
   async startUp(id: string, {} = DEFAULT_CONTEXT): Promise<StartUp> {
     return Promise.resolve(
       new StartUp(
-        new CommonFields(id),
+        new CommonFields(id, id),
         DummyCMS.IMG,
         'Dummy text for ' + id,
         this.buttons()
@@ -80,18 +80,18 @@ export class DummyCMS implements CMS {
   url(id: string, {} = DEFAULT_CONTEXT): Promise<Url> {
     return Promise.resolve(
       new Url(
-        new CommonFields(id, { shortText: 'button text for' + id }),
+        new CommonFields(id, id, { shortText: 'button text for' + id }),
         `http://url.${id}`
       )
     )
   }
 
   image(id: string, {} = DEFAULT_CONTEXT): Promise<Image> {
-    return Promise.resolve(new Image(new CommonFields(id), DummyCMS.IMG))
+    return Promise.resolve(new Image(new CommonFields(id, id), DummyCMS.IMG))
   }
 
   queue(id: string, {} = DEFAULT_CONTEXT): Promise<Queue> {
-    return Promise.resolve(new Queue(new CommonFields(id), id))
+    return Promise.resolve(new Queue(new CommonFields(id, id), id))
   }
 
   contents(
@@ -103,12 +103,12 @@ export class DummyCMS implements CMS {
   }
 
   contentsWithKeywords({} = DEFAULT_CONTEXT): Promise<SearchResult[]> {
-    const contents = this.buttonCallbacks.map(cb => {
+    const contents = this.buttonCallbacks.map((cb, id) => {
       const button = DummyCMS.buttonFromCallback(cb)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       return new SearchResult(
         cb,
-        new CommonFields(button.name, {
+        new CommonFields(String(id), button.name, {
           shortText: button.text,
           keywords: [
             'keyword for ' + (button.callback.payload || button.callback.url!),
@@ -122,7 +122,7 @@ export class DummyCMS implements CMS {
   schedule(id: string): Promise<ScheduleContent> {
     const schedule = new time.Schedule('Europe/Madrid')
     return Promise.resolve(
-      new ScheduleContent(new CommonFields('name'), schedule)
+      new ScheduleContent(new CommonFields(id, 'name'), schedule)
     )
   }
 
@@ -134,7 +134,7 @@ export class DummyCMS implements CMS {
     const now = new Date()
     const dateRange = new time.DateRange('daterange name', now, now)
     return Promise.resolve(
-      new DateRangeContent(new CommonFields(dateRange.name), dateRange)
+      new DateRangeContent(new CommonFields(id, dateRange.name), dateRange)
     )
   }
 

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -62,6 +62,7 @@ export class CommonFields {
   readonly dateRange?: DateRangeContent
   followUp?: FollowUp
   constructor(
+    readonly id: string,
     readonly name: string,
     opt?: {
       shortText?: string

--- a/packages/botonic-plugin-contentful/src/cms/factories.ts
+++ b/packages/botonic-plugin-contentful/src/cms/factories.ts
@@ -8,7 +8,17 @@ import {
 } from './contents'
 
 abstract class ModelBuilder {
-  protected constructor(readonly name: string) {}
+  protected constructor(public id: string, public name: string) {}
+
+  withId(id: string): ModelBuilder {
+    this.id = id
+    return this
+  }
+
+  withName(name: string): ModelBuilder {
+    this.name = name
+    return this
+  }
 
   abstract build(): Content
 }
@@ -17,14 +27,21 @@ abstract class ModelBuilder {
  * Helps constructing @link Text, which has many fields and it's immutable
  */
 export class TextBuilder extends ModelBuilder {
-  buttons: Button[] = []
+  // TODO move CommonFields to a new TopContentBuilder
   shortText?: string
   keywords: string[] = []
   followUp?: FollowUp
+
+  buttons: Button[] = []
   buttonsStyle = ButtonStyle.BUTTON
 
-  constructor(readonly name: string, readonly text: string) {
-    super(name)
+  constructor(id: string, name: string, public text: string) {
+    super(id, name)
+  }
+
+  withText(text: string): TextBuilder {
+    this.text = text
+    return this
   }
 
   withButtons(buttons: Button[]): TextBuilder {
@@ -54,7 +71,7 @@ export class TextBuilder extends ModelBuilder {
 
   build(): Text {
     return new Text(
-      new CommonFields(this.name, {
+      new CommonFields(this.id, this.name, {
         shortText: this.shortText,
         keywords: this.keywords,
         followUp: this.followUp,

--- a/packages/botonic-plugin-contentful/src/cms/test-helpers/builders.ts
+++ b/packages/botonic-plugin-contentful/src/cms/test-helpers/builders.ts
@@ -5,18 +5,18 @@ import {
   ContentCallback,
   ModelType,
   Text,
-} from '../../src/cms'
-import { TextBuilder } from '../../src/cms/factories'
+} from '../index'
+import { TextBuilder } from '../factories'
 
-function rndStr(): string {
+export function rndStr(): string {
   return Math.random().toString()
 }
 
-function rndBool(): boolean {
+export function rndBool(): boolean {
   return Math.random() >= 0.5
 }
 
-export class ButtonsBuilder {
+export class RndButtonsBuilder {
   name = rndStr()
   buttons: Button[] = []
 
@@ -24,7 +24,7 @@ export class ButtonsBuilder {
     return this.buttons
   }
 
-  withButton(): ButtonsBuilder {
+  withButton(): RndButtonsBuilder {
     this.buttons.push(
       new Button(
         rndStr(),
@@ -36,7 +36,7 @@ export class ButtonsBuilder {
   }
 }
 
-export class KeywordsBuilder {
+export class RndKeywordsBuilder {
   keywords = [rndStr(), rndStr()]
 
   build(): string[] {
@@ -45,11 +45,14 @@ export class KeywordsBuilder {
 }
 
 export class RndTextBuilder extends TextBuilder {
-  readonly buttonsBuilder = new ButtonsBuilder()
-  readonly keywordsBuilder = new KeywordsBuilder()
+  readonly buttonsBuilder = new RndButtonsBuilder()
+  readonly keywordsBuilder = new RndKeywordsBuilder()
 
   constructor(name: string = rndStr(), text: string = rndStr()) {
-    super(name, text)
+    super(rndStr(), name, text)
+  }
+
+  withRandomFields(): RndTextBuilder {
     this.buttons = this.buttonsBuilder
       .withButton()
       .withButton()
@@ -58,7 +61,8 @@ export class RndTextBuilder extends TextBuilder {
     this.keywords = this.keywordsBuilder.build()
     this.followUp = rndBool()
       ? undefined
-      : new Text(new CommonFields(rndStr()), rndStr(), [])
+      : new Text(new CommonFields(rndStr(), rndStr()), rndStr(), [])
     this.buttonsStyle = rndBool() ? ButtonStyle.QUICK_REPLY : ButtonStyle.BUTTON
+    return this
   }
 }

--- a/packages/botonic-plugin-contentful/src/cms/test-helpers/index.ts
+++ b/packages/botonic-plugin-contentful/src/cms/test-helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './builders'

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -143,7 +143,7 @@ export function commonFieldsFromEntry(
   const dateRange =
     fields.dateRange && DateRangeDelivery.fromEntry(fields.dateRange)
 
-  return new CommonFields(fields.name, {
+  return new CommonFields(entry.sys.id, fields.name, {
     keywords: fields.keywords,
     shortText: fields.shortText,
     partitions: fields.partitions,

--- a/packages/botonic-plugin-contentful/src/contentful/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/keywords.ts
@@ -39,7 +39,7 @@ export class KeywordsDelivery {
     const callback = DeliveryApi.callbackFromEntry(entry)
     return new SearchResult(
       callback,
-      new CommonFields(entry.fields.name, {
+      new CommonFields(entry.sys.id, entry.fields.name, {
         shortText: entry.fields.shortText,
         keywords,
       }),

--- a/packages/botonic-plugin-contentful/src/plugin.ts
+++ b/packages/botonic-plugin-contentful/src/plugin.ts
@@ -67,12 +67,8 @@ export default class BotonicPluginContentful {
   }
 
   // @ts-ignore
-  pre({ input, session, lastRoutePath }) {
-    return { input, session, lastRoutePath }
-  }
+  pre({ input, session, lastRoutePath }) {}
 
   // @ts-ignore
-  post({ input, session, lastRoutePath, response }) {
-    return { input, session, lastRoutePath, response }
-  }
+  post({ input, session, lastRoutePath, response }) {}
 }

--- a/packages/botonic-plugin-contentful/tests/cms/contents.test.ts
+++ b/packages/botonic-plugin-contentful/tests/cms/contents.test.ts
@@ -1,11 +1,10 @@
 import { instance, mock, when } from 'ts-mockito'
 import { Content, Text } from '../../src/cms'
-import { RndTextBuilder } from '../helpers/builders'
+import { RndTextBuilder } from '../../src/cms/test-helpers/builders'
 import { expectEqualExceptOneField } from '../helpers/expect'
 
 test('TEST: cloneWithButtons copies all fields except buttons', () => {
-  const builder = new RndTextBuilder()
-  const t1 = builder.build()
+  const t1 = new RndTextBuilder().withRandomFields().build()
   expect(t1).toBeInstanceOf(Text)
 
   const clone = t1.cloneWithButtons(t1.buttons.slice(1, 2))
@@ -20,8 +19,7 @@ test('TEST: cloneWithButtons copies all fields except buttons', () => {
 })
 
 test('TEST: cloneWithText copies all fields except text', () => {
-  const builder = new RndTextBuilder()
-  const t1 = builder.build()
+  const t1 = new RndTextBuilder().withRandomFields().build()
   const oldText = t1.text
   expect(t1).toBeInstanceOf(Text)
 
@@ -36,7 +34,7 @@ test('TEST: cloneWithText copies all fields except text', () => {
 })
 
 test('TEST: cloneWithFollowUp copies all fields except followUp', () => {
-  const builder = new RndTextBuilder()
+  const builder = new RndTextBuilder().withRandomFields()
   const t1 = builder.build()
   const oldFollowUp = t1.common.followUp
   expect(t1).toBeInstanceOf(Text)

--- a/packages/botonic-plugin-contentful/tests/contentful/queue.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/queue.test.ts
@@ -18,7 +18,10 @@ test('TEST: contentful Queue', async () => {
   ])
   expect(queue).toEqual(
     new Queue(
-      new CommonFields('TEST_QUEUE', { shortText: 'Short Text', searchableBy }),
+      new CommonFields(TEST_QUEUE_ID, 'TEST_QUEUE', {
+        shortText: 'Short Text',
+        searchableBy,
+      }),
       'queueName',
       testSchedule()
     )

--- a/packages/botonic-plugin-contentful/tests/contentful/startup.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/startup.test.ts
@@ -9,10 +9,11 @@ import { testContentful } from './contentful.helper'
 import { TEST_CAROUSEL_MAIN_ID } from './carousel.test'
 
 test('TEST: contentful startUp', async () => {
-  const startUp = await testContentful().startUp('PfMPIeS6zD1Rix6Px9m0u')
+  const id = 'PfMPIeS6zD1Rix6Px9m0u'
+  const startUp = await testContentful().startUp(id)
   expect(startUp).toEqual(
     new StartUp(
-      new CommonFields('BANNER', {
+      new CommonFields(id, 'BANNER', {
         shortText: 'Bienvenida',
         keywords: ['keyword1'],
       }),

--- a/packages/botonic-plugin-contentful/tests/contentful/url.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/url.test.ts
@@ -7,7 +7,7 @@ test('TEST: contentful url', async () => {
   const url = await testContentful().url(TEST_URL_HUBTYPE_ID, { locale: 'en' })
   expect(url).toEqual(
     new Url(
-      new CommonFields('URL_HUBTYPE', {
+      new CommonFields(TEST_URL_HUBTYPE_ID, 'URL_HUBTYPE', {
         shortText: 'Web de Hubtype',
         keywords: ['hubtypeEn', 'botonicEn'],
       }),

--- a/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../src'
 import { SearchResult as CallbackToContentWithKeywords1 } from '../../src/search/search-result'
 import { Normalizer, StemmingBlackList, MatchType } from '../../src/nlp'
+import { rndStr } from '../../src/cms/test-helpers/builders'
 
 const ES_CONTEXT = { locale: 'es' }
 test('TEST: searchContentsFromInput keywords found', async () => {
@@ -101,7 +102,7 @@ test('TEST: searchContentsFromInput with stem blacklist', async () => {
 export function contentWithKeyword(callback: Callback, keywords: string[]) {
   return new SearchResult(
     callback,
-    new CommonFields(callback.payload!, {
+    new CommonFields(rndStr(), callback.payload!, {
       shortText: 'shortText' + callback.payload,
       keywords,
     })
@@ -112,7 +113,7 @@ export function chitchatContent(keywords: string[]) {
   const id = Math.random().toString()
   return new SearchResult(
     new ContentCallback(ModelType.TEXT, id),
-    new CommonFields(id, { shortText: 'chitchat', keywords })
+    new CommonFields(id, id, { shortText: 'chitchat', keywords })
   )
 }
 

--- a/packages/botonic-plugin-contentful/tests/search/search.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/search.test.ts
@@ -9,29 +9,30 @@ import {
 } from '../../src/cms'
 import { Search, SearchResult } from '../../src/search'
 import { Normalizer } from '../../src/nlp'
+import { rndStr } from '../../src/cms/test-helpers/builders'
 
 const CONTEXT = { locale: 'es' }
 
 test('TEST: respondFoundContents text with buttons', async () => {
   const cms = mock(DummyCMS)
   when(cms.url('urlCmsId', CONTEXT)).thenResolve(
-    new Url(new CommonFields('url'), 'http:/mocked_url')
+    new Url(new CommonFields(rndStr(), 'url'), 'http:/mocked_url')
   )
   const sut = new Search(instance(cms), instance(mock(Normalizer)))
 
   const urlContent = new SearchResult(
     new ContentCallback(ModelType.URL, 'urlCmsId'),
-    new CommonFields('name', { shortText: 'url shortText' })
+    new CommonFields(rndStr(), 'name', { shortText: 'url shortText' })
   )
 
   const textContent = new SearchResult(
     new ContentCallback(ModelType.TEXT, 'textCmsId'),
-    new CommonFields('name', { shortText: 'text shortText' })
+    new CommonFields(rndStr(), 'name', { shortText: 'text shortText' })
   )
 
   // sut
   when(cms.text('foundId', CONTEXT)).thenResolve(
-    new Text(new CommonFields('foundName'), 'foundText', [])
+    new Text(new CommonFields(rndStr(), 'foundName'), 'foundText', [])
   )
   const response = await sut.respondFoundContents(
     [urlContent, textContent],
@@ -60,11 +61,11 @@ test('TEST: respondFoundContents text with chitchat', async () => {
   when(cms.chitchat('chitchatCmsId', CONTEXT)).thenResolve(chitchat)
   const chitchatCallback = new SearchResult(
     new ContentCallback(ModelType.CHITCHAT, 'chitchatCmsId'),
-    new CommonFields('name', { shortText: 'chitchat' })
+    new CommonFields(rndStr(), 'name', { shortText: 'chitchat' })
   )
 
   when(cms.text('foundId', CONTEXT)).thenResolve(
-    new Text(new CommonFields('foundName'), 'foundText', [])
+    new Text(new CommonFields(rndStr(), 'foundName'), 'foundText', [])
   )
 
   //act
@@ -85,7 +86,7 @@ test('TEST: respondFoundContents without contents', async () => {
 
   // sut
   when(cms.text('notFoundId', CONTEXT)).thenResolve(
-    new Text(new CommonFields('notFoundName'), 'notFoundText', [])
+    new Text(new CommonFields(rndStr(), 'notFoundName'), 'notFoundText', [])
   )
   const response = await sut.respondFoundContents(
     [],

--- a/packages/botonic-plugin-dynamodb/src/index.ts
+++ b/packages/botonic-plugin-dynamodb/src/index.ts
@@ -56,14 +56,10 @@ export default class BotonicPluginDynamoDB {
   }
 
   // @ts-ignore
-  pre({ input, session, lastRoutePath }) {
-    return { input, session, lastRoutePath }
-  }
+  pre({ input, session, lastRoutePath }) {}
 
   // @ts-ignore
-  post({ input, session, lastRoutePath, response }) {
-    return { input, session, lastRoutePath, response }
-  }
+  post({ input, session, lastRoutePath, response }) {}
 
   private applyTimeout(pluginDynamoOpts: DynamoDbOptions): void {
     if (!pluginDynamoOpts.timeout) {

--- a/packages/botonic-react/index.d.ts
+++ b/packages/botonic-react/index.d.ts
@@ -1,4 +1,3 @@
-import { Input, Locales, Routes, Session } from '@botonic/core';
 import * as React from 'react'
 import * as core from '@botonic/core'
 
@@ -50,32 +49,28 @@ export class Element extends React.Component<any, any> {}
 
 /**
  * See @botonic/core's Response for the description of the Response's semantics*/
-type Response = [React.ReactNode]
+export interface BotResponse extends core.BotRequest {
+  response: [React.ReactNode]
+}
+
 
 export class NodeApp {
   constructor(options: core.BotOptions)
 
   renderNode(args): string
 
-  input(_: {
-    input: core.Input
-    session?: core.Session
-    lastRoutePath: string
-  }): {
-    input: core.Input
-    response: Response
-    session: core.Session
-    lastRoutePath: string
-  }
+  input(request: core.BotRequest): BotResponse
 }
 
 // Parameters of the actions' botonicInit method
-export interface ActionInitInput {
-  input: core.Input
+export interface ActionRequest {
   session: core.Session
-  params: any
-  lastRoutePath: any
-  plugins: any
+  params: {[key: string]: string}
+  input: core.Input
+  plugins: { [id: string]: core.Plugin }
+  defaultTyping: number,
+  defaultDelay: number,
+  lastRoutePath: string
 }
 
 export class BotonicInputTester {
@@ -100,17 +95,12 @@ export class BotonicOutputTester {
   text(out: string, replies?: any): Promise<string>
 }
 
-export const RequestContext: React.Context<{
+export interface RequestContextInterface extends ActionRequest {
   getString: (stringId: string) => string
   setLocale: (locale: string) => string
-  session: core.Session
-  params: any
-  input: core.Input
-  defaultDelay: number
-  defaultTyping: number
-  lastRoutePath?: string
-  plugins: { [id: string]: core.Plugin }
-}>
+}
+
+export const RequestContext: React.Context<RequestContextInterface>
 
 export function msgToBotonic(msg: any): React.ReactNode
 export function msgsToBotonic(msgs: any | any[]): React.ReactNode


### PR DESCRIPTION
So far we used an id to retrieve CMS contents, but the returned object did not have an id type.
In this PR we add it to the CommonFields object, which all TopContents have