### PR TITLE
Contentful/test timeout and error improvements

### DIFF
--- a/packages/botonic-plugin-contentful/jest.config.js
+++ b/packages/botonic-plugin-contentful/jest.config.js
@@ -22,6 +22,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/tests/__mocks__/fileMock.js',
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
-  }
-};
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  testEnvironment: 'node',
+}

--- a/packages/botonic-plugin-contentful/jest.setup.js
+++ b/packages/botonic-plugin-contentful/jest.setup.js
@@ -1,2 +1,7 @@
+// When running all tests, the test which modify contentful contents may cause
+// contention on the other tests (due to the sleep while retrying?)
+// That's why we need such a large default timeout
+// In the future we should run independently integration and unit tests
+jest.setTimeout(15000)
 // uncomment to extend jest test timeout while debugging from IDE
 // jest.setTimeout(3000000)

--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -173,13 +173,15 @@ export class ContentfulExceptionWrapper {
       content += ` with id '${contentId}'`
     }
     const msg = `Error calling ${this.wrappee}.${method}${content}.`
+    const exception = new CmsException(msg, contentfulError)
     if (this.logErrors) {
-      // eslint-disable-next-line no-console
-      console.error(msg, contentfulError.toString())
+      if (this.logStack) {
+        console.error(exception)
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(exception.toString())
+      }
     }
-    if (this.logStack) {
-      console.error(msg, contentfulError.stack || 'No callstack')
-    }
-    throw new CmsException(msg, contentfulError)
+    throw exception
   }
 }

--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -156,7 +156,7 @@ export class ContentfulExceptionWrapper {
   constructor(
     readonly wrappee: string,
     readonly logErrors = true,
-    readonly logStack = false
+    readonly logStack = true
   ) {}
 
   wrap(

--- a/packages/botonic-plugin-contentful/src/cms/exceptions.ts
+++ b/packages/botonic-plugin-contentful/src/cms/exceptions.ts
@@ -3,7 +3,15 @@ export class CmsException extends Error {
    * @param msg description of the problem
    * @param reason what caused the exception (normally a low level exception)
    */
-  constructor(msg: string, readonly reason?: any) {
-    super(msg)
+  constructor(message: string, readonly reason?: any) {
+    super(message)
+  }
+
+  toString(): string {
+    if (!this.reason) {
+      return this.message
+    }
+    const reason = this.reason.message || String(this.reason)
+    return `${this.message} due to: ${reason}`
   }
 }

--- a/packages/botonic-plugin-contentful/src/cms/exceptions.ts
+++ b/packages/botonic-plugin-contentful/src/cms/exceptions.ts
@@ -1,17 +1,23 @@
 export class CmsException extends Error {
   /**
-   * @param msg description of the problem
+   * @param message description of the problem
    * @param reason what caused the exception (normally a low level exception)
    */
   constructor(message: string, readonly reason?: any) {
-    super(message)
+    super(CmsException.mergeMessages(message, reason))
   }
 
-  toString(): string {
-    if (!this.reason) {
-      return this.message
+  /**
+   * Reason's string is merged into message because many tools (eg. jest)
+   * only report Error.message and not Error.toString()
+   */
+  private static mergeMessages(
+    message: string,
+    reason: any | undefined
+  ): string {
+    if (!reason) {
+      return message
     }
-    const reason = this.reason.message || String(this.reason)
-    return `${this.message} due to: ${reason}`
+    return `${message} due to: ${reason.message || String(reason)}`
   }
 }

--- a/packages/botonic-plugin-contentful/src/contentful/manage/manage-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/manage/manage-contentful.ts
@@ -75,9 +75,10 @@ export class ManageContentful implements ManageCms {
       )
     }
     if (!context.allowOverwrites) {
-      if (entry.fields[field.cmsName][context.locale]) {
+      const value = entry.fields[field.cmsName][context.locale]
+      if (value) {
         throw new CmsException(
-          `Cannot overwrite field ${field.cmsName} of entry ${entry.sys.id} because ManageContext.allowOverwrites is enabled`
+          `Cannot overwrite field $'{field.cmsName}' of entry '${entry.sys.id}' (has value '${value}) because ManageContext.allowOverwrites is false`
         )
       }
     }

--- a/packages/botonic-plugin-contentful/src/contentful/manage/manage-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/manage/manage-contentful.ts
@@ -78,7 +78,7 @@ export class ManageContentful implements ManageCms {
       const value = entry.fields[field.cmsName][context.locale]
       if (value) {
         throw new CmsException(
-          `Cannot overwrite field $'{field.cmsName}' of entry '${entry.sys.id}' (has value '${value}) because ManageContext.allowOverwrites is false`
+          `Cannot overwrite field '${field.cmsName}' of entry '${entry.sys.id}' (has value '${value}') because ManageContext.allowOverwrites is false`
         )
       }
     }

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
@@ -4,6 +4,10 @@ import { ContentId } from '../cms'
 import * as nlp from '../nlp'
 import { ContentFieldType } from './fields'
 
+/**
+ * Take into account that if you request a content immediately after updating it
+ * you might get the old version
+ */
 export interface ManageCms {
   updateField<T extends cms.Content>(
     context: ManageContext,

--- a/packages/botonic-plugin-contentful/src/util/backoff.ts
+++ b/packages/botonic-plugin-contentful/src/util/backoff.ts
@@ -1,0 +1,34 @@
+export function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export interface Backoff {
+  backoff(): Promise<void>
+}
+
+export class ExponentialBackoff implements Backoff {
+  constructor(private startMs = 10, private times = 10) {}
+  async backoff(): Promise<void> {
+    if (this.times <= 0) {
+      throw new Error('Aborting exponential backoff')
+    }
+    await sleep(this.startMs)
+    this.startMs *= 2
+    this.times++
+  }
+}
+
+export async function repeatWithBackoff<T>(
+  func: () => Promise<T>,
+  backoff = new ExponentialBackoff(),
+  logger: (msg: string) => void = console.log
+): Promise<T> {
+  for (;;) {
+    try {
+      return await func()
+    } catch (e) {
+      logger(`Retrying after exception at ${new Date()}: ${String(e)}`)
+      await backoff.backoff()
+    }
+  }
+}

--- a/packages/botonic-plugin-contentful/tests/cms/cms-error.test.ts
+++ b/packages/botonic-plugin-contentful/tests/cms/cms-error.test.ts
@@ -7,7 +7,6 @@ test('TEST: ErrorReportingCMS integration test', async () => {
   const sut = new ErrorReportingCMS(contentful)
   expect.assertions(1)
   await sut.text('invalid_id').catch(error => {
-    console.log('in!')
     expect(error).toBeInstanceOf(CmsException)
   })
 })

--- a/packages/botonic-plugin-contentful/tests/cms/exceptions.test.ts
+++ b/packages/botonic-plugin-contentful/tests/cms/exceptions.test.ts
@@ -9,7 +9,9 @@ describe('CMSException', () => {
     'TEST: CMSException',
     (msg: string, reason: any, expectedToString: string) => {
       const sut = new CmsException(msg, reason)
-      expect(sut.toString()).toEqual(expectedToString)
+      expect(sut.message).toEqual(expectedToString)
+      expect(sut.toString()).toEqual(`Error: ${expectedToString}`)
+      expect(String(sut)).toEqual(`Error: ${expectedToString}`)
     }
   )
 })

--- a/packages/botonic-plugin-contentful/tests/cms/exceptions.test.ts
+++ b/packages/botonic-plugin-contentful/tests/cms/exceptions.test.ts
@@ -1,0 +1,15 @@
+import { CmsException } from '../../src/cms'
+
+describe('CMSException', () => {
+  test.each([
+    ['msg1', new Error('cause error'), 'msg1 due to: cause error'],
+    ['msg1', 'non-Error exception', 'msg1 due to: non-Error exception'],
+    ['msg1', undefined, 'msg1'],
+  ])(
+    'TEST: CMSException',
+    (msg: string, reason: any, expectedToString: string) => {
+      const sut = new CmsException(msg, reason)
+      expect(sut.toString()).toEqual(expectedToString)
+    }
+  )
+})

--- a/packages/botonic-plugin-contentful/tests/contentful/ignore-fallback-decorator.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/ignore-fallback-decorator.test.ts
@@ -81,7 +81,7 @@ test.each<any>([ENGLISH, SPANISH])(
       }
     }
   },
-  10000
+  20000
 )
 
 test('TEST: IgnoreFallbackDecorator.getEntry<TextFields> uses fallback locale', async () => {

--- a/packages/botonic-plugin-contentful/tests/contentful/keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/keywords.test.ts
@@ -34,4 +34,4 @@ test('TEST: contentful contentsWithKeywords', async () => {
     "can't find my order",
     'where is my order',
   ])
-})
+}, 10000)

--- a/packages/botonic-plugin-contentful/tests/tools/translators/csv-export.test.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/translators/csv-export.test.ts
@@ -17,7 +17,7 @@ test('TEST: CsvExport integration test', async () => {
   // running for ENGLISH to test contents with empty fields
   const from = ENGLISH
   await exporter.write(`/tmp/contentful_${from}.csv`, cms, from)
-}, 10000)
+}, 30000)
 
 test('TEST: ContentToCsvLines.getCsvLines Text', () => {
   const exporter = new ContentToCsvLines({})

--- a/packages/botonic-plugin-contentful/tests/tools/translators/csv-import.test.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/translators/csv-import.test.ts
@@ -13,6 +13,7 @@ import { ManageCms } from '../../../src/manage-cms/manage-cms'
 import { ContentFieldType } from '../../../src/manage-cms/fields'
 import { ManageContext } from '../../../src/manage-cms/manage-context'
 import { ContentId } from '../../../src/cms'
+import { repeatWithBackoff } from '../../../src/util/backoff'
 
 const TEST_CSV_IMPORT_ID = '3LOUB5Udmxw7rh87G5Ob9b'
 const FIXTURES_BASE = path.resolve(__dirname, '__fixtures__')
@@ -21,116 +22,117 @@ function ctxt(ctx: Partial<ManageContext>): ManageContext {
   return { ...ctx, preview: false } as ManageContext
 }
 
-describe('ManageContentful', () => {
-  test('TEST: CsvImport read text & carousel', async () => {
-    const mockFieldImporter = mock<StringFieldImporter>()
-    const readLines: Record[] = []
-    when(mockFieldImporter.consume(anything())).thenCall((record: Record) => {
-      console.log(record.Code, record.Field, record.to)
-      readLines.push(record)
-    })
-    const importer = new CsvImport(instance(mockFieldImporter))
-    // running for ENGLISH to test contents with empty fields
-    await importer.import(`${FIXTURES_BASE}/contentful_es-pl.csv`)
-    expect(readLines.length).toEqual(3)
-    expect(readLines[0]).toEqual({
-      Model: 'text',
-      Code: 'POST_FAQ1',
-      Id: 'id1',
-      Field: ContentFieldType.SHORT_TEXT,
-      from: 'from',
-      to: 'válor1',
-    } as Record)
-    expect(readLines[1]).toEqual({
-      Model: 'text',
-      Code: 'POST_FAQ1',
-      Id: 'id1',
-      Field: ContentFieldType.KEYWORDS,
-      from: 'from',
-      to: 'kw1;hola,amigo',
-    } as Record)
-    expect(readLines[2]).toEqual({
-      Model: 'carousel',
-      Code: 'POST_FAQ2',
-      Id: 'id2',
-      Field: ContentFieldType.TEXT,
-      from: 'from',
-      to: 'válor2',
-    } as Record)
-  }, 10000)
+test('TEST: CsvImport read text & carousel', async () => {
+  const mockFieldImporter = mock<StringFieldImporter>()
+  const readLines: Record[] = []
+  when(mockFieldImporter.consume(anything())).thenCall((record: Record) => {
+    console.log(record.Code, record.Field, record.to)
+    readLines.push(record)
+  })
+  const importer = new CsvImport(instance(mockFieldImporter))
+  // running for ENGLISH to test contents with empty fields
+  await importer.import(`${FIXTURES_BASE}/contentful_es-pl.csv`)
+  expect(readLines.length).toEqual(3)
+  expect(readLines[0]).toEqual({
+    Model: 'text',
+    Code: 'POST_FAQ1',
+    Id: 'id1',
+    Field: ContentFieldType.SHORT_TEXT,
+    from: 'from',
+    to: 'válor1',
+  } as Record)
+  expect(readLines[1]).toEqual({
+    Model: 'text',
+    Code: 'POST_FAQ1',
+    Id: 'id1',
+    Field: ContentFieldType.KEYWORDS,
+    from: 'from',
+    to: 'kw1;hola,amigo',
+  } as Record)
+  expect(readLines[2]).toEqual({
+    Model: 'carousel',
+    Code: 'POST_FAQ2',
+    Id: 'id2',
+    Field: ContentFieldType.TEXT,
+    from: 'from',
+    to: 'válor2',
+  } as Record)
+}, 10000)
 
-  test('TEST: StringFieldImporter test', async () => {
-    // using manual mock because mockito was not recognizing the call. maybe because method returns Promise to void?
-    class MockCms implements ManageCms {
-      numCalls = 0
+test('TEST: StringFieldImporter test', async () => {
+  // using manual mock because mockito was not recognizing the call. maybe because method returns Promise to void?
+  class MockCms implements ManageCms {
+    numCalls = 0
 
-      copyField<T extends cms.Content>(
-        context: ManageContext,
-        contentId: cms.ContentId,
-        field: ContentFieldType,
-        fromLocale: string
-      ): Promise<void> {
-        fail("sholdn't be called")
-      }
-
-      updateField<T extends cms.Content>(
-        context: ManageContext,
-        contentId: ContentId,
-        fieldType: ContentFieldType,
-        value: any
-      ): Promise<void> {
-        this.numCalls++
-        expect(context).toEqual(ctxt({ locale: SPANISH }))
-        expect(contentId).toEqual(
-          new cms.ContentId(cms.ContentType.TEXT, TEST_CSV_IMPORT_ID)
-        )
-        expect(fieldType).toEqual(ContentFieldType.KEYWORDS)
-        expect(value).toEqual(['kw1', 'hola, amigo'])
-        return Promise.resolve()
-      }
+    copyField<T extends cms.Content>(
+      context: ManageContext,
+      contentId: cms.ContentId,
+      field: ContentFieldType,
+      fromLocale: string
+    ): Promise<void> {
+      fail("sholdn't be called")
     }
 
-    const mock = new MockCms()
-    const sut = new StringFieldImporter(mock, ctxt({ locale: SPANISH }))
+    updateField<T extends cms.Content>(
+      context: ManageContext,
+      contentId: ContentId,
+      fieldType: ContentFieldType,
+      value: any
+    ): Promise<void> {
+      this.numCalls++
+      expect(context).toEqual(ctxt({ locale: SPANISH }))
+      expect(contentId).toEqual(
+        new cms.ContentId(cms.ContentType.TEXT, TEST_CSV_IMPORT_ID)
+      )
+      expect(fieldType).toEqual(ContentFieldType.KEYWORDS)
+      expect(value).toEqual(['kw1', 'hola, amigo'])
+      return Promise.resolve()
+    }
+  }
+
+  const mock = new MockCms()
+  const sut = new StringFieldImporter(mock, ctxt({ locale: SPANISH }))
+  await sut.consume({
+    Model: 'text',
+    Code: 'POST_FAQ1',
+    Id: TEST_CSV_IMPORT_ID,
+    Field: ContentFieldType.KEYWORDS,
+    from: 'from',
+    to: ' kw1;hola, amigo ',
+  } as Record)
+
+  expect(mock.numCalls).toEqual(1)
+}, 10000)
+
+// Since the test modifies contentful contents, it might fail if executed
+// more than once simultaneously (eg from 2 different branches from CI)
+test('TEST: StringFieldImporter integration test', async () => {
+  const manageCms = testManageContentful()
+  try {
+    const sut = new StringFieldImporter(manageCms, ctxt({ locale: SPANISH }))
     await sut.consume({
       Model: 'text',
       Code: 'POST_FAQ1',
       Id: TEST_CSV_IMPORT_ID,
       Field: ContentFieldType.KEYWORDS,
       from: 'from',
-      to: ' kw1;hola, amigo ',
+      to: 'kw1; kw2 ',
     } as Record)
-
-    expect(mock.numCalls).toEqual(1)
-  }, 10000)
-
-  test('TEST: StringFieldImporter integration test', async () => {
-    const manageCms = testManageContentful()
-    try {
-      const sut = new StringFieldImporter(manageCms, ctxt({ locale: SPANISH }))
-      await sut.consume({
-        Model: 'text',
-        Code: 'POST_FAQ1',
-        Id: TEST_CSV_IMPORT_ID,
-        Field: ContentFieldType.KEYWORDS,
-        from: 'from',
-        to: 'kw1; kw2 ',
-      } as Record)
+    await repeatWithBackoff(async () => {
       expect(
         (await testContentful().text(TEST_CSV_IMPORT_ID, { locale: SPANISH }))
           .common.keywords
       ).toEqual(['kw1', 'kw2'])
-    } finally {
-      console.log('restoring')
-      await manageCms.updateField(
-        ctxt({
-          locale: SPANISH,
-          allowOverwrites: true,
-        }),
-        new cms.ContentId(cms.ContentType.TEXT, TEST_CSV_IMPORT_ID),
-        ContentFieldType.KEYWORDS,
-        undefined
-      )
-    }
-  }, 10000)
-})
+    })
+  } finally {
+    await manageCms.updateField(
+      ctxt({
+        locale: SPANISH,
+        allowOverwrites: true,
+      }),
+      new cms.ContentId(cms.ContentType.TEXT, TEST_CSV_IMPORT_ID),
+      ContentFieldType.KEYWORDS,
+      undefined
+    )
+  }
+}, 40000)

--- a/packages/botonic-plugin-contentful/tests/tools/translators/csv-import.test.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/translators/csv-import.test.ts
@@ -26,7 +26,6 @@ test('TEST: CsvImport read text & carousel', async () => {
   const mockFieldImporter = mock<StringFieldImporter>()
   const readLines: Record[] = []
   when(mockFieldImporter.consume(anything())).thenCall((record: Record) => {
-    console.log(record.Code, record.Field, record.to)
     readLines.push(record)
   })
   const importer = new CsvImport(instance(mockFieldImporter))

--- a/packages/botonic-plugin-contentful/tests/util/backoff.test.ts
+++ b/packages/botonic-plugin-contentful/tests/util/backoff.test.ts
@@ -1,0 +1,27 @@
+import { ExponentialBackoff, repeatWithBackoff } from '../../src/util/backoff'
+
+test('TEST: repeatWithBackoff', async () => {
+  let counter = 0
+  const NUM_FAILURES = 4
+  let loggerCount = 0
+  const logger = (msg: string) => {
+    loggerCount++
+  }
+
+  // act
+  await repeatWithBackoff(
+    () => {
+      counter++
+      if (counter <= NUM_FAILURES) {
+        throw new Error('forced error')
+      }
+      return Promise.resolve()
+    },
+    new ExponentialBackoff(),
+    logger
+  )
+
+  // assert
+  expect(counter).toEqual(NUM_FAILURES + 1)
+  expect(loggerCount).toEqual(NUM_FAILURES)
+})

--- a/packages/botonic-plugin-dynamodb/jest.config.js
+++ b/packages/botonic-plugin-dynamodb/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/tests/__mocks__/fileMock.js',
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
-  }
-};
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  testEnvironment: 'node',
+}


### PR DESCRIPTION
### Description
* Improve message in exceptions raised by contentful plugin
* Extend timeouts
* Wait for contentful.com content is updated before checking the new value
* Exponential backoff class 

### Context
Contentful tests which modify contents on contentful.com sometimes failed
because we we're checking the updated value before their CDN updated the new
version
