### PR TITLE
fix: add comments to annoying pr templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,34 @@
 _Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
-_[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) 
+[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)
+
 ## Description
+
+<!--
 - Must be clear and concise (2-3 lines).
   - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
   - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
-  - If you consider it appropriate, include the steps to try the new features.  
+  - If you consider it appropriate, include the steps to try the new features.
+-->
+
 ## Context
-* What problem is trying to solve this pull request?
-* What are the reasons or business goals of this implementation?
-* Can I provide visual resources or links to understand better the situation?  
+
+<!--
+- What problem is trying to solve this pull request?
+- What are the reasons or business goals of this implementation?
+- Can I provide visual resources or links to understand better the situation?
+-->
+
 ## Approach taken / Explain the design
-* Explain what the code does.
-* If it's a complex solution, try to provide a sketch.
+
+<!--
+- Explain what the code does.
+- If it's a complex solution, try to provide a sketch.
+-->
+
 ## Testing
+
 The pull request...
+
 - [ ] has unit tests
 - [ ] has integration tests
 - [ ] doesn't need tests because... **[provide a description]**


### PR DESCRIPTION
Leave sections commented in PR template file. You can now simply add your descriptions.