### PR TITLE
Chore(dynamo/contentful)eslint on .eslintrc*.js

### DIFF
--- a/packages/botonic-cli/.eslintrc.js
+++ b/packages/botonic-cli/.eslintrc.js
@@ -1,73 +1,71 @@
 module.exports = {
-  parser: "@typescript-eslint/parser", // Specifies the ESLint parser
+  parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
-    "plugin:prettier/recommended", // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
-    "eslint:recommended",
+    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'eslint:recommended',
     // typescript
-    "plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-    "plugin:@typescript-eslint/eslint-recommended",
-    "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+    'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    'plugin:@typescript-eslint/eslint-recommended',
+    'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
   ],
-  plugins: [
-    "no-null",
-    "filenames",
-    "@typescript-eslint"
-  ],
+  plugins: ['no-null', 'filenames', '@typescript-eslint'],
   parserOptions: {
     ecmaVersion: 2017, // async is from ecma2017. Supported in node >=7.10
-    sourceType: "module", // Allows for the use of imports
+    sourceType: 'module', // Allows for the use of imports
     ecmaFeatures: {
-      jsx: true // Allows for the parsing of JSX
-    }
+      jsx: true, // Allows for the parsing of JSX
+    },
   },
-// npm run lint runs eslint with --quiet --fix so that only errors are fixed
+  // npm run lint runs eslint with --quiet --fix so that only errors are fixed
   rules: {
     // style. Soon a precommit githook will fix prettier errors
-    "prettier/prettier": "error",
-    "filenames/match-regex": ["error", "^[a-z-.]+$", true],
+    'prettier/prettier': 'error',
+    'filenames/match-regex': ['error', '^[a-z-.]+$', true],
 
     // In typescript we must use obj.field when we have the types, and obj['field'] when we don't
     // Not set to warn because Webstorm cannot fix eslint rules with --quiet https://youtrack.jetbrains.com/issue/WEB-39246
-    "dot-notation": "off",
-    "no-console" :"off",
+    'dot-notation': 'off',
+    'no-console': 'off',
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     // e.g. "@typescript-eslint/explicit-function-return-type": "off",
-    "node/no-unsupported-features/es-syntax": "off", //babel will take care of ES compatibility
-    "unicorn/no-abusive-eslint-disable" : "off",
-    "@typescript-eslint/camelcase" : "warn",
-    "consistent-return": "error",
+    'node/no-unsupported-features/es-syntax': 'off', //babel will take care of ES compatibility
+    'unicorn/no-abusive-eslint-disable': 'off',
+    '@typescript-eslint/camelcase': 'warn',
+    'consistent-return': 'error',
 
     // special for TYPESCRIPT
-    "@typescript-eslint/explicit-function-return-type": "off", // annoying for tests
-    "@typescript-eslint/explicit-member-accessibility": "off", //we think defaulting to public is a good default
-    "@typescript-eslint/no-namespace": ["error", { allowDeclarations: true }], // to encapsulate types in namespace with same name as Class
-    "@typescript-eslint/no-non-null-assertion" : "warn", // specially useful in tests, and "when you know what you're doing"
-    "@typescript-eslint/no-parameter-properties": "off", // opinionated: parameter properties make data classes shorter
+    '@typescript-eslint/explicit-function-return-type': 'off', // annoying for tests
+    '@typescript-eslint/explicit-member-accessibility': 'off', //we think defaulting to public is a good default
+    '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }], // to encapsulate types in namespace with same name as Class
+    '@typescript-eslint/no-non-null-assertion': 'warn', // specially useful in tests, and "when you know what you're doing"
+    '@typescript-eslint/no-parameter-properties': 'off', // opinionated: parameter properties make data classes shorter
     // allow public functions/classes to call private functions/classes declared below.
     // otoh, variables (typically constants) should be declared at the top
-    "@typescript-eslint/no-use-before-define": ["error", { "variables": true, "functions": false, "classes": false }],
-    "@typescript-eslint/no-useless-constructor": "warn",
-    "no-empty-pattern" : "off",
-    "no-null/no-null": "warn", // fields declared with ? are undefined, not null (be aware that React uses null)
-    "unicorn/prevent-abbreviations" : "off", // the plugin removes removes type annotations from typescript code :-(
-    "unicorn/filename-case" : "off", // React convention is in CamelCase
-    "valid-jsdoc": "off", // function comments hide code complexity (and typescript already have type specifications),
-
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      { variables: true, functions: false, classes: false },
+    ],
+    '@typescript-eslint/no-useless-constructor': 'warn',
+    'no-empty-pattern': 'off',
+    'no-null/no-null': 'warn', // fields declared with ? are undefined, not null (be aware that React uses null)
+    'unicorn/prevent-abbreviations': 'off', // the plugin removes removes type annotations from typescript code :-(
+    'unicorn/filename-case': 'off', // React convention is in CamelCase
+    'valid-jsdoc': 'off', // function comments hide code complexity (and typescript already have type specifications),
   },
-  "overrides": [
+  overrides: [
     {
-      "files": [
-        "tests/**/*.ts" // to be able to skip required fields when not used in a particular test
+      files: [
+        'tests/**/*.ts', // to be able to skip required fields when not used in a particular test
       ],
-      "rules": {
-        "@typescript-eslint/no-object-literal-type-assertion" : "off",
-      }
-    }
+      rules: {
+        '@typescript-eslint/no-object-literal-type-assertion': 'off',
+      },
+    },
   ],
   env: {
     es6: true,
     // browser/node to prevent "'console' is not defined  no-undef"
     browser: true,
-    node: true
-  }
-};
+    node: true,
+  },
+}

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -59,7 +59,7 @@
     "postinstall": "node scripts/postinstall.js",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",
-    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"
+    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' 'src/**/*.ts*'"
   },
   "types": "lib/index.d.ts"
 }

--- a/packages/botonic-cli/tsconfig.json
+++ b/packages/botonic-cli/tsconfig.json
@@ -3,5 +3,11 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "lib"
-	}
+	},
+  "include": [
+    ".eslintrc.js",
+    "babel.config.js",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
 }

--- a/packages/botonic-core/.eslintrc.js
+++ b/packages/botonic-core/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: "../.eslintrc.js"
+  extends: '../.eslintrc.js',
 }

--- a/packages/botonic-core/babel.config.js
+++ b/packages/botonic-core/babel.config.js
@@ -18,6 +18,6 @@ module.exports = {
     require('@babel/plugin-proposal-object-rest-spread'),
     require('@babel/plugin-proposal-class-properties'),
     require('babel-plugin-add-module-exports'),
-    require('@babel/plugin-transform-runtime')
-  ]
+    require('@babel/plugin-transform-runtime'),
+  ],
 }

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -7,7 +7,7 @@
     "test": "../../node_modules/.bin/jest --coverage",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_ci -- --fix",
-    "lint_ci": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.js*' '**/*.d.ts'",
+    "lint_ci": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' '*.js' 'src/**/*.js*' '**/*.d.ts'",
     "build": "rm -rf lib && babel src --out-dir lib --source-maps --copy-files"
   },
   "repository": {

--- a/packages/botonic-plugin-contentful/.eslintrc.js
+++ b/packages/botonic-plugin-contentful/.eslintrc.js
@@ -1,73 +1,71 @@
 module.exports = {
-  parser: "@typescript-eslint/parser", // Specifies the ESLint parser
+  parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
-    "plugin:prettier/recommended", // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
-    "eslint:recommended",
-    "plugin:jest/recommended",
+    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'eslint:recommended',
+    'plugin:jest/recommended',
     // typescript
-    "plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-    "plugin:@typescript-eslint/eslint-recommended",
-    "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+    'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    'plugin:@typescript-eslint/eslint-recommended',
+    'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
   ],
-  plugins: [
-    "jest",
-    "no-null",
-    "filenames",
-    "@typescript-eslint"
-  ],
+  plugins: ['jest', 'no-null', 'filenames', '@typescript-eslint'],
   parserOptions: {
     ecmaVersion: 2017, // async is from ecma2017. Supported in node >=7.10
-    sourceType: "module", // Allows for the use of imports
+    sourceType: 'module', // Allows for the use of imports
   },
-// npm run lint runs eslint with --quiet --fix so that only errors are fixed
+  // npm run lint runs eslint with --quiet --fix so that only errors are fixed
   rules: {
     // style. Soon a precommit githook will fix prettier errors
-    "prettier/prettier": "error",
-    "filenames/match-regex": ["error", "^[a-z-.]+$", true],
+    'prettier/prettier': 'error',
+    'filenames/match-regex': ['error', '^[a-z-.]+$', true],
 
     // In typescript we must use obj.field when we have the types, and obj['field'] when we don't
     // Not set to warn because Webstorm cannot fix eslint rules with --quiet https://youtrack.jetbrains.com/issue/WEB-39246
-    "dot-notation": "off",
-    "no-console" :"off",
+    'dot-notation': 'off',
+    'no-console': 'off',
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     // e.g. "@typescript-eslint/explicit-function-return-type": "off",
-    "node/no-unsupported-features/es-syntax": "off", //babel will take care of ES compatibility
-    "unicorn/no-abusive-eslint-disable" : "off",
-    "@typescript-eslint/camelcase" : "warn",
-    "consistent-return": "error",
-    "jest/no-export": "warn",
+    'node/no-unsupported-features/es-syntax': 'off', //babel will take care of ES compatibility
+    'unicorn/no-abusive-eslint-disable': 'off',
+    '@typescript-eslint/camelcase': 'warn',
+    'consistent-return': 'error',
+    'jest/no-export': 'warn',
 
     // special for TYPESCRIPT
-    "@typescript-eslint/ban-ts-ignore": "warn",
-    "@typescript-eslint/explicit-function-return-type": "off", // annoying for tests
-    "@typescript-eslint/explicit-member-accessibility": "off", //we think defaulting to public is a good default
-    "@typescript-eslint/no-empty-function": "warn",
-    "@typescript-eslint/no-namespace": ["error", { allowDeclarations: true }], // to encapsulate types in namespace with same name as Class
-    "@typescript-eslint/no-non-null-assertion" : "warn", // specially useful in tests, and "when you know what you're doing"
-    "@typescript-eslint/no-parameter-properties": "off", // opinionated: parameter properties make data classes shorter
+    '@typescript-eslint/ban-ts-ignore': 'warn',
+    '@typescript-eslint/explicit-function-return-type': 'off', // annoying for tests
+    '@typescript-eslint/explicit-member-accessibility': 'off', //we think defaulting to public is a good default
+    '@typescript-eslint/no-empty-function': 'warn',
+    '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }], // to encapsulate types in namespace with same name as Class
+    '@typescript-eslint/no-non-null-assertion': 'warn', // specially useful in tests, and "when you know what you're doing"
+    '@typescript-eslint/no-parameter-properties': 'off', // opinionated: parameter properties make data classes shorter
     // allow public functions/classes to call private functions/classes declared below.
     // otoh, variables (typically constants) should be declared at the top
-    "@typescript-eslint/no-use-before-define": ["error", { "variables": true, "functions": false, "classes": false }],
-    "@typescript-eslint/no-useless-constructor": "warn",
-    "no-empty-pattern" : "off",
-    "no-null/no-null": "warn", // fields declared with ? are undefined, not null (be aware that React uses null)
-    "unicorn/prevent-abbreviations" : "off", // the plugin removes removes type annotations from typescript code :-(
-    "unicorn/filename-case" : "off", // React convention is in CamelCase
-    "valid-jsdoc": "off", // function comments hide code complexity (and typescript already have type specifications),
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      { variables: true, functions: false, classes: false },
+    ],
+    '@typescript-eslint/no-useless-constructor': 'warn',
+    'no-empty-pattern': 'off',
+    'no-null/no-null': 'warn', // fields declared with ? are undefined, not null (be aware that React uses null)
+    'unicorn/prevent-abbreviations': 'off', // the plugin removes removes type annotations from typescript code :-(
+    'unicorn/filename-case': 'off', // React convention is in CamelCase
+    'valid-jsdoc': 'off', // function comments hide code complexity (and typescript already have type specifications),
   },
-  "overrides": [
+  overrides: [
     {
-      "files": [
-        "tests/**/*.ts" // to be able to skip required fields when not used in a particular test
+      files: [
+        'tests/**/*.ts', // to be able to skip required fields when not used in a particular test
       ],
-    }
+    },
   ],
   env: {
     jest: true,
-    "jest/globals": true,
+    'jest/globals': true,
     es6: true,
     // browser/node to prevent "'console' is not defined  no-undef"
     browser: true,
-    node: true
-  }
-};
+    node: true,
+  },
+}

--- a/packages/botonic-plugin-contentful/.eslintrc_slow.js
+++ b/packages/botonic-plugin-contentful/.eslintrc_slow.js
@@ -1,5 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const base = require('./.eslintrc');
-base.parserOptions.project = "./tests/tsconfig.json";
+base.parserOptions.project = "./tsconfig.eslint.json";
 
 base.rules["@typescript-eslint/no-floating-promises"] =  "error"; // see https://github.com/xjamundx/eslint-plugin-promise/issues/151
 base.rules["@typescript-eslint/no-misused-promises"] = "error";

--- a/packages/botonic-plugin-contentful/.eslintrc_slow.js
+++ b/packages/botonic-plugin-contentful/.eslintrc_slow.js
@@ -1,9 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const base = require('./.eslintrc');
-base.parserOptions.project = "./tsconfig.eslint.json";
+const base = require('./.eslintrc')
+base.parserOptions.project = './tsconfig.eslint.json'
 
-base.rules["@typescript-eslint/no-floating-promises"] =  "error"; // see https://github.com/xjamundx/eslint-plugin-promise/issues/151
-base.rules["@typescript-eslint/no-misused-promises"] = "error";
-base.rules["@typescript-eslint/require-await"] = "error";
+base.rules['@typescript-eslint/no-floating-promises'] = 'error' // see https://github.com/xjamundx/eslint-plugin-promise/issues/151
+base.rules['@typescript-eslint/no-misused-promises'] = 'error'
+base.rules['@typescript-eslint/require-await'] = 'error'
 
-module.exports = base;
+module.exports = base

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -5,7 +5,7 @@
     "test": "../../node_modules/.bin/jest",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core -- -c .eslintrc_slow.js",
-    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*' 'tests/**/*.ts*'",
+    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' 'src/**/*.ts*' 'tests/**/*.ts*'",
     "prepare": "node ../../preinstall.js",
     "prepublishOnly": "npm run build && npm test && npm run lint",
     "preversion": "npm run lint",

--- a/packages/botonic-plugin-contentful/tsconfig.eslint.json
+++ b/packages/botonic-plugin-contentful/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tests/tsconfig.json",
+  "include": [
+    ".eslintrc.js",
+    ".eslintrc_slow.js",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/packages/botonic-plugin-dynamodb/.eslintrc.js
+++ b/packages/botonic-plugin-dynamodb/.eslintrc.js
@@ -1,73 +1,71 @@
 module.exports = {
-  parser: "@typescript-eslint/parser", // Specifies the ESLint parser
+  parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
-    "plugin:prettier/recommended", // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
-    "eslint:recommended",
-    "plugin:jest/recommended",
+    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'eslint:recommended',
+    'plugin:jest/recommended',
     // typescript
-    "plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-    "plugin:@typescript-eslint/eslint-recommended",
-    "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+    'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    'plugin:@typescript-eslint/eslint-recommended',
+    'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
   ],
-  plugins: [
-    "jest",
-    "no-null",
-    "filenames",
-    "@typescript-eslint"
-  ],
+  plugins: ['jest', 'no-null', 'filenames', '@typescript-eslint'],
   parserOptions: {
     ecmaVersion: 2017, // async is from ecma2017. Supported in node >=7.10
-    sourceType: "module", // Allows for the use of imports
+    sourceType: 'module', // Allows for the use of imports
   },
-// npm run lint runs eslint with --quiet --fix so that only errors are fixed
+  // npm run lint runs eslint with --quiet --fix so that only errors are fixed
   rules: {
     // style. Soon a precommit githook will fix prettier errors
-    "prettier/prettier": "error",
-    "filenames/match-regex": ["error", "^[a-z-.]+$", true],
+    'prettier/prettier': 'error',
+    'filenames/match-regex': ['error', '^[a-z-.]+$', true],
 
     // In typescript we must use obj.field when we have the types, and obj['field'] when we don't
     // Not set to warn because Webstorm cannot fix eslint rules with --quiet https://youtrack.jetbrains.com/issue/WEB-39246
-    "dot-notation": "off",
-    "no-console" :"off",
+    'dot-notation': 'off',
+    'no-console': 'off',
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     // e.g. "@typescript-eslint/explicit-function-return-type": "off",
-    "node/no-unsupported-features/es-syntax": "off", //babel will take care of ES compatibility
-    "unicorn/no-abusive-eslint-disable" : "off",
-    "@typescript-eslint/camelcase" : "warn",
-    "consistent-return": "error",
-    "jest/no-export": "warn",
+    'node/no-unsupported-features/es-syntax': 'off', //babel will take care of ES compatibility
+    'unicorn/no-abusive-eslint-disable': 'off',
+    '@typescript-eslint/camelcase': 'warn',
+    'consistent-return': 'error',
+    'jest/no-export': 'warn',
 
     // special for TYPESCRIPT
-    "@typescript-eslint/ban-ts-ignore": "warn",
-    "@typescript-eslint/explicit-function-return-type": "off", // annoying for tests
-    "@typescript-eslint/explicit-member-accessibility": "off", //we think defaulting to public is a good default
-    "@typescript-eslint/no-empty-function": "warn",
-    "@typescript-eslint/no-namespace": ["error", { allowDeclarations: true }], // to encapsulate types in namespace with same name as Class
-    "@typescript-eslint/no-non-null-assertion" : "warn", // specially useful in tests, and "when you know what you're doing"
-    "@typescript-eslint/no-parameter-properties": "off", // opinionated: parameter properties make data classes shorter
+    '@typescript-eslint/ban-ts-ignore': 'warn',
+    '@typescript-eslint/explicit-function-return-type': 'off', // annoying for tests
+    '@typescript-eslint/explicit-member-accessibility': 'off', //we think defaulting to public is a good default
+    '@typescript-eslint/no-empty-function': 'warn',
+    '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }], // to encapsulate types in namespace with same name as Class
+    '@typescript-eslint/no-non-null-assertion': 'warn', // specially useful in tests, and "when you know what you're doing"
+    '@typescript-eslint/no-parameter-properties': 'off', // opinionated: parameter properties make data classes shorter
     // allow public functions/classes to call private functions/classes declared below.
     // otoh, variables (typically constants) should be declared at the top
-    "@typescript-eslint/no-use-before-define": ["error", { "variables": true, "functions": false, "classes": false }],
-    "@typescript-eslint/no-useless-constructor": "warn",
-    "no-empty-pattern" : "off",
-    "no-null/no-null": "warn", // fields declared with ? are undefined, not null (be aware that React uses null)
-    "unicorn/prevent-abbreviations" : "off", // the plugin removes removes type annotations from typescript code :-(
-    "unicorn/filename-case" : "off", // React convention is in CamelCase
-    "valid-jsdoc": "off", // function comments hide code complexity (and typescript already have type specifications),
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      { variables: true, functions: false, classes: false },
+    ],
+    '@typescript-eslint/no-useless-constructor': 'warn',
+    'no-empty-pattern': 'off',
+    'no-null/no-null': 'warn', // fields declared with ? are undefined, not null (be aware that React uses null)
+    'unicorn/prevent-abbreviations': 'off', // the plugin removes removes type annotations from typescript code :-(
+    'unicorn/filename-case': 'off', // React convention is in CamelCase
+    'valid-jsdoc': 'off', // function comments hide code complexity (and typescript already have type specifications),
   },
-  "overrides": [
+  overrides: [
     {
-      "files": [
-        "tests/**/*.ts" // to be able to skip required fields when not used in a particular test
+      files: [
+        'tests/**/*.ts', // to be able to skip required fields when not used in a particular test
       ],
-    }
+    },
   ],
   env: {
     jest: true,
-    "jest/globals": true,
+    'jest/globals': true,
     es6: true,
     // browser/node to prevent "'console' is not defined  no-undef"
     browser: true,
-    node: true
-  }
-};
+    node: true,
+  },
+}

--- a/packages/botonic-plugin-dynamodb/.eslintrc_slow.js
+++ b/packages/botonic-plugin-dynamodb/.eslintrc_slow.js
@@ -1,5 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const base = require('./.eslintrc');
-base.parserOptions.project = "./tests/tsconfig.json";
+base.parserOptions.project = "./tsconfig.eslint.json";
 
 base.rules["@typescript-eslint/no-floating-promises"] =  "error"; // see https://github.com/xjamundx/eslint-plugin-promise/issues/151
 base.rules["@typescript-eslint/no-misused-promises"] = "error";

--- a/packages/botonic-plugin-dynamodb/.eslintrc_slow.js
+++ b/packages/botonic-plugin-dynamodb/.eslintrc_slow.js
@@ -1,9 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const base = require('./.eslintrc');
-base.parserOptions.project = "./tsconfig.eslint.json";
+const base = require('./.eslintrc')
+base.parserOptions.project = './tsconfig.eslint.json'
 
-base.rules["@typescript-eslint/no-floating-promises"] =  "error"; // see https://github.com/xjamundx/eslint-plugin-promise/issues/151
-base.rules["@typescript-eslint/no-misused-promises"] = "error";
-base.rules["@typescript-eslint/require-await"] = "error";
+base.rules['@typescript-eslint/no-floating-promises'] = 'error' // see https://github.com/xjamundx/eslint-plugin-promise/issues/151
+base.rules['@typescript-eslint/no-misused-promises'] = 'error'
+base.rules['@typescript-eslint/require-await'] = 'error'
 
-module.exports = base;
+module.exports = base

--- a/packages/botonic-plugin-dynamodb/package.json
+++ b/packages/botonic-plugin-dynamodb/package.json
@@ -5,7 +5,7 @@
     "test": "../../node_modules/.bin/jest",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core -- -c .eslintrc_slow.js",
-    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*' 'tests/**/*.ts*'",
+    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' 'src/**/*.ts*' 'tests/**/*.ts*'",
     "prepare": "node ../../preinstall.js",
     "prepublishOnly": "npm run build && npm test && npm run lint",
     "preversion": "npm run lint",

--- a/packages/botonic-plugin-dynamodb/tsconfig.eslint.json
+++ b/packages/botonic-plugin-dynamodb/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tests/tsconfig.json",
+  "include": [
+    ".eslintrc.js",
+    ".eslintrc_slow.js",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/packages/botonic-react/.eslintrc.js
+++ b/packages/botonic-react/.eslintrc.js
@@ -1,20 +1,20 @@
 module.exports = {
   extends: [
-    "../.eslintrc.js",
-    "plugin:react/recommended", // Uses the recommended rules from @eslint-plugin-react
+    '../.eslintrc.js',
+    'plugin:react/recommended', // Uses the recommended rules from @eslint-plugin-react
   ],
   parserOptions: {
     ecmaFeatures: {
-      jsx: true // Allows for the parsing of JSX
-    }
+      jsx: true, // Allows for the parsing of JSX
+    },
   },
   rules: {
     // REACT
-    "react/prop-types": ["error", { skipUndeclared: true }],
+    'react/prop-types': ['error', { skipUndeclared: true }],
   },
   settings: {
     react: {
-      version: "detect" // Tells eslint-plugin-react to automatically detect the version of React to use
-    }
+      version: 'detect', // Tells eslint-plugin-react to automatically detect the version of React to use
+    },
   },
-};
+}

--- a/packages/botonic-react/babel.config.js
+++ b/packages/botonic-react/babel.config.js
@@ -18,6 +18,6 @@ module.exports = {
     require('@babel/plugin-proposal-object-rest-spread'),
     require('@babel/plugin-proposal-class-properties'),
     require('babel-plugin-add-module-exports'),
-    require('@babel/plugin-transform-runtime')
-  ]
+    require('@babel/plugin-transform-runtime'),
+  ],
 }

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -9,7 +9,7 @@
     "build": "rm -rf lib && babel src --out-dir lib --source-maps --copy-files",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",
-    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.js*' '**/*.d.ts' 'tests/**/*.js' 'tests/**/*.jsx'"
+    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' '*.js' 'src/**/*.js*' '**/*.d.ts' 'tests/**/*.js' 'tests/**/*.jsx'"
   },
   "sideEffects": [
     "*.(scss|css)"


### PR DESCRIPTION
.eslintrc*.js were not being formatted by prettier.
Split in 2 commits because an extra tsconfig file is required to avoid an eslint error when specifying the eslintsrc files to test in the eslint command with wildcards https://github.com/typescript-eslint/typescript-eslint/issues/967#issuecomment-531817014