### PR TITLE
fix: fix outer-page-scrolling-bug

### DIFF
--- a/packages/botonic-react/src/utils.js
+++ b/packages/botonic-react/src/utils.js
@@ -64,3 +64,16 @@ export const _getThemeProperty = theme => (
 
 export const ConditionalWrapper = ({ condition, wrapper, children }) =>
   condition ? wrapper(children) : children
+
+export const scrollToBottom = (timeout = 100) => {
+  const botonicScrollableArea = document.getElementById(
+    'botonic-scrollable-content'
+  )
+  const frame =
+    botonicScrollableArea &&
+    botonicScrollableArea.querySelectorAll('.simplebar-content-wrapper')[0]
+  if (frame) {
+    frame.scrollTop = frame.scrollHeight
+    setTimeout(() => (frame.scrollTop = frame.scrollHeight), timeout)
+  }
+}

--- a/packages/botonic-react/src/webchat/components/styled-scrollbar.jsx
+++ b/packages/botonic-react/src/webchat/components/styled-scrollbar.jsx
@@ -2,6 +2,7 @@ import { COLORS } from '../../constants'
 import styled, { css } from 'styled-components'
 import SimpleBar from 'simplebar-react'
 import 'simplebar/dist/simplebar.css'
+import './styled-scrollbar.scss'
 
 export const StyledScrollbar = styled(SimpleBar)`
   ${props =>

--- a/packages/botonic-react/src/webchat/components/styled-scrollbar.scss
+++ b/packages/botonic-react/src/webchat/components/styled-scrollbar.scss
@@ -1,0 +1,6 @@
+#botonic-scrollable-content
+  .simplebar-mask
+  .simplebar-offset
+  .simplebar-content-wrapper {
+  scroll-behavior: smooth;
+}

--- a/packages/botonic-react/src/webchat/hooks.js
+++ b/packages/botonic-react/src/webchat/hooks.js
@@ -1,5 +1,6 @@
 import { useEffect, useReducer, useState, useRef } from 'react'
 import { WEBCHAT, COLORS } from '../constants'
+import { scrollToBottom } from '../utils'
 
 export const webchatInitialState = {
   width: WEBCHAT.DEFAULTS.WIDTH,
@@ -191,11 +192,7 @@ export function useWebchat() {
 export function useTyping({ webchatState, updateTyping, updateMessage }) {
   useEffect(() => {
     let delayTimeout, typingTimeout
-    const end = document.getElementById('messages-end')
-    if (end) {
-      end.scrollIntoView({ behavior: 'smooth' })
-      setTimeout(() => end.scrollIntoView({ behavior: 'smooth' }), 100)
-    }
+    scrollToBottom()
     try {
       const nextMsg = webchatState.messagesJSON.filter(m => !m.display)[0]
       if (nextMsg.delay && nextMsg.typing) {

--- a/packages/botonic-react/src/webchat/message-list.jsx
+++ b/packages/botonic-react/src/webchat/message-list.jsx
@@ -42,6 +42,7 @@ export const WebchatMessageList = props => {
 
   return (
     <StyledScrollbar
+      id='botonic-scrollable-content'
       scrollbar={scrollbarOptions}
       autoHide={scrollbarOptions.autoHide}
       ismessagescontainer='true'

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -32,6 +32,7 @@ import {
   staticAsset,
   _getThemeProperty,
   ConditionalWrapper,
+  scrollToBottom,
 } from '../utils'
 import { WEBCHAT, MIME_WHITELIST, COLORS } from '../constants'
 import { motion } from 'framer-motion'
@@ -191,12 +192,7 @@ export const Webchat = forwardRef((props, ref) => {
 
   useEffect(() => {
     if (!webchatState.isWebchatOpen) return
-    setTimeout(() => {
-      const end = document.getElementById('messages-end')
-      if (end) {
-        end.scrollIntoView()
-      }
-    })
+    scrollToBottom()
   }, [webchatState.isWebchatOpen])
 
   useEffect(() => {
@@ -484,7 +480,6 @@ export const Webchat = forwardRef((props, ref) => {
       messages={webchatState.messagesComponents}
     >
       {webchatState.typing && <TypingIndicator />}
-      <div id='messages-end' />
     </WebchatMessageList>
   )
   const webchatReplies = () => <WebchatReplies replies={webchatState.replies} />


### PR DESCRIPTION
As mentioned in #541 PR, I just added:
1. **Adjusting class name / id to prevent conflicts** --> Added a new class 'botonic-scrollable-content'
2. **Adding the smooth scroll CSS to this adjusted class name / ID** --> Add css overwriting default simplebar class wrapped by the new 'botonic-scrollable-content'

Now should not produce conflicts with outer pages.