### PR TITLE
chore(react): eslint plugin for react hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4853,6 +4853,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
+      "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
+    "eslint-plugin-react-hooks": "^2.5.1",
     "eslint_d": "^8.1.1",
     "jest": "^25.2.7",
     "jest-each": "^25.1.0",

--- a/packages/botonic-react/.eslintrc.js
+++ b/packages/botonic-react/.eslintrc.js
@@ -8,9 +8,12 @@ module.exports = {
       jsx: true, // Allows for the parsing of JSX
     },
   },
+  plugins: ['react-hooks'],
   rules: {
     // REACT
     'react/prop-types': ['error', { skipUndeclared: true }],
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
     '@typescript-eslint/no-use-before-define': [
       'error', // we have many variables which are actually functions
       { variables: false, functions: false, classes: false },

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -73,6 +73,7 @@ export const Message = props => {
     e => ![Button, Reply].includes(e.type)
   )
   if (isBrowser()) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       const decomposedChildren = json
       const message = {
@@ -100,6 +101,7 @@ export const Message = props => {
       addMessage(message)
     }, [])
 
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       const msg = webchatState.messagesJSON.find(m => m.id === state.id)
       if (

--- a/packages/botonic-react/src/webchat/session-view.jsx
+++ b/packages/botonic-react/src/webchat/session-view.jsx
@@ -98,6 +98,7 @@ const KeepSessionContainer = styled.div`
 `
 
 export const SessionView = props => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { webchatState, updateDevSettings } = props.webchatHooks || useWebchat()
   const { latestInput: input, session, lastRoutePath } = webchatState
   const toggleSessionView = () =>

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -140,6 +140,7 @@ export const Webchat = forwardRef((props, ref) => {
     clearMessages,
     openWebviewT,
     closeWebviewT,
+    // eslint-disable-next-line react-hooks/rules-of-hooks
   } = props.webchatHooks || useWebchat()
   const { theme } = webchatState
   const { initialSession, initialDevSettings, onStateChange } = props


### PR DESCRIPTION
- Disabled the rule "hook is called conditionally" where the condition was constant. Despite https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level , when the condition is fixed I don't think there should be an issue.
- Plugin added to root because IDEs may require plugins to be in some folder as eslint