### PR TITLE
fix: updating last messages depending on last message update

### DIFF
--- a/packages/.eslintrc.js
+++ b/packages/.eslintrc.js
@@ -14,8 +14,8 @@ module.exports = {
     ecmaVersion: 2017, // async is from ecma2017. Supported in node >=7.10
     sourceType: 'module', // Allows for the use of imports
     ecmaFeatures: {
-      jsx: true // Allows for the parsing of JSX
-    }
+      jsx: true, // Allows for the parsing of JSX
+    },
   },
   // npm run lint runs eslint with --quiet --fix so that only errors are fixed
   rules: {
@@ -23,7 +23,7 @@ module.exports = {
     'prettier/prettier': 'error',
     'filenames/match-regex': ['error', '^[a-z-.]+$', true],
 
-    complexity: ['error', { max: 18 }],
+    complexity: ['error', { max: 19 }],
 
     // In typescript we must use obj.field when we have the types, and obj['field'] when we don't
     // Not set to warn because Webstorm cannot fix eslint rules with --quiet https://youtrack.jetbrains.com/issue/WEB-39246
@@ -37,7 +37,7 @@ module.exports = {
     'consistent-return': 'error',
     'jest/no-export': 'warn',
     'no-empty': 'warn',
-    "prefer-const": ["error", { "destructuring": "all"}],
+    'prefer-const': ['error', { destructuring: 'all' }],
 
     // special for TYPESCRIPT
     '@typescript-eslint/ban-ts-ignore': 'warn',

--- a/packages/botonic-core/package-lock.json
+++ b/packages/botonic-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.11.2-alpha.1",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.11.2-alpha.1",
+  "version": "0.11.2",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -11,7 +11,7 @@ export class HubtypeService {
     this.lastMessageId = lastMessageId
     this.lastMessageUpdateDate = lastMessageUpdateDate
     this.onEvent = onEvent
-    if (user.id && lastMessageId) this.init()
+    if (user.id && (lastMessageId || lastMessageUpdateDate)) this.init()
   }
 
   init(user, lastMessageId, lastMessageUpdate) {

--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -5,17 +5,19 @@ const PUSHER_KEY = process.env.WEBCHAT_PUSHER_KEY || '434ca667c8e6cb3f641c'
 const HUBTYPE_API_URL = process.env.HUBTYPE_API_URL || 'https://api.hubtype.com'
 
 export class HubtypeService {
-  constructor({ appId, user, lastMessageId, onEvent }) {
+  constructor({ appId, user, lastMessageId, lastMessageUpdateDate, onEvent }) {
     this.appId = appId
     this.user = user || {}
     this.lastMessageId = lastMessageId
+    this.lastMessageUpdateDate = lastMessageUpdateDate
     this.onEvent = onEvent
     if (user.id && lastMessageId) this.init()
   }
 
-  init(user, lastMessageId) {
+  init(user, lastMessageId, lastMessageUpdate) {
     if (user) this.user = user
     if (lastMessageId) this.lastMessageId = lastMessageId
+    if (lastMessageUpdate) this.lastMessageUpdate = lastMessageUpdate
     if (this.pusher || !this.user.id || !this.appId) return null
     this.pusher = new Pusher(PUSHER_KEY, {
       cluster: 'eu',
@@ -25,6 +27,7 @@ export class HubtypeService {
         headers: {
           'X-BOTONIC-USER-ID': this.user.id,
           'X-BOTONIC-LAST-MESSAGE-ID': this.lastMessageId,
+          'X-BOTONIC-LAST-MESSAGE-UPDATE-DATE': this.lastMessageUpdate,
         },
       },
     })

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -59,6 +59,7 @@ export class WebchatApp {
         appId: this.appId,
         user,
         lastMessageId: lastMessage && lastMessage.id,
+        lastMessageUpdateDate: this.getLastMessageUpdate(),
         onEvent: event => this.onServiceEvent(event),
       })
     }
@@ -124,6 +125,10 @@ export class WebchatApp {
 
   clearMessages() {
     this.webchatRef.current.clearMessages()
+  }
+
+  getLastMessageUpdate() {
+    return this.webchatRef.current.getLastMessageUpdate()
   }
 
   getComponent(optionsAtRuntime = {}) {

--- a/packages/botonic-react/src/webchat/hooks.js
+++ b/packages/botonic-react/src/webchat/hooks.js
@@ -30,6 +30,7 @@ export const webchatInitialState = {
   error: {},
   devSettings: {},
   isWebchatOpen: false,
+  lastMessageUpdate: undefined,
 }
 
 export function useWebchat() {
@@ -101,6 +102,12 @@ export function useWebchat() {
       type: 'clearMessages',
     })
   }
+  const updateLastMessageDate = date => {
+    webchatDispatch({
+      type: 'updateLastMessageDate',
+      payload: date,
+    })
+  }
 
   return {
     webchatState,
@@ -121,6 +128,7 @@ export function useWebchat() {
     toggleWebchat,
     setError,
     clearMessages,
+    updateLastMessageDate,
   }
 }
 

--- a/packages/botonic-react/src/webchat/webchat-reducer.js
+++ b/packages/botonic-react/src/webchat/webchat-reducer.js
@@ -42,7 +42,7 @@ export function webchatReducer(state, action) {
     case 'updateLastMessageDate':
       return {
         ...state,
-        lastMessageUpdate: action.payload || undefined,
+        lastMessageUpdate: action.payload,
       }
     default:
       throw new Error()

--- a/packages/botonic-react/src/webchat/webchat-reducer.js
+++ b/packages/botonic-react/src/webchat/webchat-reducer.js
@@ -39,6 +39,11 @@ export function webchatReducer(state, action) {
         messagesJSON: [],
         messagesComponents: [],
       }
+    case 'updateLastMessageDate':
+      return {
+        ...state,
+        lastMessageUpdate: action.payload || undefined,
+      }
     default:
       throw new Error()
   }

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -149,6 +149,7 @@ export const Webchat = forwardRef((props, ref) => {
     clearMessages,
     openWebviewT,
     closeWebviewT,
+    updateLastMessageDate,
     // eslint-disable-next-line react-hooks/rules-of-hooks
   } = props.webchatHooks || useWebchat()
   const { theme } = webchatState
@@ -174,8 +175,14 @@ export const Webchat = forwardRef((props, ref) => {
 
   // Load initial state from localStorage
   useEffect(() => {
-    let { user, messages, session, lastRoutePath, devSettings } =
-      botonicState || {}
+    let {
+      user,
+      messages,
+      session,
+      lastRoutePath,
+      devSettings,
+      lastMessageUpdate,
+    } = botonicState || {}
     if (!user || Object.keys(user).length == 0) user = createUser()
     updateUser(user)
     if (
@@ -200,6 +207,7 @@ export const Webchat = forwardRef((props, ref) => {
     } else updateSession(initialSession)
     if (devSettings) updateDevSettings(devSettings)
     else if (initialDevSettings) updateDevSettings(initialDevSettings)
+    if (lastMessageUpdate) updateLastMessageDate(lastMessageUpdate)
     if (props.onInit) setTimeout(() => props.onInit(), 100)
   }, [])
 
@@ -218,6 +226,7 @@ export const Webchat = forwardRef((props, ref) => {
         session: webchatState.session,
         lastRoutePath: webchatState.lastRoutePath,
         devSettings: webchatState.devSettings,
+        lastMessageUpdate: webchatState.lastMessageUpdate,
       })
     )
   }, [
@@ -226,6 +235,7 @@ export const Webchat = forwardRef((props, ref) => {
     webchatState.session,
     webchatState.lastRoutePath,
     webchatState.devSettings,
+    webchatState.lastMessageUpdate,
   ])
 
   useTyping({ webchatState, updateTyping, updateMessage })
@@ -356,6 +366,7 @@ export const Webchat = forwardRef((props, ref) => {
         lastRoutePath: webchatState.lastRoutePath,
       })
     updateLatestInput(input)
+    updateLastMessageDate(new Date())
     updateReplies(false)
     setPersistentMenuIsOpened(false)
     setEmojiPickerIsOpened(false)
@@ -378,6 +389,7 @@ export const Webchat = forwardRef((props, ref) => {
         updateHandoff(handoff)
       }
       if (lastRoutePath) updateLastRoutePath(lastRoutePath)
+      updateLastMessageDate(new Date())
     },
     setTyping: typing => updateTyping(typing),
     addUserMessage: message => sendInput(message),
@@ -397,6 +409,7 @@ export const Webchat = forwardRef((props, ref) => {
     clearMessages: () => {
       clearMessages()
     },
+    getLastMessageUpdate: () => webchatState.lastMessageUpdate,
   }))
 
   const resolveCase = () => {


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
* Added methods with @guinii  to set a `lastMessageUpdate` in order to be read after and ensure all the messages are loaded in the enduser side in the right way.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
If the agent was the last to write in a chat, the information of some messages was missing if the enduser closed the tab of Botonic.
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design
<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->
Store and keep updaing a lastMessageUpdate timestamp to keep tracking messages to be updated correctly.

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [X] doesn't need tests because... It's quite critical
