### PR TITLE
Avoid error log empty payload

### DIFF
--- a/packages/botonic-core/index.d.ts
+++ b/packages/botonic-core/index.d.ts
@@ -58,6 +58,7 @@ type RouteMatcher =
 export interface Route {
   path?: StringMatcher
   action?: any
+  retryAction?: any
   redirect?: string
   childRoutes?: Route[]
 

--- a/packages/botonic-core/src/router.js
+++ b/packages/botonic-core/src/router.js
@@ -123,6 +123,9 @@ export class Router {
 
   getOnFinishParams(input) {
     try {
+      if (!input.payload) {
+        return undefined
+      }
       const params = input.payload.split('__PATH_PAYLOAD__')
       if (params.length < 2) {
         return undefined

--- a/packages/botonic-core/src/router.test.js
+++ b/packages/botonic-core/src/router.test.js
@@ -244,6 +244,7 @@ describe('Process input (v<0.9)', () => {
 })
 
 test.each([
+  [undefined, undefined, undefined],
   ['', undefined, undefined],
   ['bad_input', undefined, undefined],
   ['__PATH_PAYLOAD__', '', undefined],

--- a/packages/botonic-react/src/index.d.ts
+++ b/packages/botonic-react/src/index.d.ts
@@ -9,6 +9,7 @@ export interface BotResponse extends core.BotRequest {
 
 export interface Route extends core.Route {
   action?: typeof React.Component
+  retryAction?: typeof React.Component
 }
 type Routes = core.Routes<Route>
 


### PR DESCRIPTION
## Description
* avoid error log when input.payload is empty
* add retryAction to botonic-core and botonic-react types
 
## Context
* when input.payload was empty, a console.error prined "ERROR getOnFinishParams"

## Testing
The pull request...
- [x] has unit tests
