### PR TITLE
Contentful/ chore and util improvements 1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ ij_typescript_use_double_quotes = false
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.snap]
+trim_trailing_whitespace = false

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^2.5.1",
     "eslint_d": "^8.1.1",
-    "jest": "^25.2.7",
+    "jest": "^25.3.0",
     "jest-each": "^25.1.0",
     "lerna": "^3.19.0",
     "prettier": "^2.0.4",

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -149,6 +149,12 @@ export class Button extends Content {
     }
     return undefined
   }
+
+  cloneWithText(newText: string): this {
+    const clone = shallowClone(this)
+    ;(clone as any).text = newText
+    return clone
+  }
 }
 
 export class StartUp extends MessageContent {
@@ -177,6 +183,12 @@ export class Carousel extends MessageContent {
   validate(): string | undefined {
     return Content.validateContents(this.elements)
   }
+
+  cloneWithElements(elements: Element[]): this {
+    const clone = shallowClone(this)
+    ;(clone as any).elements = elements
+    return clone
+  }
 }
 
 /** Part of a carousel */
@@ -195,6 +207,12 @@ export class Element extends Content {
 
   validate(): string | undefined {
     return Content.validateContents(this.buttons)
+  }
+
+  cloneWithButtons(buttons: Button[]): this {
+    const clone = shallowClone(this)
+    ;(clone as any).buttons = buttons
+    return clone
   }
 }
 

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -69,7 +69,7 @@ export abstract class TopContent extends Content {
     return new TopContentId(this.contentType, this.id)
   }
 
-  cloneWithFollowUp(newFollowUp: FollowUp): this {
+  cloneWithFollowUp(newFollowUp: FollowUp | undefined): this {
     const clone = shallowClone(this)
     ;(clone as any).common = shallowClone(clone.common)
     ;(clone as any).common.followUp = newFollowUp
@@ -102,7 +102,8 @@ export class CommonFields {
    */
   readonly partitions: string[]
   readonly dateRange?: DateRangeContent
-  followUp?: FollowUp
+  readonly followUp?: FollowUp // TODO move to MessageContent
+
   constructor(
     readonly id: string,
     readonly name: string,
@@ -169,6 +170,12 @@ export class StartUp extends MessageContent {
 
   validate(): string | undefined {
     return Content.validateContents(this.buttons)
+  }
+
+  cloneWithText(newText: string): this {
+    const clone = shallowClone(this)
+    ;(clone as any).text = newText
+    return clone
   }
 }
 
@@ -286,4 +293,4 @@ export class ScheduleContent extends TopContent {
 /**
  * A {@link Content} which is automatically displayed after another one
  */
-export type FollowUp = Text | Carousel | Image | StartUp
+export type FollowUp = MessageContent

--- a/packages/botonic-plugin-contentful/src/contentful/contents/button.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/button.ts
@@ -68,7 +68,7 @@ export class ButtonDelivery {
     return new cms.Button(
       buttonEntry.sys.id,
       buttonEntry.fields.name,
-      buttonEntry.fields.text,
+      buttonEntry.fields.text ?? '',
       callback
     )
   }
@@ -96,7 +96,7 @@ export class ButtonDelivery {
       entry
     ) as cms.TopContentType
     if (modelType === ContentType.URL) {
-      return cms.Callback.ofUrl((entry.fields as UrlFields).url)
+      return cms.Callback.ofUrl((entry.fields as UrlFields).url || '')
     }
     return new cms.ContentCallback(modelType, entry.sys.id)
   }
@@ -106,7 +106,7 @@ export class ButtonDelivery {
     switch (model) {
       case ContentType.URL: {
         const urlFields = target as contentful.Entry<UrlFields>
-        return cms.Callback.ofUrl(urlFields.fields.url)
+        return cms.Callback.ofUrl(urlFields.fields.url || '')
       }
       case ButtonDelivery.PAYLOAD_CONTENT_TYPE: {
         const payloadFields = target as contentful.Entry<PayloadFields>
@@ -136,6 +136,6 @@ type ButtonTarget = contentful.Entry<
 >
 
 export interface ButtonFields extends ContentWithNameFields {
-  text: string
+  text?: string
   target?: ButtonTarget
 }

--- a/packages/botonic-plugin-contentful/src/contentful/contents/carousel.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/carousel.ts
@@ -56,8 +56,8 @@ export class CarouselDelivery extends DeliveryWithFollowUp {
         new cms.Element(
           entry.sys.id,
           buttons,
-          fields.title,
-          fields.subtitle,
+          fields.title ?? '',
+          fields.subtitle ?? '',
           fields.pic && ContentfulEntryUtils.urlFromAsset(fields.pic)
         )
     )
@@ -65,8 +65,8 @@ export class CarouselDelivery extends DeliveryWithFollowUp {
 }
 
 interface ElementFields {
-  title: string
-  subtitle: string
+  title?: string
+  subtitle?: string
   pic?: contentful.Asset
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   buttons?: contentful.Entry<any>[]

--- a/packages/botonic-plugin-contentful/src/contentful/contents/carousel.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/carousel.ts
@@ -8,7 +8,7 @@ import {
   ContentfulEntryUtils,
 } from '../delivery-api'
 
-// TODO remove DeliveryWithFollowUp
+// TODO does not yet load the followU p
 export class CarouselDelivery extends DeliveryWithFollowUp {
   constructor(delivery: DeliveryApi, readonly button: ButtonDelivery) {
     super(cms.ContentType.CAROUSEL, delivery)

--- a/packages/botonic-plugin-contentful/src/contentful/contents/follow-up.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/follow-up.ts
@@ -77,7 +77,14 @@ export class FollowUpDelivery {
   }
 
   async commonFields(entry: Entry<CommonEntryFields>, context: cms.Context) {
-    const common = ContentfulEntryUtils.commonFieldsFromEntry(entry)
+    const followUp = await this.getFollowUp(entry, context)
+    return ContentfulEntryUtils.commonFieldsFromEntry(entry, followUp)
+  }
+
+  private async getFollowUp(
+    entry: Entry<CommonEntryFields>,
+    context: cms.Context
+  ): Promise<cms.FollowUp | undefined> {
     if (entry.fields.followup) {
       const followUp = entry.fields.followup.sys.contentType
         ? entry.fields.followup
@@ -85,10 +92,8 @@ export class FollowUpDelivery {
             entry.fields.followup.sys.id,
             context
           )
-
-      common.followUp = await this.fromEntry(followUp, context)
-      return common
+      return (await this.fromEntry(followUp, context)) as cms.FollowUp
     }
-    return common
+    return undefined
   }
 }

--- a/packages/botonic-plugin-contentful/src/contentful/contents/startup.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/startup.ts
@@ -41,7 +41,7 @@ export class StartUpDelivery extends DeliveryWithFollowUp {
     return new cms.StartUp(
       await this.getFollowUp().commonFields(entry, context),
       img,
-      fields.text,
+      fields.text ?? '',
       buttons
     )
   }
@@ -49,7 +49,7 @@ export class StartUpDelivery extends DeliveryWithFollowUp {
 
 export interface StartUpFields extends CommonEntryFields {
   pic?: contentful.Asset
-  text: string
+  text?: string
   // typed as any because we might only get the entry.sys but not the fields
   buttons?: contentful.Entry<any>[]
 }

--- a/packages/botonic-plugin-contentful/src/contentful/contents/text.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/text.ts
@@ -44,7 +44,7 @@ export class TextDelivery extends DeliveryWithFollowUp {
       common.followUp = followUp
       return new cms.Text(
         common,
-        fields.text,
+        fields.text ?? '',
         buttons,
         fields.buttonsStyle == 'QuickReplies'
           ? cms.ButtonStyle.QUICK_REPLY
@@ -56,7 +56,7 @@ export class TextDelivery extends DeliveryWithFollowUp {
 
 export interface TextFields extends CommonEntryFields {
   // Full text
-  text: string
+  text?: string
   // typed as any because we might only get the entry.sys but not the fields
   buttons?: contentful.Entry<any>[]
   buttonsStyle?: string

--- a/packages/botonic-plugin-contentful/src/contentful/contents/text.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/text.ts
@@ -40,8 +40,7 @@ export class TextDelivery extends DeliveryWithFollowUp {
     return Promise.all(promises).then(followUpAndButtons => {
       const followUp = followUpAndButtons.shift() as cms.FollowUp | undefined
       const buttons = followUpAndButtons as cms.Button[]
-      const common = ContentfulEntryUtils.commonFieldsFromEntry(entry)
-      common.followUp = followUp
+      const common = ContentfulEntryUtils.commonFieldsFromEntry(entry, followUp)
       return new cms.Text(
         common,
         fields.text ?? '',

--- a/packages/botonic-plugin-contentful/src/contentful/contents/url.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/url.ts
@@ -17,11 +17,11 @@ export class UrlDelivery extends DeliveryWithFollowUp {
   async fromEntry(entry: contentful.Entry<UrlFields>, context: Context) {
     return new cms.Url(
       await this.getFollowUp().commonFields(entry, context),
-      entry.fields.url
+      entry.fields.url || ''
     )
   }
 }
 
 export interface UrlFields extends CommonEntryFields {
-  url: string
+  url?: string
 }

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -6,6 +6,7 @@ import {
   Content,
   ContentType,
   Context,
+  FollowUp,
   SearchableBy,
   TopContent,
   TopContentType,
@@ -172,7 +173,10 @@ export class ContentfulEntryUtils {
     return 'https:' + assetField.fields.file.url
   }
 
-  static commonFieldsFromEntry(entry: Entry<CommonEntryFields>): CommonFields {
+  static commonFieldsFromEntry(
+    entry: Entry<CommonEntryFields>,
+    followUp?: FollowUp
+  ): CommonFields {
     const fields = entry.fields
 
     const searchableBy =
@@ -192,6 +196,7 @@ export class ContentfulEntryUtils {
       partitions: fields.partitions,
       searchableBy,
       dateRange,
+      followUp,
     })
   }
 }

--- a/packages/botonic-plugin-contentful/src/index.ts
+++ b/packages/botonic-plugin-contentful/src/index.ts
@@ -5,5 +5,6 @@ export * from './render'
 export * from './search'
 export * from './time'
 export * from './tools'
+export * from './util'
 
 export { default, CmsOptions, ContentfulOptions } from './plugin'

--- a/packages/botonic-plugin-contentful/src/util/index.ts
+++ b/packages/botonic-plugin-contentful/src/util/index.ts
@@ -1,0 +1,1 @@
+export * from './objects'

--- a/packages/botonic-plugin-contentful/src/util/objects.ts
+++ b/packages/botonic-plugin-contentful/src/util/objects.ts
@@ -51,3 +51,13 @@ export const deepClone = <T>(target: T, alreadyCloned: object[] = []): T => {
   }
   return target
 }
+
+export interface Equatable {
+  equals(other: Equatable): boolean
+}
+
+export interface Stringable {
+  toString(): string
+}
+
+export interface ValueObject extends Equatable, Stringable {}


### PR DESCRIPTION
* new content cloners
* type contentful entry fields as undefineable as they should be
* ValueObject (Stringable & Equatable) implemented in Callback & ContentId
* followUp fields is now readonly to ensure immutability