### PR TITLE
fix: fix 'covid-19' tokenization in Portuguese & fix pre-commit

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -155,508 +155,508 @@
       }
     },
     "@nlpjs/builtin-duckling": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-duckling/-/builtin-duckling-4.1.4.tgz",
-      "integrity": "sha512-NO8GD7u2NgnrupErM+WU98vwsKh92GldnOCtfI9jnglnOm1XoSGzNGwiTD6bonv3FIlqX8uTzI9XA8umQT47LQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-duckling/-/builtin-duckling-4.3.0.tgz",
+      "integrity": "sha512-TJ4OU1ZQE2MvjwTuIInqJg/+4zpryO8XyhNumorXpjoWtjp7Oi6eqN9Rn52mS2RMSRYAnlzZ/ncn3wzlFsNWzw==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/builtin-microsoft": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-microsoft/-/builtin-microsoft-4.1.4.tgz",
-      "integrity": "sha512-yJUhwDiBK8i5xMAXcU3GswN6e31x5QF4FmxktungtZdjzTgk/dvlWnGpdVbxdcbUlQHI0JLrYSYaiOKpcb7tpw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-microsoft/-/builtin-microsoft-4.3.0.tgz",
+      "integrity": "sha512-sytVSgR55Yjmag7aCkvel9jSBrhWpRiKXT/yFgs+hmaKL+09x89Tkboe35pq8WW5QRSu7MBeEhM5lCUt0RTGMg==",
       "requires": {
         "@microsoft/recognizers-text-suite": "1.1.4",
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/core": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core/-/core-4.1.4.tgz",
-      "integrity": "sha512-iOH+w84glw3GXnthNxsLKi+MYACb3GdFIBS8uHQIvhd8uo2WjMvr3AI1x3zsi2gPZEfVB/cHyZ6xAs/NnvYRjA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/core/-/core-4.3.0.tgz",
+      "integrity": "sha512-RI81kZMl7Z4TigCaq2rmZSejMRY7YWTGrPfmxIMC+Q9VQZ0Hkl3OqP9OqMI4fCMS45mCEBqzswpmY1Y0lFB6SQ=="
     },
     "@nlpjs/core-loader": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core-loader/-/core-loader-4.2.1.tgz",
-      "integrity": "sha512-mvQwlDuF9m5CsKlGS61+VY89yJDt7f/kEpURafuLpFduWiG/k8ygyx32Scpog7Y7kVr2VPjz2uj9BMG54Wx/vw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/core-loader/-/core-loader-4.3.0.tgz",
+      "integrity": "sha512-zkZS3YtABLNLbpHYAHjm4lUrAFU9E8cbjhGRJtPKP9fgz7tQtATym5xaUK+3m0tNwxNbTXhwa2EUGltZp0e+PA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4",
-        "@nlpjs/request": "^4.1.0"
+        "@nlpjs/core": "^4.3.0",
+        "@nlpjs/request": "^4.3.0"
       }
     },
     "@nlpjs/emoji": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/emoji/-/emoji-4.1.4.tgz",
-      "integrity": "sha512-1w9Vteqeec+Xe+LlgmMXZnqF5bTt+tRivJrjTlXjyFmHBpJtx/Z6qYDYt7Os8xyaVp5FXUsEdmrwiBLidGqPEw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/emoji/-/emoji-4.3.0.tgz",
+      "integrity": "sha512-IWmYMpT+xmTWFhnTYhpnRl4e4/siLABUn280lr/LUeCSMwB6M1uQj+PS1Tjnmv3SeBBsyNxrao4IYZ1lJiTlVA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/evaluator": {
-      "version": "4.0.0-rc.19",
-      "resolved": "https://registry.npmjs.org/@nlpjs/evaluator/-/evaluator-4.0.0-rc.19.tgz",
-      "integrity": "sha512-A0Fi/kw3NwWaD10nEzdUTP+KRm0ZMKJdaitt58fMcUnjkHxeB8FPCHEHKkYcbZAWbcA+T8TQVDUy7vTMjI6/8Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/evaluator/-/evaluator-4.3.0.tgz",
+      "integrity": "sha512-zjUCNyasDzagfVH5Qd873tpLA3KaZ1t+TIXJbKmlIpDuJBI4FF6BuB/6eN6rF5zCyGy4aqiz2TGpk7HRqkoPwg==",
       "requires": {
         "escodegen": "^1.12.0",
         "esprima": "^4.0.1"
       }
     },
     "@nlpjs/lang-all": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.2.1.tgz",
-      "integrity": "sha512-0p8iuVBj4f/gJIMjXxvELdyeAskFPjxJzmeT1PgOLwuwcOUa9iuoL0ZTCsHVZA0jUjRJObuaBgPPgv/vVg0aeQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.3.0.tgz",
+      "integrity": "sha512-If/4XiA8nEVIfAmNAXQMGtFudCsW3UiQxve9aIzUWbZoykGpJEWpRWcNslMgF0n1IW2a8wyuCbRY05O7EMMjHg==",
       "requires": {
-        "@nlpjs/core": "^4.1.4",
-        "@nlpjs/lang-ar": "^4.1.4",
-        "@nlpjs/lang-bn": "^4.1.4",
-        "@nlpjs/lang-ca": "^4.1.4",
-        "@nlpjs/lang-cs": "^4.1.4",
-        "@nlpjs/lang-da": "^4.1.4",
-        "@nlpjs/lang-de": "^4.1.4",
-        "@nlpjs/lang-el": "^4.1.4",
-        "@nlpjs/lang-en": "^4.1.4",
-        "@nlpjs/lang-es": "^4.1.4",
-        "@nlpjs/lang-eu": "^4.1.4",
-        "@nlpjs/lang-fa": "^4.1.4",
-        "@nlpjs/lang-fi": "^4.1.4",
-        "@nlpjs/lang-fr": "^4.1.4",
-        "@nlpjs/lang-ga": "^4.1.4",
-        "@nlpjs/lang-gl": "^4.1.4",
-        "@nlpjs/lang-hi": "^4.1.4",
-        "@nlpjs/lang-hu": "^4.1.4",
-        "@nlpjs/lang-hy": "^4.1.4",
-        "@nlpjs/lang-id": "^4.2.0",
-        "@nlpjs/lang-it": "^4.1.4",
-        "@nlpjs/lang-ja": "^4.1.4",
-        "@nlpjs/lang-ko": "^4.2.1",
-        "@nlpjs/lang-lt": "^4.1.4",
-        "@nlpjs/lang-ms": "^4.2.0",
-        "@nlpjs/lang-ne": "^4.1.4",
-        "@nlpjs/lang-nl": "^4.1.4",
-        "@nlpjs/lang-no": "^4.1.4",
-        "@nlpjs/lang-pl": "^4.1.4",
-        "@nlpjs/lang-pt": "^4.1.4",
-        "@nlpjs/lang-ro": "^4.1.4",
-        "@nlpjs/lang-ru": "^4.1.4",
-        "@nlpjs/lang-sl": "^4.1.4",
-        "@nlpjs/lang-sr": "^4.1.4",
-        "@nlpjs/lang-sv": "^4.1.4",
-        "@nlpjs/lang-ta": "^4.1.4",
-        "@nlpjs/lang-th": "^4.1.4",
-        "@nlpjs/lang-tl": "^4.1.4",
-        "@nlpjs/lang-tr": "^4.1.4",
-        "@nlpjs/lang-uk": "^4.1.4",
-        "@nlpjs/lang-zh": "^4.2.1"
+        "@nlpjs/core": "^4.3.0",
+        "@nlpjs/lang-ar": "^4.3.0",
+        "@nlpjs/lang-bn": "^4.3.0",
+        "@nlpjs/lang-ca": "^4.3.0",
+        "@nlpjs/lang-cs": "^4.3.0",
+        "@nlpjs/lang-da": "^4.3.0",
+        "@nlpjs/lang-de": "^4.3.0",
+        "@nlpjs/lang-el": "^4.3.0",
+        "@nlpjs/lang-en": "^4.3.0",
+        "@nlpjs/lang-es": "^4.3.0",
+        "@nlpjs/lang-eu": "^4.3.0",
+        "@nlpjs/lang-fa": "^4.3.0",
+        "@nlpjs/lang-fi": "^4.3.0",
+        "@nlpjs/lang-fr": "^4.3.0",
+        "@nlpjs/lang-ga": "^4.3.0",
+        "@nlpjs/lang-gl": "^4.3.0",
+        "@nlpjs/lang-hi": "^4.3.0",
+        "@nlpjs/lang-hu": "^4.3.0",
+        "@nlpjs/lang-hy": "^4.3.0",
+        "@nlpjs/lang-id": "^4.3.0",
+        "@nlpjs/lang-it": "^4.3.0",
+        "@nlpjs/lang-ja": "^4.3.0",
+        "@nlpjs/lang-ko": "^4.3.0",
+        "@nlpjs/lang-lt": "^4.3.0",
+        "@nlpjs/lang-ms": "^4.3.0",
+        "@nlpjs/lang-ne": "^4.3.0",
+        "@nlpjs/lang-nl": "^4.3.0",
+        "@nlpjs/lang-no": "^4.3.0",
+        "@nlpjs/lang-pl": "^4.3.0",
+        "@nlpjs/lang-pt": "^4.3.0",
+        "@nlpjs/lang-ro": "^4.3.0",
+        "@nlpjs/lang-ru": "^4.3.0",
+        "@nlpjs/lang-sl": "^4.3.0",
+        "@nlpjs/lang-sr": "^4.3.0",
+        "@nlpjs/lang-sv": "^4.3.0",
+        "@nlpjs/lang-ta": "^4.3.0",
+        "@nlpjs/lang-th": "^4.3.0",
+        "@nlpjs/lang-tl": "^4.3.0",
+        "@nlpjs/lang-tr": "^4.3.0",
+        "@nlpjs/lang-uk": "^4.3.0",
+        "@nlpjs/lang-zh": "^4.3.0"
       }
     },
     "@nlpjs/lang-ar": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ar/-/lang-ar-4.1.4.tgz",
-      "integrity": "sha512-Y+EXBMw4rIcKf0L51dr6nwZEa6AN+NpnkDpoRQr+hy6RQwY/DKKG0i3QMfqXKKKjELHCHFyXhlBtO4gdhwMs8g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ar/-/lang-ar-4.3.0.tgz",
+      "integrity": "sha512-t0to0+DHlUL5EPd8El0a9MnEtzQxqtLodIVP3F3ABs1kOyqEOUhUhFyTpz395kaFt6EvpGgpaLJdrNePHnqGoA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-bn": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.1.4.tgz",
-      "integrity": "sha512-oBT5YfOj1+w0WSNWkMBaxRzSEXsETRP+PdfgzQwB1ZH9L6r6XeAs14proqXcZOv0sZ5bXM6x+TvqYm905+QwEw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.3.0.tgz",
+      "integrity": "sha512-rTRzEDFLU53ffen4uBMS/CcGuTGzvbWxaGnfrN4H5kyXEC60dHBSmZBbGAPnmbVJSiDXCY2FSKuzcWXCck/yvA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-ca": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ca/-/lang-ca-4.1.4.tgz",
-      "integrity": "sha512-NOgS1r6ktMhR0Sh9gorEmjWcwrC8psYsy+BgMBgbtR+M1bYAJlqkHLXF15MfvxwPnB3eHPkEFjDT7xkbVwNzbQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ca/-/lang-ca-4.3.0.tgz",
+      "integrity": "sha512-51z1tU3qT8t8bmn9iGxL5jSzk2rtqh6SfPx3ZwCqtPM8dwcixvZx/z4jpQXQnYAb3Vz26vBARzNfNRtg9CIXBg==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-cs": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.1.4.tgz",
-      "integrity": "sha512-/VLm1QCkU6bnAHiRzX5zSmWZasJXO641D0OXty1ywh9gHIcilXJRZF+hP9GRf8ZsMCHMXLgVCiaf2s1gIHzWGw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.3.0.tgz",
+      "integrity": "sha512-L8Z3PGxEQ3/R4SDiDvDnaWtynp72ibKfSFt3qfqvCKEAvnO1o5IE/49DxJnUlxE7RN/JQyuqMmK/TNn9v54FsA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-da": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-da/-/lang-da-4.1.4.tgz",
-      "integrity": "sha512-brJP0IWdQT1NuMqgnidHab49sKR4AfIUM8vwWqKQYyB4x0im+R3SKqVv120BOLP/exrxm2PfmcDGIOsoEW//cw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-da/-/lang-da-4.3.0.tgz",
+      "integrity": "sha512-/Ep0CFDtPML4wE5DDe8k5nnyXOx3qdonPbpuKkTzP4Icmcjwo7nN4RUdvKJDGq/FR2k4AFxR5Jmr5MqE/zPRZA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-de": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.1.4.tgz",
-      "integrity": "sha512-DYgoEYynWJ6lVTWEljXPinJRILoOJnYOREXTUK3yILPYvVuw+HKbQvAp0SrRltJAgqrH8rRaqITQa6PKo+e1Pg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.3.0.tgz",
+      "integrity": "sha512-uutxR7guI9yviDhfTEVEAUFFpMrkkHUod1GEdjsrQCkCBvkde67cayU9Ot/XQXUj/Yp91nVzsrvasrD1yKUUfA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-el": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-el/-/lang-el-4.1.4.tgz",
-      "integrity": "sha512-m1VFbm+CPxzjXcfrQSiG4a31fTvanGIsyTaOwk9GZJiUvyQkt5ln9epb7PHv4zMfQZbM6MqtAUniN/6fIHNt3A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-el/-/lang-el-4.3.0.tgz",
+      "integrity": "sha512-tq8HIYoQ2evi4s4LP3Jn4oBofW0wuDOclDGKZtt4LhFglm0ZdxBPCerIG55b8V5PyvZbpGFSstgF3EM3TsP/1g==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-en": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en/-/lang-en-4.1.4.tgz",
-      "integrity": "sha512-zwGntJ4nE/XRMC+AccYYlgBHHVWsbVK33HpTx6tiST28SCx3KhgDiSmKKe89kKbgJmy8jjYlGJazsTDzF8ggWA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en/-/lang-en-4.3.0.tgz",
+      "integrity": "sha512-HfxQyyD5lMOo05Wil01lg5zNILMYCv/HWfr3qeTzbfylNbB/3jorDGpuGQe70e8ZjveJSwSegyow4Q859/OgPw==",
       "requires": {
-        "@nlpjs/core": "^4.1.4",
-        "@nlpjs/lang-en-min": "^4.1.4"
+        "@nlpjs/core": "^4.3.0",
+        "@nlpjs/lang-en-min": "^4.3.0"
       }
     },
     "@nlpjs/lang-en-min": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.1.4.tgz",
-      "integrity": "sha512-yCHRYXXlhDZ46x/qmU33UE4yBe9EPwyq2ILVRhqlEm54M10CTuLiXRTqMHrM+jfbM10P4q7lBcsTF088//uBbw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.3.0.tgz",
+      "integrity": "sha512-UvVJpqNTZQlp9gcVtwxRLYcyNawt+hUn9nz8sBhKrscg/5i9m5Gf2u0o2Y+us5LVw+704X0qZn4W2yKzbA6Jug==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-es": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.1.4.tgz",
-      "integrity": "sha512-fSv69kv5LJZMj0ndlpSwFZW2YnYZaXwLTnHcl+4kTdDjKJqDTr06f6uxNucWYlk3waXa8SJhPKKA/y5KCX8fAw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.3.0.tgz",
+      "integrity": "sha512-Hzz2vZqaNy89/mnELaiWobmIgFcLmyUwoRkjuPLCs1+4QHau6dSMqoJnD4kQPF46iA4WfBqTiAjLuYKd3wQ98g==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-eu": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-eu/-/lang-eu-4.1.4.tgz",
-      "integrity": "sha512-Gxc7qDgETpd+dAB3dk2gYiQ8GZI5nyEsdR2wj41nm8iZApZCcY1NbCzWi3EMjBe3IPqQfzEjBooZSFVH6yur3Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-eu/-/lang-eu-4.3.0.tgz",
+      "integrity": "sha512-SRfhm6qTGYW/347RqszJzHWDh9ENZC9z75tvcO15V52qUPDgn4pVaFJWOncJaskUYDIn9CRQR+2fMzn3xKOw/w==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-fa": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.1.4.tgz",
-      "integrity": "sha512-oB08x+mnS7dMEXUfVMzg5t0GGeOLzVQ7TtiO85Oi5ZBFAq7c1hNClZGKpOpoqGiNo62LUoyTKcr7QqiaO3GYQg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.3.0.tgz",
+      "integrity": "sha512-Q3IIvBm+C4MvtoGcST0HDFoJAVLewKSHxKF0t4+LAgqEx2iWiehCxMZNn9igGYN9I8X0wiiFfCn7kdYUnXyGTA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-fi": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fi/-/lang-fi-4.1.4.tgz",
-      "integrity": "sha512-zoIrImr5wAVnsUwZVsOAc956f7ah9+Ywlt6wQgEQXM34pGF0iyh7TKM6QRQgxxXPFKBeC4kTAArO4CU4oELIIA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fi/-/lang-fi-4.3.0.tgz",
+      "integrity": "sha512-4B29e5WuA9IUWD530l7x3HicJKlzX/bY9H+EzbQRjOWJqEljJOttlOIs05o+rnORdxto4EGXYWITI3yIkZ7fpQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-fr": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.1.4.tgz",
-      "integrity": "sha512-zpf3bvicRqIiZqAX0I1QeBUBJt0kRnYTCAP5gLw4ZOpFxtOhAp2X8+0EoAaHgESV5ZYDkeOANpQNCUgOMsBFgQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.3.0.tgz",
+      "integrity": "sha512-1DQcsPr2iKwzGyhslg9NcC7UKaRXQpGWhoATr+lyBU2dC8nlSIMTdYi8k0OIUgVup8ZXp6k1D2pvTc1tijXlXQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-ga": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ga/-/lang-ga-4.1.4.tgz",
-      "integrity": "sha512-LjsNy1E2vh5pGcsal3lpnhPTp51U/+Od+cswX0JKzGsGLpyk1Jwr1wXCtB+/uO3j1zMoaI9hWPT1IaFf0QMevA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ga/-/lang-ga-4.3.0.tgz",
+      "integrity": "sha512-BsoH36i14jJr0IiJ1bRPdMkabbsZt1qRF+lAv0a7AQkWBKdNsOLnDdmqsOzVdwfo5yW8jz5TlY/+Y9/F8tleDA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-gl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.1.4.tgz",
-      "integrity": "sha512-Pawb5E/4TER4lO8ihbau0USMRLSHExONAu6s1ryowLCrTtBC03/sTw+qOQieXEWJvcIK8vV5dckSF1k3Go7v5w==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.3.0.tgz",
+      "integrity": "sha512-IgT1dXHzfrzhjKrHVuYm5MgAn4DvLYxGu/aQmy8opKal33LQ4nSZP94xSQdKu46AiaGpHFmx31mj+CZvWbxUSQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-hi": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hi/-/lang-hi-4.1.4.tgz",
-      "integrity": "sha512-dwLNMu0x0Hxo2Jlp2dR8YL/ZaOke/MGGm/XwXDuDvQV3gkjZcZqrtZyySVIgzR7GXDYOuA3d1ZPutX6NZSlxhA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hi/-/lang-hi-4.3.0.tgz",
+      "integrity": "sha512-CGMfRhrvMhxYLqxzO33WFAZzXYiIHK4AIVoTc3kbbw/rAcrGiOZBDjmD97xzbKM7+0Ivj4tSsiK55l8GrutAwQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-hu": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.1.4.tgz",
-      "integrity": "sha512-3J46wGg6eH3tI5TCbfUBeXLJCM0lli6bjbFugulpYPIyOX+RJERfDIhyaueH0nc4akPnahkP9mwWkWdcjdyZDQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.3.0.tgz",
+      "integrity": "sha512-5BCofozIbvVD1t+FVJD+5VwISU3ep41UnzN83z96nkhQrUcCAReNb2AS5Cj3oIbSLTnO1Ygl+2DZg0nr3XfjLw==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-hy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hy/-/lang-hy-4.1.4.tgz",
-      "integrity": "sha512-r5m6rCr4xAGgc2NTCuIACleVHHaA1Lkscu42REF/NYkbAXqTddIYTiHTNh5Ywh/IyeYLYz9+YyUhmJZlAezgNQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hy/-/lang-hy-4.3.0.tgz",
+      "integrity": "sha512-tYlBp+VqEcc0GcKmIne89hrFa+yM7u4Rj2uGYEfEXNRepDnDKJ0uiXpr5ZlEsPPI/+9fOJGlZkUqrNTvgIC//w==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-id": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.2.0.tgz",
-      "integrity": "sha512-KWIE2vpR2zeyJDA0+pzaO+QWUNXUu476TiS8m2WjOD/BWFIbBrG5ty0a6cIVEpgTVXUwyMk+NHFKPa/CqWwh5A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.3.0.tgz",
+      "integrity": "sha512-hj0oAQsJWllXRarQcU2RHpmpnak3pvCCEJ37ox/XzIvQ0U69BFLI/sIalNxV7tkhHx+buQWd8m2Pl4h+pDqutA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-it": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-it/-/lang-it-4.1.4.tgz",
-      "integrity": "sha512-F9RFb97NgGdJiy23LbMi/v2kxFsruuEH/6VrZMSh6EIwU9a3f3ZRhARR/ZTjJULAc9PI1zp1xSm0c8fvweqnag==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-it/-/lang-it-4.3.0.tgz",
+      "integrity": "sha512-XcporaZBTCsahhahq2OSzxf63z2A3GHPX3iQBE54HN7HS91FXOgVlW87D+px2cn9E84BaernWPCx9XRCGgSRWQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-ja": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.1.4.tgz",
-      "integrity": "sha512-PfeLytTHGZ8c8rpEW2NWgSPvSjVGSH9owoodMLKs/QRjeBYCppJIwGLhprSo2IfOQihoUpndM4j5xqPRP7IPVw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.3.0.tgz",
+      "integrity": "sha512-P3Wqi5SQU3FMkHTd5KFfjOJZsm60c0DAyDfnpjAxBwQF/odKZwy+YMpaumQbDumwl4dzFFD9vOkxm+47xxQaiA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4",
+        "@nlpjs/core": "^4.3.0",
         "kuromoji": "^0.1.2"
       }
     },
     "@nlpjs/lang-ko": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ko/-/lang-ko-4.2.1.tgz",
-      "integrity": "sha512-PJs+da1PyomAuMKkgVMOJNXTKM7AnnuBZ6bTyT/Hw7jnRdLjgsEWEhb/wf65qyBveVh5Wrl50DSzQWqn9J10/g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ko/-/lang-ko-4.3.0.tgz",
+      "integrity": "sha512-PhcYNVO8WhA3AL8dOfK8zejxm5cFOLikbecl2fkE/npdI56kxWUH6sMe5/Ym/tZ82xC54Pl6ThRkqtPGMKOt5Q==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-lt": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.1.4.tgz",
-      "integrity": "sha512-FdyAaGKPYN06dIa/jH/5G0qXr8vX4w/ZMA96ViVLWmaRFr7FBha5PqxjF1IxkS50lwVpK66J+QuYbsAEgnNz4A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.3.0.tgz",
+      "integrity": "sha512-u5PPYO0gagUd+8GZXiM3Mr3zyOdtp4dGnCsDcoOhH7UM4ZYZlcsyCsqlpfaSgAHK7QtB3yc6s0xDmbe/mOyvcQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-ms": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ms/-/lang-ms-4.2.0.tgz",
-      "integrity": "sha512-XXTApbBiFHOzqYgACTbAQE+eKCkn2226mExh5bpW3Xf27k6vwtk9HEZtkHbsNISFcGpy2DmvI2bhI6cBuess9w==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ms/-/lang-ms-4.3.0.tgz",
+      "integrity": "sha512-UorfB4h8h4a1eJfgZtM/DapVMfv1+TUOJ5tKPYluDGV+5JEFaRl1a1TSHzG2FxLX7iuj7kQSMhC8ug43VTOYQg==",
       "requires": {
-        "@nlpjs/core": "^4.1.4",
-        "@nlpjs/lang-id": "^4.2.0"
+        "@nlpjs/core": "^4.3.0",
+        "@nlpjs/lang-id": "^4.3.0"
       }
     },
     "@nlpjs/lang-ne": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.1.4.tgz",
-      "integrity": "sha512-NacphIBFyMiTAZEjtJlKQjcmojWN/fobhtQZMjdZE1mFuBwk4EKL/qG6RFqLJROjW9AbbKSFIctvhYxzIOUIIA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.3.0.tgz",
+      "integrity": "sha512-jxYOvyi1a1sjhPmA9X9GbUZfGMAnUrC0ubohKLlSe7LYPEZBZRnHPSP0edo/VFuQy/MCkL+BccIO2Mw1UO6rYA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-nl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-nl/-/lang-nl-4.1.4.tgz",
-      "integrity": "sha512-EslLit03FUiFJwv9sNXbeVgUf/7C9GCTsmVjg27Xw8VHKEjhBNdsAxF1GiNNtxG8Bmj9ozhcl3Y6YlwTYPGitQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-nl/-/lang-nl-4.3.0.tgz",
+      "integrity": "sha512-/FGQpjUlhFRpi01QL1M2PYBSg/CXhrxs4Ffl3o8UMzKaze0o1vgb9a4ZOkpzQF0xai4hzqr2xhTNnlhjRXq50A==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-no": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.1.4.tgz",
-      "integrity": "sha512-pQ6icQUgcxjtsop0aLmlM5LE1kB60UjaqAJW/JfUv5e4ybK87ahMpaNQwC4R3DFxjKxtuxL/e2jx/X+7kR5b0Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.3.0.tgz",
+      "integrity": "sha512-Utx6/kskdOEQQv/kPVjba4MbPV4pTSh9PvwNcw3ui5eD1TnQDdinHMrFi/nurnjZGsFsNu1tcZ+Yde5oNal7aA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-pl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pl/-/lang-pl-4.1.4.tgz",
-      "integrity": "sha512-LI3BLJdlA9zsjIsgxUaZ0FbYXQnRIlPRON7ixS5fay8fnRau80PhiLxIJR3SOXzDIsZAUNaQgbpBl2klDwUPuw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pl/-/lang-pl-4.3.0.tgz",
+      "integrity": "sha512-GyzTDs/hrX4BAomJO7z9eWA+9/EFkQoytX9GrhyRtoYstpdd85Mq/14nbS7EoakcnXQCBFJzgd31Ia0ymAvuRw==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-pt": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.1.4.tgz",
-      "integrity": "sha512-uv7jhaCXlUkYU0At9vhMuPtm5S+VNhJfFbMPmgburUEnbKgLYR8sxsnAOEErVHt1F8YVUO31xomBjBQtRNg16w==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.3.0.tgz",
+      "integrity": "sha512-0wmWzV0sHassje/ys8QBO8Q7oeHVaFE2g6ZF5NRwzsy8SH4//DZ5T5eb8JYBrsPTVSZ4krnJUmuG9FnQRdrePw==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-ro": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ro/-/lang-ro-4.1.4.tgz",
-      "integrity": "sha512-SFT79asmGMr8fkMIGB89V0v7MY9/lZ1JpHJBFFfDq1/rmzA0OLqaB8c3k8eeIduUEVVUOH1kUgzBdRysS5+Alg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ro/-/lang-ro-4.3.0.tgz",
+      "integrity": "sha512-7uAEuAZy2ZAQNEnXC3E8+zusczsRWB9q9y0ZeId3F70F80zGG3r3QRoAPjhf4AaW/vmhHDaIlOKr61/obIodtg==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-ru": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.1.4.tgz",
-      "integrity": "sha512-ca/G82Zk/xucJ4d6vf6JGwavtBwb2zJ/XV+v3kvMAMN7wIdMcfOUpBuD1N2ojBmJbsftQcslcQLyWYh5Mgp0+Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.3.0.tgz",
+      "integrity": "sha512-xxdodGGiKEjbd1UuyeMGcOUET9aS+wlUpaT0KlI9U+xMgS8gYumIws6z5ISaZsJqEc+FYXd7qf009y4gN2tdSA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-sl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sl/-/lang-sl-4.1.4.tgz",
-      "integrity": "sha512-zislVLkVjaqLihLhDwl9sC1B/Z3cAfGJ2iHYmya9uHK/D6HYkCf+33+93mkVl7Nzl7uHImPyZODSXliw8mG+SQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sl/-/lang-sl-4.3.0.tgz",
+      "integrity": "sha512-rMijxpaf7eByCpJzxIJTPTJ0oOtcRraKLvzB7qTTwd76f9PtRP9d75OZcgjnIhGEMGGyARX4HtlKHLalMHClfg==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-sr": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.1.4.tgz",
-      "integrity": "sha512-jSQzdx7tmUJRPb/y/Hu3ABj2/oau79/TblKPtwtSLoF9sJmI54w4oTykox2keZnwrH0E1cGsBBu9Wx2qT2TPRw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.3.0.tgz",
+      "integrity": "sha512-xOg7RMXwTsubMvghbpvjXdeWk7r0+l4kOeBGn7fJt/AfQid1ALdAEBd324ctQirMbMFJwxqobuKaLTa97O0KYQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-sv": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sv/-/lang-sv-4.1.4.tgz",
-      "integrity": "sha512-+XcW11dc9YbWWgAN+1YmDhkexRLQ3F7Xvj2Ke2pgrmVs6rx/bFG12A+bORvwotXhdLQ/IsFkL4g7UNgClARzCg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sv/-/lang-sv-4.3.0.tgz",
+      "integrity": "sha512-lY1Z6JqFvQlJmzhQ2S9Ys287Q9TmkksCX6/Pxja+vEaKSGNNUEjCVH4qbqAzY5Obf1k+7KkEyTu4sjyEr/0n7A==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-ta": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.1.4.tgz",
-      "integrity": "sha512-47W2LSy5KMYjc7RylmBxJIN1OS2kAvFY8OZznhnBOUMF/73PwN+1M/UTaJI6HmxPW3zi595Uk0XqNvdJlWvAkw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.3.0.tgz",
+      "integrity": "sha512-3Q174Bkw7JLKSv/XCpS15WFygoB+ZEX6a3YUmmQG9PAZ1dvvBXkktgHU56gwoZ8RMuOg6eanrYT1/0/Yb0OigA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-th": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-th/-/lang-th-4.1.4.tgz",
-      "integrity": "sha512-0zZYqkSRt9s8VFWzNiMpDSdf6rx/R/13CcZx6vzTZT3pMrJk6b7GwSbfT8ub+StIXKFIjZudnfNqDFtYUMzmSg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-th/-/lang-th-4.3.0.tgz",
+      "integrity": "sha512-GKf24v2YdWIWiP8jvUZnZ2opYvY5fziTbRaoHomlBpw8N/4aQIAa/iqoJrHmwrXTva9siBzKe4JvjusHNzUx8Q==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-tl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.1.4.tgz",
-      "integrity": "sha512-8mz0gZVP3hhxT5ylVOL702v4/8aXLVfPqMptBbQTEI44xez093rvs76dpgyT3R1vtrkww4ifSNHo/QxqcuxVQQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.3.0.tgz",
+      "integrity": "sha512-PP1gvyzOmmvEZVch2x4oBEZo5larn31USyjRFRq+dghJ7LK40TPWcipmbc1vg/l5FMiI+BlW3kcxuDToySRMyA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-tr": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tr/-/lang-tr-4.1.4.tgz",
-      "integrity": "sha512-yBbl+2KXVauhQDfrF0pjlxLj1ItdccczCLPOP/vcxCJfaGOViYD7rFKSxHS5xuiI9qFPNrC8MUBl+/+ToLH3hQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tr/-/lang-tr-4.3.0.tgz",
+      "integrity": "sha512-dixTifRbrPbrUETXTkUe233kBc+G2SrMK3nde+TOlaYL8oXOmujXAzLS8fyd87o9IrunUsAd8/RSjrkwG86K0A==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-uk": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.1.4.tgz",
-      "integrity": "sha512-EvkU+EOlScQu+Er3/S8Xspxx15EzkUOfEdtID69ZsQdsSo87SWM/yI2jpI9+0dXaH8bxoCDHuEUI/S9ILoLhjg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.3.0.tgz",
+      "integrity": "sha512-MXjjjtnTiJzxS5j4rMxZEQUUKpMwnzPhzlA1sME5I+7+c/84LzFEXfktAzvZ+z8JfqpIjdV4Oo6oJfoym/TyyA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/lang-zh": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-zh/-/lang-zh-4.2.1.tgz",
-      "integrity": "sha512-Li1lNzVXy+HAbBxF8rK3XSUZvSO8Kv1ySKjpoPjNy9+AWeFAwqCf1vljqMLF7YwiE77r8dj6uFhmYdnWr3Y/bg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/lang-zh/-/lang-zh-4.3.0.tgz",
+      "integrity": "sha512-GRjUTk5auf5D/F0iimhz5dWkX18R+KDdxS33ymOYMr7fb3bxtFrLmwrhDVyVJCqP54J+70CcxB863jGcH8FK9A==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/language": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language/-/language-4.1.1.tgz",
-      "integrity": "sha512-9t/jxCjGhuUwh0uNGUk8XLg44JZoOj9mQTfMF57G6EqL9j4myFm06TBM9lNqLWBkzHxUONqHBeWhQxY+TAdjfQ=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/language/-/language-4.3.0.tgz",
+      "integrity": "sha512-MEGbVW+nR+5sk3I5q1op/iWx+dyAUpppt5/NLr7UoBX0oPNm7kMbsslDFmKJc7g63/GwtfsYpTOB87HGWK0I4w=="
     },
     "@nlpjs/language-min": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.1.2.tgz",
-      "integrity": "sha512-fIjjUiqITXwGrPd7LXt8w+S75tNI2+huel00eyai3zhaObL57ZAl7U/jrhCGHEIiJXiKLtsG4oMiLG3FUGkIlA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.3.0.tgz",
+      "integrity": "sha512-6PaopdEsHyN+H7N1pK91OET83vAEJ8yQaYRMSFIwmPh05KqEq5nSKimK78Z1j7kPe1T1Hbgy7O5ZctJZR79RDw=="
     },
     "@nlpjs/ner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.1.4.tgz",
-      "integrity": "sha512-lN8qwdl1rx0KWglKIuskQLvzS8qaRRQ57MSq5mdwzns7/nxdkZDqJs4C6fxlOpXU2JElQZKHp/qWz9soh6rOAw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.3.0.tgz",
+      "integrity": "sha512-XA8FK8vWgcafrhofM8Qw8JYAKo+zj2PMWugAFq+BtlJb7gw43RcivZ4TR43V+8wvOvHrcCZRv3MCIZL9Jj9bsQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4",
-        "@nlpjs/language-min": "^4.1.2",
+        "@nlpjs/core": "^4.3.0",
+        "@nlpjs/language-min": "^4.3.0",
         "@nlpjs/similarity": "^4.0.0-rc.4"
       }
     },
     "@nlpjs/neural": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/neural/-/neural-4.1.4.tgz",
-      "integrity": "sha512-lMQMavAm+tMeju1yEsyTtcml6eyDG2C5txGMzzWBmeLnOVPelqMzzWzY0S21HRYtD7t/24d/eoto749xxLwPgA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/neural/-/neural-4.3.0.tgz",
+      "integrity": "sha512-917TQC/8evIrh9LIn14pakoib4DZLTNWb4SWR1T0WUqirqR+BZv2+G9UXxUPZURXvgtgleUUmCxasbp9cnHXEA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/nlg": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.1.4.tgz",
-      "integrity": "sha512-zcximogcALUVJmaWtzwWF4fR3oL2oTatrgRiUQY9fYXwMLeEnHFHBqdtoj2FS1Wp4YXjaWqZfAMrD5qMre4d6g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.3.0.tgz",
+      "integrity": "sha512-dxZuTnycrOMGTiLUGSC3lDAp6Nq7Y/Qh/xViyDAPHky2ai2B75gY4FlzMtrpcS7AhoKsqEixf35u3POAL9DGcQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4"
+        "@nlpjs/core": "^4.3.0"
       }
     },
     "@nlpjs/nlp": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlp/-/nlp-4.2.1.tgz",
-      "integrity": "sha512-hhPo0pqJSwgjQCOKDoNFTg0mdONbnzGH+hVlEL3y4fX//thkukzM4BDktZ86f2O8MANuRMFyRAHHMtAcO0ixNg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/nlp/-/nlp-4.3.0.tgz",
+      "integrity": "sha512-ueZW7n++3mM+VBwU7JZLqbc/VS1lNox2KDeLQmySLyTE9MJmnSLovXX6x1/HavjjKOI7t2RYMzRKNxkeBPD6yA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4",
-        "@nlpjs/ner": "^4.1.4",
-        "@nlpjs/nlg": "^4.1.4",
-        "@nlpjs/nlu": "^4.2.0",
-        "@nlpjs/sentiment": "^4.1.4",
-        "@nlpjs/slot": "^4.0.0-rc.4"
+        "@nlpjs/core": "^4.3.0",
+        "@nlpjs/ner": "^4.3.0",
+        "@nlpjs/nlg": "^4.3.0",
+        "@nlpjs/nlu": "^4.3.0",
+        "@nlpjs/sentiment": "^4.3.0",
+        "@nlpjs/slot": "^4.3.0"
       }
     },
     "@nlpjs/nlu": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.2.0.tgz",
-      "integrity": "sha512-Gmy1P20hcpXWav1V9Kki94bpH6QVvcyYLXEBNEpHgxwkwC0loyF8TYwOjyx91Jxfb826S/5pOrov2wI3vGANYQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.3.0.tgz",
+      "integrity": "sha512-jGg5xWQP4EqZxo4IAaLxdKSI9ZVVn/LlqDe+C/XFa4H2XsE4AkxXY9E4/unV72YiRrwWqytGwc3fe1TvgkicyQ==",
       "requires": {
-        "@nlpjs/core": "^4.1.4",
-        "@nlpjs/language-min": "^4.1.2",
-        "@nlpjs/neural": "^4.1.4",
+        "@nlpjs/core": "^4.3.0",
+        "@nlpjs/language-min": "^4.3.0",
+        "@nlpjs/neural": "^4.3.0",
         "@nlpjs/similarity": "^4.0.0-rc.4"
       }
     },
     "@nlpjs/request": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/request/-/request-4.1.0.tgz",
-      "integrity": "sha512-2yYLdetqRjSrP44GV3xvNUZs2NB1a4cAhYut0tep/93M4U3tst/B+N1Ug6vP3GOSwc0NBJKOS3bwuYUSxbnAbQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/request/-/request-4.3.0.tgz",
+      "integrity": "sha512-mIz1S7EZfOPRQeFUxKPF+Fs0HrkV75thQ2FDxQQTNJdZ5OIEw2v0JlFSY4olntJLzeBejIJPF6vtytj+rM0WNw==",
       "requires": {
         "https-proxy-agent": "^3.0.1"
       }
     },
     "@nlpjs/sentiment": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.1.4.tgz",
-      "integrity": "sha512-rTnEhSj6NzzT9fKSuvBcR8oCy63SstG5QPTB4PIRWAOVXXTYw1FNOEVyU3XfVB+rUxpfcdF9lh8P9kYR/bxeTA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.3.0.tgz",
+      "integrity": "sha512-IZPxD+LwJYhsVeC+NMECsVQODX5sSv/jPAoSbzbdKt1cMwUOcVqZ71rPJlRbn/Rtyk+btNM9FsNGpmX3eZFNTA==",
       "requires": {
-        "@nlpjs/core": "^4.1.4",
-        "@nlpjs/language-min": "^4.1.2",
-        "@nlpjs/neural": "^4.1.4"
+        "@nlpjs/core": "^4.3.0",
+        "@nlpjs/language-min": "^4.3.0",
+        "@nlpjs/neural": "^4.3.0"
       }
     },
     "@nlpjs/similarity": {
@@ -665,14 +665,14 @@
       "integrity": "sha512-S5zC6JbISyLtZkLF86qU5T4X5kolibvmY7DCHQICsWsu/P7xDQEQ9whRCM4NO3bypnvQefRsljsAGCCC462eWw=="
     },
     "@nlpjs/slot": {
-      "version": "4.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.0.0-rc.4.tgz",
-      "integrity": "sha512-oprPTcwCjjg+zJYmKeBhfHQDaYjVCOyMgmN6puFYQR4t//0kHbTw4XVwljJv68Wd3h6JTwx96k1X7tFTuDPrew=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.3.0.tgz",
+      "integrity": "sha512-uicsKVXsp+8FqYN+vtPV2iQzjndvKuyu7yeFL/O209fg/Q1tgghbV+rCPc/vciwHCGXUQ36HCIhGqDDj5LFW+w=="
     },
     "@nlpjs/xtables": {
-      "version": "4.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@nlpjs/xtables/-/xtables-4.0.0-rc.4.tgz",
-      "integrity": "sha512-zakc473Zb6/0iIf2cisKZcJiGH2y9EPKS2YvhrxcRP+glOY1eSo3SEsreqPk2O0x+4LTOl43UZcCCELjvYhSCA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nlpjs/xtables/-/xtables-4.3.0.tgz",
+      "integrity": "sha512-b6ICyNsi2KLn/raE6kX/Of9jPojc5QHw2jNoPCU6uNhd30Sp7qjUQmyVTzB4MqBuijjf8HFlx7E1biJERbc4Sg==",
       "requires": {
         "xlsx": "^0.15.1"
       }
@@ -2019,25 +2019,25 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node-nlp": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-nlp/-/node-nlp-4.2.1.tgz",
-      "integrity": "sha512-q4NbXK3vKYTWHptXCbn1LsZAziRkiLrhj/U0tkvnM3tG0FU+xvWsPUhs0NNrBL3IfWhnvuO3ilo55AUf/ufd4A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-nlp/-/node-nlp-4.3.0.tgz",
+      "integrity": "sha512-iC+ENdyYt1i1SQvAGIBsq/9F8H+i1Dyn5jFeSwNH99uQ0ZhW0voaDZSiqh5QvucMzJgTOvfmNWSnCmDqUZpKEA==",
       "requires": {
-        "@nlpjs/builtin-duckling": "^4.1.4",
-        "@nlpjs/builtin-microsoft": "^4.1.4",
-        "@nlpjs/core-loader": "^4.2.1",
-        "@nlpjs/emoji": "^4.1.4",
-        "@nlpjs/evaluator": "^4.0.0-rc.19",
-        "@nlpjs/lang-all": "^4.2.1",
-        "@nlpjs/language": "^4.1.1",
-        "@nlpjs/neural": "^4.1.4",
-        "@nlpjs/nlg": "^4.1.4",
-        "@nlpjs/nlp": "^4.2.1",
-        "@nlpjs/nlu": "^4.2.0",
-        "@nlpjs/request": "^4.1.0",
-        "@nlpjs/sentiment": "^4.1.4",
+        "@nlpjs/builtin-duckling": "^4.3.0",
+        "@nlpjs/builtin-microsoft": "^4.3.0",
+        "@nlpjs/core-loader": "^4.3.0",
+        "@nlpjs/emoji": "^4.3.0",
+        "@nlpjs/evaluator": "^4.3.0",
+        "@nlpjs/lang-all": "^4.3.0",
+        "@nlpjs/language": "^4.3.0",
+        "@nlpjs/neural": "^4.3.0",
+        "@nlpjs/nlg": "^4.3.0",
+        "@nlpjs/nlp": "^4.3.0",
+        "@nlpjs/nlu": "^4.3.0",
+        "@nlpjs/request": "^4.3.0",
+        "@nlpjs/sentiment": "^4.3.0",
         "@nlpjs/similarity": "^4.0.0-rc.4",
-        "@nlpjs/xtables": "^4.0.0-rc.4"
+        "@nlpjs/xtables": "^4.3.0"
       }
     },
     "object-copy": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -37,7 +37,7 @@
     "memoizee": "^0.4.14",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
-    "node-nlp": "^4.2.1",
+    "node-nlp": "^4.3.0",
     "sort-stream": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/botonic-plugin-contentful/tests/nlp/stemmer.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/stemmer.test.ts
@@ -1,10 +1,5 @@
 import { stemmerFor } from '../../src/nlp/stemmer'
-import {
-  Locale,
-  PORTUGUESE,
-  SUPPORTED_LOCALES,
-  tokenizerPerLocale,
-} from '../../src/nlp'
+import { Locale, SUPPORTED_LOCALES, tokenizerPerLocale } from '../../src/nlp'
 
 test.each<any>([
   ['es', 'ponerse', ['pon']],
@@ -35,15 +30,8 @@ test.each<any>([
 
 describe('Stemmers', () => {
   test.each<any>(SUPPORTED_LOCALES)(
-    'TEST numbers in words are kept for locale %s',
+    "TEST numbers in words are kept for locale '%s'",
     (locale: Locale) => {
-      // TODO remove when node-nlp PR is merged
-      if (locale === PORTUGUESE) {
-        console.error(
-          'Skipping PT due to https://github.com/axa-group/nlp.js/pull/419'
-        )
-        return
-      }
       const stemmer = stemmerFor(locale)
       for (const word of ['covid19', 'covid-19']) {
         const stemmed = stemmer.stem(

--- a/scripts/qa/lint-all-packages.sh
+++ b/scripts/qa/lint-all-packages.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$BIN_BIN_DIR" || exit 1
 
-for package in packages/botonic-*; do
-  $BIN_DIR/lint-package.sh $package
+for package in ../../packages/botonic-*; do
+  ./lint-package.sh $package
   if [[ $? != 0 ]]; then
     FAILED=$?
   fi

--- a/scripts/qa/lint-package.sh
+++ b/scripts/qa/lint-package.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-cd $1
+cd "$1" || exit
 npm run lint
+EXIT_CODE=$?
 # when lint can fix all errors, npm will return 0
 # In this case, we want to see which files were changed
 if [[ $? == 0 ]]; then
@@ -8,4 +9,6 @@ if [[ $? == 0 ]]; then
   echo "If lint fixed some files, run the following to verify the changes and commit again:"
   echo " git diff"
   echo " git commit -a"
+else
+  exit $EXIT_CODE
 fi


### PR DESCRIPTION
1) node-nlp did not correctly tokenize "covid-19"
Upgrade it so that it has incorporated this patch https://github.com/axa-group/nlp.js/pull/419

2) pre-commit script was not aborting when "npm run lint" returned non 0