### PR TITLE
fix: make sure there are no residual tmp files

### DIFF
--- a/packages/botonic-cli/README.md
+++ b/packages/botonic-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @botonic/cli
 $ botonic COMMAND
 running command...
 $ botonic (-v|--version|version)
-@botonic/cli/0.11.2-alpha.0 darwin-x64 node-v10.19.0
+@botonic/cli/0.11.2 darwin-x64 node-v10.20.0
 $ botonic --help [COMMAND]
 USAGE
   $ botonic COMMAND
@@ -64,7 +64,7 @@ EXAMPLE
   🚀 Bot deployed!
 ```
 
-_See code: [lib/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.11.2/lib/commands/deploy.js)_
 
 ## `botonic help [COMMAND]`
 
@@ -95,7 +95,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [lib/commands/login.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/login.js)_
+_See code: [lib/commands/login.js](https://github.com/hubtype/botonic/blob/v0.11.2/lib/commands/login.js)_
 
 ## `botonic logout`
 
@@ -109,7 +109,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [lib/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/logout.js)_
+_See code: [lib/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.11.2/lib/commands/logout.js)_
 
 ## `botonic new NAME [TEMPLATENAME]`
 
@@ -129,7 +129,7 @@ EXAMPLE
   ✨ test_bot was successfully created!
 ```
 
-_See code: [lib/commands/new.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/new.js)_
+_See code: [lib/commands/new.js](https://github.com/hubtype/botonic/blob/v0.11.2/lib/commands/new.js)_
 
 ## `botonic serve`
 
@@ -144,7 +144,7 @@ EXAMPLE
   > Project is running at http://localhost:8080/
 ```
 
-_See code: [lib/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.11.2/lib/commands/serve.js)_
 
 ## `botonic test`
 
@@ -171,7 +171,7 @@ EXAMPLE
   Ran all test suites.
 ```
 
-_See code: [lib/commands/test.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/test.js)_
+_See code: [lib/commands/test.js](https://github.com/hubtype/botonic/blob/v0.11.2/lib/commands/test.js)_
 
 ## `botonic train`
 
@@ -189,5 +189,5 @@ EXAMPLE
        TRAINING MODEL FOR {LANGUAGE}...
 ```
 
-_See code: [lib/commands/train.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/train.js)_
+_See code: [lib/commands/train.js](https://github.com/hubtype/botonic/blob/v0.11.2/lib/commands/train.js)_
 <!-- commandsstop -->

--- a/packages/botonic-cli/README.md
+++ b/packages/botonic-cli/README.md
@@ -8,41 +8,38 @@ Build Chatbots Using React
 [![License](https://img.shields.io/npm/l/@botonic/cli.svg)](https://github.com/hubtype/botonic/blob/master/package.json)
 
 <!-- toc -->
-
-- [Usage](#usage)
-- [Commands](#commands)
-  <!-- tocstop -->
+* [@botonic/cli](#botoniccli)
+* [Usage](#usage)
+* [Commands](#commands)
+<!-- tocstop -->
 
 # Usage
 
 <!-- usage -->
-
 ```sh-session
 $ npm install -g @botonic/cli
 $ botonic COMMAND
 running command...
 $ botonic (-v|--version|version)
-@botonic/cli/0.11.1 darwin-x64 node-v10.19.0
+@botonic/cli/0.11.2-alpha.0 darwin-x64 node-v10.19.0
 $ botonic --help [COMMAND]
 USAGE
   $ botonic COMMAND
 ...
 ```
-
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-
-- [`botonic deploy [BOT_NAME]`](#botonic-deploy-bot_name)
-- [`botonic help [COMMAND]`](#botonic-help-command)
-- [`botonic login`](#botonic-login)
-- [`botonic logout`](#botonic-logout)
-- [`botonic new NAME [TEMPLATENAME]`](#botonic-new-name-templatename)
-- [`botonic serve`](#botonic-serve)
-- [`botonic test`](#botonic-test)
-- [`botonic train`](#botonic-train)
+* [`botonic deploy [BOT_NAME]`](#botonic-deploy-bot_name)
+* [`botonic help [COMMAND]`](#botonic-help-command)
+* [`botonic login`](#botonic-login)
+* [`botonic logout`](#botonic-logout)
+* [`botonic new NAME [TEMPLATENAME]`](#botonic-new-name-templatename)
+* [`botonic serve`](#botonic-serve)
+* [`botonic test`](#botonic-test)
+* [`botonic train`](#botonic-train)
 
 ## `botonic deploy [BOT_NAME]`
 
@@ -67,7 +64,7 @@ EXAMPLE
   🚀 Bot deployed!
 ```
 
-_See code: [src/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.11.1/src/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/deploy.js)_
 
 ## `botonic help [COMMAND]`
 
@@ -98,7 +95,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [src/commands/login.js](https://github.com/hubtype/botonic/blob/v0.11.1/src/commands/login.js)_
+_See code: [lib/commands/login.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/login.js)_
 
 ## `botonic logout`
 
@@ -112,7 +109,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [src/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.11.1/src/commands/logout.js)_
+_See code: [lib/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/logout.js)_
 
 ## `botonic new NAME [TEMPLATENAME]`
 
@@ -132,7 +129,7 @@ EXAMPLE
   ✨ test_bot was successfully created!
 ```
 
-_See code: [src/commands/new.js](https://github.com/hubtype/botonic/blob/v0.11.1/src/commands/new.js)_
+_See code: [lib/commands/new.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/new.js)_
 
 ## `botonic serve`
 
@@ -147,7 +144,7 @@ EXAMPLE
   > Project is running at http://localhost:8080/
 ```
 
-_See code: [src/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.11.1/src/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/serve.js)_
 
 ## `botonic test`
 
@@ -174,7 +171,7 @@ EXAMPLE
   Ran all test suites.
 ```
 
-_See code: [src/commands/test.js](https://github.com/hubtype/botonic/blob/v0.11.1/src/commands/test.js)_
+_See code: [lib/commands/test.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/test.js)_
 
 ## `botonic train`
 
@@ -192,6 +189,5 @@ EXAMPLE
        TRAINING MODEL FOR {LANGUAGE}...
 ```
 
-_See code: [src/commands/train.js](https://github.com/hubtype/botonic/blob/v0.11.1/src/commands/train.js)_
-
+_See code: [lib/commands/train.js](https://github.com/hubtype/botonic/blob/v0.11.2-alpha.0/lib/commands/train.js)_
 <!-- commandsstop -->

--- a/packages/botonic-cli/package-lock.json
+++ b/packages/botonic-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/cli",
-  "version": "0.11.2-alpha.0",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-cli/package-lock.json
+++ b/packages/botonic-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/cli",
-  "version": "0.11.1",
+  "version": "0.11.2-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-cli/package-lock.json
+++ b/packages/botonic-cli/package-lock.json
@@ -207,14 +207,12 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -224,14 +222,21 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
       "version": "13.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.3.tgz",
-      "integrity": "sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==",
-      "dev": true
+      "integrity": "sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA=="
+    },
+    "@types/rimraf": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==",
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "analytics-node": {
       "version": "3.4.0-beta.1",
@@ -1788,6 +1793,17 @@
           "dev": true,
           "requires": {
             "rimraf": "^2.6.3"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         }
       }
@@ -1841,10 +1857,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
       }

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -10,6 +10,7 @@
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.14.0",
     "@oclif/plugin-help": "^2.2.3",
+    "@types/rimraf": "^3.0.0",
     "analytics-node": "^3.4.0-beta.1",
     "axios": "^0.19.2",
     "colors": "^1.4.0",
@@ -18,6 +19,7 @@
     "fs-extra": "^8.1.0",
     "inquirer": "^7.0.4",
     "ora": "^3.4.0",
+    "rimraf": "^3.0.2",
     "tslib": "^1.11.0",
     "zip-a-folder": "0.0.12"
   },

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.11.1",
+  "version": "0.11.2-alpha.0",
   "bin": {
     "botonic": "./bin/run"
   },

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.11.2-alpha.0",
+  "version": "0.11.2",
   "bin": {
     "botonic": "./bin/run"
   },

--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -58,7 +58,6 @@ Uploading...
   async run() {
     const { args, flags } = this.parse(Run)
     track('Deployed Botonic CLI')
-
     force = flags.force || false
     npmCommand = flags.command
     this.botName = flags.botName
@@ -283,6 +282,7 @@ Uploading...
       text: 'Creating bundle...',
       spinner: 'bouncingBar',
     }).start()
+    if (fs.existsSync('tmp')) fs.rmdirSync('tmp')
     fs.mkdirSync(join('tmp'))
     copySync('dist', join('tmp', 'dist'))
     const zipRes = await zip('tmp', join(BOTONIC_BUNDLE_FILE))

--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -7,6 +7,7 @@ import { zip } from 'zip-a-folder'
 
 import * as fs from 'fs'
 import * as ora from 'ora'
+import * as rimraf from 'rimraf'
 
 import { BotonicAPIService } from '../botonicapiservice'
 import { track, sleep } from '../utils'
@@ -282,7 +283,7 @@ Uploading...
       text: 'Creating bundle...',
       spinner: 'bouncingBar',
     }).start()
-    if (fs.existsSync('tmp')) fs.rmdirSync('tmp')
+    if (fs.existsSync('tmp')) rimraf.sync('tmp')
     fs.mkdirSync(join('tmp'))
     copySync('dist', join('tmp', 'dist'))
     const zipRes = await zip('tmp', join(BOTONIC_BUNDLE_FILE))

--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -283,6 +283,7 @@ Uploading...
       text: 'Creating bundle...',
       spinner: 'bouncingBar',
     }).start()
+    // Why using rimraf instead of fs.rmdirSync?: https://stackoverflow.com/a/57834155/145289
     if (fs.existsSync('tmp')) rimraf.sync('tmp')
     fs.mkdirSync(join('tmp'))
     copySync('dist', join('tmp', 'dist'))


### PR DESCRIPTION
I managed to reproduce the following error by creating manually a `tmp` file in my bot's project directory.

```shell
? Do you want to create a new Bot? Yes
? Bot name: borar65
✔ Building...
[    ] Creating bundle...Deploy Error { Error: EEXIST: file already exists, mkdir 'tmp'
    at Object.mkdirSync (fs.js:757:3)
    at Run.createBundle (/usr/local/lib/node_modules/@botonic/cli/lib/commands/deploy.js:222:12)
    at Run.deploy (/usr/local/lib/node_modules/@botonic/cli/lib/commands/deploy.js:302:24)
    at process._tickCallback (internal/process/next_tick.js:68:7) errno: -17, syscall: 'mkdir', code: 'EEXIST', path: 'tmp' }
[==  ] Creating bundle...^C
```

Taking a deeper look on it, it seems that sometimes we have the residual `tmp` directory if a deploy failed previously at certain point or we abort the command in the middle of the process. 
I managed to solve it being sure that we always check and delete this directory whichever it was the situation. Now seems that it's not stuck in this part of deploy process at least.

**Updated**:
I keep it testing more with the new fix and forcing the error to occur. Now sometimes the error is exactly the opposite, directory `tmp` doesn't exist. As I read, fs doesn't remove the content recursively. I tried to pass also the flag `recursive: true` in options (it only works under experimental mode in Node v12).  Now I'm using `rimraf` instead which seems to work better for these situations. [Ref](https://stackoverflow.com/questions/18052762/remove-directory-which-is-not-empty) 

