### PR TITLE
feat(react): multichannel to allow separating messages with custom st…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.5.0
     hooks:
       - id: check-yaml
       - id: check-added-large-files

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -30,7 +30,7 @@
     "moment": "^2.24.0",
     "react": "^16.13.0",
     "react-children-utilities": "^2.1.0",
-    "react-dom": "^16.13.0",
+    "react-dom": "^16.13.1",
     "react-frame-component": "^4.1.1",
     "react-json-tree": "^0.11.2",
     "react-reveal": "^1.2.2",

--- a/packages/botonic-react/src/components/multichannel/index.d.ts
+++ b/packages/botonic-react/src/components/multichannel/index.d.ts
@@ -9,14 +9,16 @@ export interface MultichannelViewOptions {
 
 export interface MultichannelContextType extends MultichannelViewOptions {
   currentIndex: number | string // can be letter or number
-  oneMessagePerComponent?: boolean
+  /** @see same field at MultichannelProps */
+  messageSeparator?: string
 }
 
 // Text
 export interface MultichannelTextProps extends MultichannelViewOptions {
   index?: string
   indexMode?: IndexMode
-  newline?: boolean
+  /** Defaults to no separator between lines*/
+  newline?: string
 }
 
 export const MultichannelText: React.FunctionComponent<MultichannelTextProps>
@@ -32,7 +34,7 @@ export const MultichannelCarousel: React.FunctionComponent<MultichannelCarouselP
 
 // Button
 export interface MultichannelButtonProps {
-  newline?: boolean
+  newline?: string
 }
 export const MultichannelButton: React.FunctionComponent<MultichannelButtonProps>
 
@@ -40,7 +42,13 @@ export interface MultichannelProps extends MultichannelViewOptions {
   firstIndex?: number | string
   carousel?: MultichannelCarouselProps
   text?: MultichannelTextProps
-  oneMessagePerComponent?: boolean
+  /**
+   * If undefined, each component will be served in a different botonic message
+   * '' will concatenate in the same line
+   * '\n' will split in different lines
+   * '\n\n' will separate with an empty line
+   **/
+  messageSeparator?: string
 }
 
 export const Multichannel: React.FunctionComponent<MultichannelProps>

--- a/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
@@ -42,7 +42,7 @@ export const MultichannelButton = props => {
 
   const getText = () => {
     let text = props.children
-    const newline = props.newline ? '\n' : ''
+    const newline = props.newline || ''
     const separator = multichannelContext.indexSeparator || ' '
     const index = multichannelContext.currentIndex
       ? `${formatIndex(multichannelContext.currentIndex + separator)} `

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -65,20 +65,21 @@ export const MultichannelText = props => {
     elements = [].concat([...text], [...postbackButtons], [...urlButtons])
     multichannelContext.currentIndex = getDefaultIndex()
     elements = elements.map((element, i) => {
-      const newline = multichannelContext.oneMessagePerComponent ? i > 0 : true
+      const newline =
+        multichannelContext.messageSeparator == null && i === 0 ? '' : '\n'
       if (isMultichannelButton(element) || isMultichannelReply(element)) {
         return (
           <MultichannelButton key={i} newline={newline} {...element.props}>
             {element.props.children}
           </MultichannelButton>
         )
-      } else if (typeof element === 'string' && props.newline) {
-        return '\n' + element
+      } else if (typeof element === 'string') {
+        return (props.newline || '') + element
       } else {
         return element
       }
     })
-    if (!multichannelContext.oneMessagePerComponent) {
+    if (multichannelContext.messageSeparator != null) {
       return elements
     }
     return <Text {...props}>{elements}</Text>

--- a/packages/botonic-react/src/components/multichannel/multichannel.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel.jsx
@@ -37,7 +37,8 @@ export const Multichannel = props => {
           {...child.props}
           {...props.text}
           key={props.key}
-          {...(!props.oneMessagePerComponent && index > 0 && { newline: true })}
+          {...(props.messageSeparator &&
+            index > 0 && { newline: props.messageSeparator })}
         >
           {child.props.children}
         </MultichannelText>
@@ -56,9 +57,9 @@ export const Multichannel = props => {
     }
     return child
   })
-  if (!props.oneMessagePerComponent) {
+  if (props.messageSeparator != null) {
     newChildren = newChildren.map((c, index) =>
-      index > 0 && typeof c === 'string' ? '\n' + c : c
+      index > 0 && typeof c === 'string' ? props.messageSeparator + c : c
     )
     newChildren = (
       <Text {...props} key={props.key}>
@@ -72,7 +73,7 @@ export const Multichannel = props => {
         currentIndex: props.firstIndex,
         boldIndex: props.boldIndex,
         indexSeparator: props.indexSeparator,
-        oneMessagePerComponent: props.oneMessagePerComponent,
+        messageSeparator: props.messageSeparator,
       }}
     >
       {newChildren}

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel.test.jsx.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Multichannel carousel COMPACT mode all elements in same message 1`] = `
+Array [
+  "
+Previo",
+  "
+Durante",
+]
+`;
+
 exports[`Multichannel carousel COMPACT mode dynamic carousel (just text in button) with payload/path buttons 1`] = `
 Array [
   <message

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-wrapper.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-wrapper.test.jsx.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Multichannel wrapper 1 text in 1 single message. Default props 1`] = `
+exports[`Multichannel wrapper 1 text in 1 single message 1`] = `
 <message
   delay={0}
+  messageSeparator="
+"
   type="text"
   typing={0}
 >
@@ -10,9 +12,11 @@ exports[`Multichannel wrapper 1 text in 1 single message. Default props 1`] = `
 </message>
 `;
 
-exports[`Multichannel wrapper 2 text in 1 single message. Default props 1`] = `
+exports[`Multichannel wrapper 2 text in 1 single message 1`] = `
 <message
   delay={0}
+  messageSeparator="
+"
   type="text"
   typing={0}
 >
@@ -22,9 +26,11 @@ Text2
 </message>
 `;
 
-exports[`Multichannel wrapper 2 texts with buttons. Default props 1`] = `
+exports[`Multichannel wrapper 2 texts with buttons 1`] = `
 <message
   delay={0}
+  messageSeparator="
+"
   type="text"
   typing={0}
 >
@@ -149,7 +155,8 @@ exports[`Multichannel wrapper text and carousel only show button text, 1 single 
   }
   delay={0}
   indexSeparator="."
-  oneMessagePerComponent={false}
+  messageSeparator="
+"
   type="text"
   typing={0}
 >

--- a/packages/botonic-react/tests/components/multichannel/multichannel-carousel-multibutton.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-carousel-multibutton.test.jsx
@@ -8,7 +8,7 @@ import { whatsappRenderer } from '../../helpers/test-utils'
 
 export const LEGACY_CONTEXT = {
   indexSeparator: '.',
-  oneMessagePerComponent: true,
+  messageSeparator: null,
 }
 
 export const LEGACY_PROPS = {

--- a/packages/botonic-react/tests/components/multichannel/multichannel-carousel.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-carousel.test.jsx
@@ -1,5 +1,16 @@
-import { MultichannelButton, Element, Pic, Subtitle, Title } from '../../../src'
-import { MultichannelCarousel } from '../../../src/components/multichannel'
+import {
+  MultichannelButton,
+  Element,
+  Pic,
+  Subtitle,
+  Title,
+  Carousel,
+  Button,
+} from '../../../src'
+import {
+  Multichannel,
+  MultichannelCarousel,
+} from '../../../src/components/multichannel'
 import React from 'react'
 import { whatsappRenderer } from '../../helpers/test-utils'
 
@@ -22,7 +33,7 @@ const movies = [
 
 export const LEGACY_CONTEXT = {
   indexSeparator: '.',
-  oneMessagePerComponent: true,
+  messageSeparator: null,
 }
 
 export const LEGACY_PROPS = {
@@ -124,6 +135,34 @@ describe('Multichannel carousel COMPACT mode', () => {
       </MultichannelCarousel>
     )
     const renderer = whatsappRenderer(sut, LEGACY_CONTEXT)
+    const tree = renderer.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('all elements in same message', () => {
+    const sut = (
+      <MultichannelCarousel>
+        {[
+          <Element key={0}>
+            <Subtitle>Subtitle will not appear</Subtitle>
+            {[
+              <MultichannelButton key={1} payload='Payload1'>
+                {'Previo'}
+              </MultichannelButton>,
+            ]}
+          </Element>,
+          <Element key={1}>
+            <Subtitle>Subtitle will not appear</Subtitle>
+            {[
+              <MultichannelButton key={1} payload='Payload2'>
+                {'Durante'}
+              </MultichannelButton>,
+            ]}
+          </Element>,
+        ]}
+      </MultichannelCarousel>
+    )
+    const renderer = whatsappRenderer(sut, { messageSeparator: '\n' })
     const tree = renderer.toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/packages/botonic-react/tests/components/multichannel/multichannel-text.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-text.test.jsx
@@ -9,7 +9,7 @@ import { MultichannelReply } from '../../../src/components/multichannel/multicha
 
 const LEGACY_CONTEXT = {
   indexSeparator: '.',
-  oneMessagePerComponent: true,
+  messageSeparator: null,
 }
 const LEGACY_PROPS = {
   indexMode: 'number',

--- a/packages/botonic-react/tests/components/multichannel/multichannel-wrapper.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-wrapper.test.jsx
@@ -22,7 +22,7 @@ const LEGACY_PROPS = {
     indexMode: 'number',
   },
   indexSeparator: '.',
-  oneMessagePerComponent: true,
+  messageSeparator: null,
 }
 
 describe('Multichannel wrapper', () => {
@@ -146,7 +146,7 @@ describe('Multichannel wrapper', () => {
           showTitle: false,
           showSubtitle: false,
         }}
-        oneMessagePerComponent={false}
+        messageSeparator={'\n'}
       >
         <Text>This is a multichannel Carousel</Text>
 
@@ -175,9 +175,9 @@ describe('Multichannel wrapper', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('2 text in 1 single message. Default props', () => {
+  test('2 text in 1 single message', () => {
     const sut = (
-      <Multichannel>
+      <Multichannel messageSeparator={'\n'}>
         <Text>Text1</Text>
         <Text>Text2</Text>
       </Multichannel>
@@ -188,9 +188,9 @@ describe('Multichannel wrapper', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('1 text in 1 single message. Default props', () => {
+  test('1 text in 1 single message', () => {
     const sut = (
-      <Multichannel>
+      <Multichannel messageSeparator={'\n'}>
         <Text>Text1</Text>
       </Multichannel>
     )
@@ -200,9 +200,9 @@ describe('Multichannel wrapper', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('2 texts with buttons. Default props', () => {
+  test('2 texts with buttons', () => {
     const sut = (
-      <Multichannel>
+      <Multichannel messageSeparator={'\n'}>
         <Text>
           Text1
           <Button key={'1'} payload='payload1'>


### PR DESCRIPTION
Based on #721 Preview it first
## Description
Allow separating the contents within a Multichannel decorator with a custom string

## Context
A customer wants to have empty lines between consecutive contents with an empty lint

## Approach taken / Explain the design
Replace the flag which configures whether each content goes into a different message, into a string which configures the separation.

## Testing

The pull request...

- [x] has unit tests
