### PR TITLE
Fix: Update hooks.js - Fix outer page scrolling bug

### DIFF
--- a/packages/botonic-react/src/webchat/hooks.js
+++ b/packages/botonic-react/src/webchat/hooks.js
@@ -178,10 +178,10 @@ export function useWebchat() {
 export function useTyping({ webchatState, updateTyping, updateMessage }) {
   useEffect(() => {
     let delayTimeout, typingTimeout
-    let end = document.getElementById('messages-end')
-    if (end) {
-      end.scrollIntoView({ behavior: 'smooth' })
-      setTimeout(() => end.scrollIntoView({ behavior: 'smooth' }), 100)
+    let frame = document.querySelectorAll('.simplebar-content-wrapper')[0];
+    if (frame) {
+      frame.scrollTop = frame.scrollHeight
+      setTimeout(() => frame.scrollTop = frame.scrollHeight, 100)
     }
     try {
       let nextMsg = webchatState.messagesJSON.filter(m => !m.display)[0]


### PR DESCRIPTION
Previously, the file used "scrollIntoView()" on the latest message element. This produced buggy behavior: When the chat was on a page that itself was scrollable, the entire page would scroll to get the bottom of the chat into view.

Currently, we 'simply' scroll the scrollable element of the chatbot all the way down. No matter where the bot is on the parent page, it will not influence the location of the parent page.

TODO: To get the exact same smooth scrolling behaviour, we need to add 
.simplebar-content-wrapper{scroll-behavior: smooth}
I currently can't find your CSS files.