### PR TITLE
feat(core): get agent vacations ranges

### DIFF
--- a/packages/botonic-core/index.d.ts
+++ b/packages/botonic-core/index.d.ts
@@ -130,7 +130,7 @@ interface VacationRange {
   start_date: number // timestamp
   end_date: number // timestamp
 }
-export declare function getAgentVacationsRanges(
+export declare function getAgentVacationRanges(
   session: Session,
   agentParams: { agentId?: string; agentEmail?: string }
 ): Promise<{ vacation_ranges: VacationRange[] }>

--- a/packages/botonic-core/index.d.ts
+++ b/packages/botonic-core/index.d.ts
@@ -125,6 +125,16 @@ export declare function getAvailableAgents(
   session: Session
 ): Promise<{ agents: HubtypeAgentsInfo[] }>
 
+interface VacationRange {
+  id: number
+  start_date: number // timestamp
+  end_date: number // timestamp
+}
+export declare function getAgentVacationsRanges(
+  session: Session,
+  agentParams: { agentId?: string; agentEmail?: string }
+): Promise<{ vacation_ranges: VacationRange[] }>
+
 export declare function cancelHandoff(
   session: Session,
   typification?: string

--- a/packages/botonic-core/src/handoff.js
+++ b/packages/botonic-core/src/handoff.js
@@ -1,7 +1,9 @@
 import axios from 'axios'
 
+const HUBTYPE_API_URL = 'https://api.hubtype.com'
+
 export async function getOpenQueues(session) {
-  const baseUrl = session._hubtype_api || 'https://api.hubtype.com'
+  const baseUrl = session._hubtype_api || HUBTYPE_API_URL
   const endpointUrl = `${baseUrl}/v1/queues/get_open_queues/`
   const resp = await axios({
     headers: {
@@ -129,7 +131,7 @@ async function _humanHandOff(
 }
 
 export async function storeCaseRating(session, rating) {
-  const baseUrl = session._hubtype_api || 'https://api.hubtype.com'
+  const baseUrl = session._hubtype_api || HUBTYPE_API_URL
   const chatId = session.user.id
   const resp = await axios({
     headers: {
@@ -143,7 +145,7 @@ export async function storeCaseRating(session, rating) {
 }
 
 export async function getAvailableAgentsByQueue(session, queueId) {
-  const baseUrl = session._hubtype_api || 'https://api.hubtype.com'
+  const baseUrl = session._hubtype_api || HUBTYPE_API_URL
   const resp = await axios({
     headers: {
       Authorization: `Bearer ${session._access_token}`,
@@ -156,7 +158,7 @@ export async function getAvailableAgentsByQueue(session, queueId) {
 }
 
 export async function getAvailableAgents(session) {
-  const baseUrl = session._hubtype_api || 'https://api.hubtype.com'
+  const baseUrl = session._hubtype_api || HUBTYPE_API_URL
   const botId = session.bot.id
   const resp = await axios({
     headers: {
@@ -168,18 +170,15 @@ export async function getAvailableAgents(session) {
   return resp.data
 }
 
-export async function getAgentVacationsRanges(
-  session,
-  { agentId, agentEmail }
-) {
-  const baseUrl = session._hubtype_api || 'https://api.hubtype.com'
+export async function getAgentVacationRanges(session, { agentId, agentEmail }) {
+  const baseUrl = session._hubtype_api || HUBTYPE_API_URL
   const botId = session.bot.id
   const resp = await axios({
     headers: {
       Authorization: `Bearer ${session._access_token}`,
     },
     method: 'get',
-    url: `${baseUrl}/v1/bots/${botId}/get_agent_vacations_ranges/`,
+    url: `${baseUrl}/v1/bots/${botId}/get_agent_vacation_ranges/`,
     params: { agent_id: agentId, agent_email: agentEmail },
   })
   return resp.data

--- a/packages/botonic-core/src/handoff.js
+++ b/packages/botonic-core/src/handoff.js
@@ -168,6 +168,23 @@ export async function getAvailableAgents(session) {
   return resp.data
 }
 
+export async function getAgentVacationsRanges(
+  session,
+  { agentId, agentEmail }
+) {
+  const baseUrl = session._hubtype_api || 'https://api.hubtype.com'
+  const botId = session.bot.id
+  const resp = await axios({
+    headers: {
+      Authorization: `Bearer ${session._access_token}`,
+    },
+    method: 'get',
+    url: `${baseUrl}/v1/bots/${botId}/get_agent_vacations_ranges/`,
+    params: { agent_id: agentId, agent_email: agentEmail },
+  })
+  return resp.data
+}
+
 export function cancelHandoff(session, typification = null) {
   let action = 'discard_case'
   if (typification) action = `${action}:${JSON.stringify({ typification })}`

--- a/packages/botonic-core/src/index.js
+++ b/packages/botonic-core/src/index.js
@@ -6,7 +6,7 @@ export {
   HandOffBuilder,
   storeCaseRating,
   getAvailableAgents,
-  getAgentVacationsRanges,
+  getAgentVacationRanges,
   cancelHandoff,
   deleteUser,
 } from './handoff'

--- a/packages/botonic-core/src/index.js
+++ b/packages/botonic-core/src/index.js
@@ -6,6 +6,7 @@ export {
   HandOffBuilder,
   storeCaseRating,
   getAvailableAgents,
+  getAgentVacationsRanges,
   cancelHandoff,
   deleteUser,
 } from './handoff'


### PR DESCRIPTION
**UPDATED: Renamed `ranges` to `vacation_ranges` to be more explicit**

* Added new method to read agent vacations ranges.

Usage:

```
import { getAgentVacationRanges } from "@botonic/core";

const res = await getAgentVacationRanges(session, {
        agentId: "SOME_AGENT_ID",
      });
for (let range of res.ranges){
....
}
```
Then in the bot we will receive the ranges with start_date, end_date in timestamp format (can be managed easily with Date or libraries like moment)

![Screenshot 2020-04-08 at 17 52 37](https://user-images.githubusercontent.com/35448568/78808822-4537ed00-79c6-11ea-9767-c556fa8f5a69.png)

