### PR TITLE
feat(react): add clearMesages public api for webchat

### DIFF
--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -122,6 +122,10 @@ export class WebchatApp {
     return this.webchatRef.current.getMessages()
   }
 
+  clearMessages() {
+    this.webchatRef.current.clearMessages()
+  }
+
   getComponent(optionsAtRuntime = {}) {
     let {
       theme = {},

--- a/packages/botonic-react/src/webchat/hooks.js
+++ b/packages/botonic-react/src/webchat/hooks.js
@@ -85,6 +85,12 @@ export function webchatReducer(state, action) {
       return { ...state, isWebchatOpen: action.payload }
     case 'setError':
       return { ...state, error: action.payload || {} }
+    case 'clearMessages':
+      return {
+        ...state,
+        messagesJSON: [],
+        messagesComponents: [],
+      }
     default:
       throw new Error()
   }
@@ -154,6 +160,12 @@ export function useWebchat() {
       payload: error,
     })
 
+  const clearMessages = () => {
+    webchatDispatch({
+      type: 'clearMessages',
+    })
+  }
+
   return {
     webchatState,
     webchatDispatch,
@@ -172,6 +184,7 @@ export function useWebchat() {
     updateDevSettings,
     toggleWebchat,
     setError,
+    clearMessages,
   }
 }
 

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -133,6 +133,7 @@ export const Webchat = forwardRef((props, ref) => {
     updateDevSettings,
     toggleWebchat,
     setError,
+    clearMessages,
     openWebviewT,
     closeWebviewT,
   } = props.webchatHooks || useWebchat()
@@ -374,6 +375,10 @@ export const Webchat = forwardRef((props, ref) => {
     toggleWebchat: () => toggleWebchat(!webchatState.isWebchatOpen),
     openWebviewApi: component => openWebviewT(component),
     setError,
+    getMessages: () => webchatState.messagesJSON,
+    clearMessages: () => {
+      clearMessages()
+    },
   }))
 
   const resolveCase = () => {


### PR DESCRIPTION
I have added a new feature to call webchat public api to clear the messages of the chat.
So for example, within the developers browser console, `Botonic.clearMessages()` will delete the all the messages of the chat, or if used with the other listeners we can do something like:

```
export const webchat = {
  onInit: app => {
    app.clearMessages()
    app.open()
  }
}
```

to automatically clear messages once the webchat is loaded.