### PR TITLE
refactor: rename 'whatsappnew' to 'whatsapp'

### DIFF
--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -266,7 +266,7 @@ Uploading...
   async displayProviders(providers: any) {
     console.log('Your bot is published on:')
     providers.map((p: any) => {
-      if (p.provider === 'whatsappnew')
+      if (p.provider === 'whatsapp')
         console.log(`💬  [whatsapp] https://wa.me/${p.username}`)
       if (p.provider === 'facebook')
         console.log(`💬  [facebook] https://m.me/${p.username}`)

--- a/packages/botonic-core/src/constants.js
+++ b/packages/botonic-core/src/constants.js
@@ -9,7 +9,6 @@ export const Providers = Object.freeze({
     WHATSAPP: 'whatsapp',
     SMOOCH: 'smooch',
     SMOOCH_WEB: 'smooch_web',
-    WHATSAPPNEW: 'whatsappnew',
     IMBEE: 'imbee',
     WEBCHAT: 'webchat',
   },

--- a/packages/botonic-react/src/components/multichannel/multichannel-utils.js
+++ b/packages/botonic-react/src/components/multichannel/multichannel-utils.js
@@ -44,4 +44,4 @@ export function getMultichannelReplies(node) {
 export const isWhatsapp = context =>
   context.session &&
   context.session.user &&
-  context.session.user.provider == Providers.Messaging.WHATSAPPNEW
+  context.session.user.provider == Providers.Messaging.WHATSAPP

--- a/packages/botonic-react/src/webview.jsx
+++ b/packages/botonic-react/src/webview.jsx
@@ -41,7 +41,7 @@ class App extends React.Component {
         console.log(e)
       }
     }
-    if (this.state.session.user.provider === 'whatsappnew') {
+    if (this.state.session.user.provider === 'whatsapp') {
       location.href = 'https://wa.me/' + this.state.session.user.imp_id
     } else {
       try {

--- a/packages/botonic-react/tests/helpers/test-utils.jsx
+++ b/packages/botonic-react/tests/helpers/test-utils.jsx
@@ -24,5 +24,5 @@ export function withRequestContext(node, context = {}) {
 
 export const whatsappRenderer = sut =>
   TestRenderer.create(
-    withRequestContext(sut, { session: { user: { provider: 'whatsappnew' } } })
+    withRequestContext(sut, { session: { user: { provider: 'whatsapp' } } })
   )


### PR DESCRIPTION
Hubtype API has changed the name of the Official Whatsapp Business API provider, from "whatsappnew" to "whatsapp". Updating the parts of botonic that are affected by this change.