### PR TITLE
fix: allow also only agent emails on handoff

### DIFF
--- a/packages/botonic-core/src/handoff.js
+++ b/packages/botonic-core/src/handoff.js
@@ -104,9 +104,6 @@ async function _humanHandOff(
   shadowing = false
 ) {
   const params = {}
-  if (!queueNameOrId && agentEmail) {
-    throw 'You must provide a queue ID'
-  }
   if (queueNameOrId) {
     params.queue = queueNameOrId
   }
@@ -125,7 +122,6 @@ async function _humanHandOff(
   if (shadowing) {
     params.shadowing = shadowing
   }
-
   if (onFinish) {
     params.on_finish = onFinish
   }


### PR DESCRIPTION
I allowed doing a handoff with in this casuistic: 
`agentId` without `queueId` 
but not for 
`email` without `queueId`
I have removed the validation checking the queue.