### PR TITLE
chore(contentful): bump 0.11.2

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -13,7 +13,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {
@@ -22,6 +22,7 @@
   },
   "files": [
     "lib/**",
+    "src/**",
     "doc/**",
     "README.md"
   ],


### PR DESCRIPTION
* publish 0.11.2, as it's required by a bot which needs the fix in Catalan Tokenizer (#649)
*now we publish also src to be able to debug typescript from bots