### PR TITLE
Chore/downgrade compromise

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,7 +1,13 @@
+# When modifying this config.yml file,
+# please, validate format: https://dependabot.com/docs/config-file/validator/
 version: 1
 update_configs:
   # Keep package.json (& lockfiles) up to date as soon as
   # new versions are published to the npm registry
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "weekly"
+  # Ignore updates: https://dependabot.com/docs/config-file/#ignored_updates
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'weekly'
+    ignored_updates:
+      - match:
+          dependency_name: 'compromise'

--- a/packages/botonic-nlu/package.json
+++ b/packages/botonic-nlu/package.json
@@ -18,7 +18,7 @@
     "@tensorflow/tfjs-node": "^1.5.1",
     "axios": "^0.19.0",
     "colors": "^1.3.3",
-    "compromise": "13.1.1",
+    "compromise": "11.13.2",
     "compromise-plugin": "0.0.9",
     "franc": "^5.0.0",
     "fs": "0.0.1-security",


### PR DESCRIPTION
* `compromise` has introduced some breaking changes in newest versions that break botonic-nlu. Working version should be `11.13.2` while we don't make the proper changes.
* Add ignore `compromise` in `.dependabot/config.yml` 