### PR TITLE
fix(templates): fix tests for all templates

### DIFF
--- a/packages/botonic-cli/templates/blank/src/index.js
+++ b/packages/botonic-cli/templates/blank/src/index.js
@@ -3,4 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
-export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }
+export const config = { defaultDelay: 0, defaultTyping: 0 }

--- a/packages/botonic-cli/templates/blank/tests/app.test.js
+++ b/packages/botonic-cli/templates/blank/tests/app.test.js
@@ -1,9 +1,14 @@
-import { BotonicInputTester, BotonicOutputTester } from '@botonic/react'
+import { routes, plugins, locales, config } from '../src/'
+import {
+  BotonicInputTester,
+  BotonicOutputTester,
+  NodeApp,
+} from '@botonic/react'
 
-import App from '../src/app'
+const app = new NodeApp({ routes, locales, plugins, ...config })
 
-let i = new BotonicInputTester(App)
-let o = new BotonicOutputTester(App)
+const i = new BotonicInputTester(app)
+const o = new BotonicOutputTester(app)
 
 test('TEST: (404) NOT FOUND', async () => {
   await expect(i.text('whatever')).resolves.toBe(

--- a/packages/botonic-cli/templates/childs/src/index.js
+++ b/packages/botonic-cli/templates/childs/src/index.js
@@ -3,4 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
-export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }
+export const config = { defaultDelay: 0, defaultTyping: 0 }

--- a/packages/botonic-cli/templates/childs/tests/app.test.js
+++ b/packages/botonic-cli/templates/childs/tests/app.test.js
@@ -1,9 +1,14 @@
-import { BotonicInputTester, BotonicOutputTester } from '@botonic/react'
+import { routes, plugins, locales, config } from '../src/'
+import {
+  BotonicInputTester,
+  BotonicOutputTester,
+  NodeApp,
+} from '@botonic/react'
 
-import App from '../src/app'
+const app = new NodeApp({ routes, locales, plugins, ...config })
 
-let i = new BotonicInputTester(App)
-let o = new BotonicOutputTester(App)
+const i = new BotonicInputTester(app)
+const o = new BotonicOutputTester(app)
 
 test('TEST: hi.js', async () => {
   await expect(i.text('Hi')).resolves.toBe(

--- a/packages/botonic-cli/templates/custom-webchat/src/actions/not-found.js
+++ b/packages/botonic-cli/templates/custom-webchat/src/actions/not-found.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Text, Button, Reply } from '@botonic/react'
+
+export default class extends React.Component {
+  render() {
+    return <Text>I don't understand you</Text>
+  }
+}

--- a/packages/botonic-cli/templates/custom-webchat/src/index.js
+++ b/packages/botonic-cli/templates/custom-webchat/src/index.js
@@ -3,4 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
-export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }
+export const config = { defaultDelay: 0, defaultTyping: 0 }

--- a/packages/botonic-cli/templates/custom-webchat/src/routes.js
+++ b/packages/botonic-cli/templates/custom-webchat/src/routes.js
@@ -1,3 +1,4 @@
+import NotFound from './actions/not-found'
 import Start from './actions/start'
 import Help from './actions/help'
 import ShowButtons from './actions/show-buttons'
@@ -14,5 +15,6 @@ export const routes = [
     input: i => i.payload == 'replies' || i.data == 'replies',
     action: ShowReplies,
   },
-  { path: 'start', text: /.*/, action: Start },
+  { path: 'start', text: /hi|start|hello/, action: Start },
+  { path: '404', text: /.*/, action: NotFound },
 ]

--- a/packages/botonic-cli/templates/custom-webchat/tests/app.test.js
+++ b/packages/botonic-cli/templates/custom-webchat/tests/app.test.js
@@ -1,69 +1,14 @@
-import { BotonicInputTester, BotonicOutputTester } from '@botonic/react'
+import { routes, plugins, locales, config } from '../src/'
+import {
+  BotonicInputTester,
+  BotonicOutputTester,
+  NodeApp,
+} from '@botonic/react'
 
-import App from '../src/app'
+const app = new NodeApp({ routes, locales, plugins, ...config })
 
-let i = new BotonicInputTester(App)
-let o = new BotonicOutputTester(App)
-
-test('TEST: hi.js', async () => {
-  await expect(i.text('Hi')).resolves.toBe(
-    o.text(
-      'Hi! Choose what you want to eat:',
-      o.replies(
-        { text: 'Pizza', payload: 'pizza' },
-        { text: 'Pasta', path: 'pasta' }
-      )
-    )
-  )
-})
-
-test('TEST: pizza.js', async () => {
-  await expect(i.payload('pizza', {}, 'hi')).resolves.toBe(
-    o.text(
-      'You chose Pizza! Choose one ingredient:',
-      o.replies(
-        { text: 'Sausage', payload: 'sausage' },
-        { text: 'Bacon', payload: 'bacon' }
-      )
-    )
-  )
-})
-
-test('TEST: sausage.js', async () => {
-  await expect(i.payload('sausage', {}, 'hi/pizza')).resolves.toBe(
-    o.text('You chose Sausage on Pizza')
-  )
-})
-
-test('TEST: bacon.js', async () => {
-  await expect(i.path('bacon', {}, 'hi/pizza')).resolves.toBe(
-    o.text('You chose Bacon on Pizza')
-  )
-})
-
-test('TEST: pasta.js', async () => {
-  await expect(i.payload('pasta', {}, 'hi')).resolves.toBe(
-    o.text(
-      'You chose Pasta! Choose one ingredient:',
-      o.replies(
-        { text: 'Cheese', payload: 'cheese' },
-        { text: 'Tomato', payload: 'tomato' }
-      )
-    )
-  )
-})
-
-test('TEST: cheese.js', async () => {
-  await expect(i.payload('cheese', {}, 'hi/pasta')).resolves.toBe(
-    o.text('You chose Cheese on Pasta')
-  )
-})
-
-test('TEST: tomato.js', async () => {
-  await expect(i.path('tomato', {}, 'hi/pasta')).resolves.toBe(
-    o.text('You chose Tomato on Pasta')
-  )
-})
+const i = new BotonicInputTester(app)
+const o = new BotonicOutputTester(app)
 
 test('TEST: (404) NOT FOUND', async () => {
   await expect(i.text('whatever')).resolves.toBe(

--- a/packages/botonic-cli/templates/dynamic-carousel/src/index.js
+++ b/packages/botonic-cli/templates/dynamic-carousel/src/index.js
@@ -3,4 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
-export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }
+export const config = { defaultDelay: 0, defaultTyping: 0 }

--- a/packages/botonic-cli/templates/dynamic-carousel/tests/app.test.js
+++ b/packages/botonic-cli/templates/dynamic-carousel/tests/app.test.js
@@ -1,9 +1,14 @@
-import { BotonicInputTester, BotonicOutputTester } from '@botonic/react'
+import { routes, plugins, locales, config } from '../src/'
+import {
+  BotonicInputTester,
+  BotonicOutputTester,
+  NodeApp,
+} from '@botonic/react'
 
-import App from '../src/app'
+const app = new NodeApp({ routes, locales, plugins, ...config })
 
-let i = new BotonicInputTester(App)
-let o = new BotonicOutputTester(App)
+const i = new BotonicInputTester(app)
+const o = new BotonicOutputTester(app)
 
 test('TEST: (404) NOT FOUND', async () => {
   await expect(i.text('whatever')).resolves.toBe(

--- a/packages/botonic-cli/templates/handoff/src/index.js
+++ b/packages/botonic-cli/templates/handoff/src/index.js
@@ -3,4 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
-export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }
+export const config = { defaultDelay: 0, defaultTyping: 0 }

--- a/packages/botonic-cli/templates/handoff/tests/app.test.js
+++ b/packages/botonic-cli/templates/handoff/tests/app.test.js
@@ -1,9 +1,14 @@
-import { BotonicInputTester, BotonicOutputTester } from '@botonic/react'
+import { routes, plugins, locales, config } from '../src/'
+import {
+  BotonicInputTester,
+  BotonicOutputTester,
+  NodeApp,
+} from '@botonic/react'
 
-import App from '../src/app'
+const app = new NodeApp({ routes, locales, plugins, ...config })
 
-let i = new BotonicInputTester(App)
-let o = new BotonicOutputTester(App)
+const i = new BotonicInputTester(app)
+const o = new BotonicOutputTester(app)
 
 test('TEST: (404) NOT FOUND', async () => {
   await expect(i.text('whatever')).resolves.toBe(

--- a/packages/botonic-cli/templates/intent/src/index.js
+++ b/packages/botonic-cli/templates/intent/src/index.js
@@ -3,4 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
-export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }
+export const config = { defaultDelay: 0, defaultTyping: 0 }

--- a/packages/botonic-cli/templates/intent/tests/app.test.js
+++ b/packages/botonic-cli/templates/intent/tests/app.test.js
@@ -1,14 +1,19 @@
-import { BotonicInputTester, BotonicOutputTester } from '@botonic/react'
+import { routes, locales, config } from '../src/'
+import {
+  BotonicInputTester,
+  BotonicOutputTester,
+  NodeApp,
+} from '@botonic/react'
 
-import App from '../src/app'
+const app = new NodeApp({ routes, locales, ...config })
 
-let i = new BotonicInputTester(App)
-let o = new BotonicOutputTester(App)
+const i = new BotonicInputTester(app)
+const o = new BotonicOutputTester(app)
 
 test('TEST: (404) NOT FOUND', async () => {
   await expect(i.text('whatever')).resolves.toBe(
     o.text(
-      'Enter the dialogflow token in integrations.js to test the bot. Try typing "hello" to start the bot.'
+      `Enter the generated JSON key for dialogflowV2 in plugins.js to test the bot. Try typing "hello" to start the bot.`
     )
   )
 })

--- a/packages/botonic-cli/templates/nlu/src/index.js
+++ b/packages/botonic-cli/templates/nlu/src/index.js
@@ -3,4 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
-export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }
+export const config = { defaultDelay: 0, defaultTyping: 0 }

--- a/packages/botonic-cli/templates/nlu/tests/app.test.js
+++ b/packages/botonic-cli/templates/nlu/tests/app.test.js
@@ -1,14 +1,17 @@
-import { BotonicInputTester, BotonicOutputTester } from '@botonic/react'
+import { routes, locales, config } from '../src/'
+import {
+  BotonicInputTester,
+  BotonicOutputTester,
+  NodeApp,
+} from '@botonic/react'
 
-import App from '../src/app'
+const app = new NodeApp({ routes, locales, ...config })
 
-let i = new BotonicInputTester(App)
-let o = new BotonicOutputTester(App)
+const i = new BotonicInputTester(app)
+const o = new BotonicOutputTester(app)
 
 test('TEST: (404) NOT FOUND', async () => {
   await expect(i.text('whatever')).resolves.toBe(
-    o.text(
-      'Enter the dialogflow token in integrations.js to test the bot. Try typing "hello" to start the bot.'
-    )
+    o.text("I don't understand you")
   )
 })

--- a/packages/botonic-cli/templates/tutorial/src/index.js
+++ b/packages/botonic-cli/templates/tutorial/src/index.js
@@ -3,4 +3,4 @@ export { locales } from './locales'
 export { plugins } from './plugins'
 export { webchat } from './webchat'
 export { webviews } from './webviews'
-export const config = { defaultDelay: 0.4, defaultTyping: 0.6 }
+export const config = { defaultDelay: 0, defaultTyping: 0 }

--- a/packages/botonic-cli/templates/tutorial/tests/app.test.js
+++ b/packages/botonic-cli/templates/tutorial/tests/app.test.js
@@ -1,9 +1,14 @@
-import { BotonicInputTester, BotonicOutputTester } from '@botonic/react'
+import { routes, plugins, locales, config } from '../src/'
+import {
+  BotonicInputTester,
+  BotonicOutputTester,
+  NodeApp,
+} from '@botonic/react'
 
-import App from '../src/app'
+const app = new NodeApp({ routes, locales, plugins, ...config })
 
-let i = new BotonicInputTester(App)
-let o = new BotonicOutputTester(App)
+const i = new BotonicInputTester(app)
+const o = new BotonicOutputTester(app)
 
 test('TEST: (404) NOT FOUND', async () => {
   await expect(i.text('whatever')).resolves.toBe(

--- a/packages/botonic-react/src/botonicTester.js
+++ b/packages/botonic-react/src/botonicTester.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
-//var decode = require('unescape')
 import decode from 'unescape'
 
 import { Text } from './components/text'


### PR DESCRIPTION
**Fixes #432** 
Fixed templates that were using old "app.js" as reported by @ericmarcos.
Changed tests for template `custom-webchat` as the test has no correspondence with the current code.