### PR TITLE
fix(react): set child keys in multichannel wrapper

### DIFF
--- a/packages/botonic-core/package-lock.json
+++ b/packages/botonic-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.11.2",
+  "version": "0.11.3-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.11.2",
+  "version": "0.11.3-alpha.1",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.11.2",
+  "version": "0.11.3-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.11.2",
+  "version": "0.11.3-alpha.1",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-react/src/components/multichannel/multichannel.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel.jsx
@@ -61,11 +61,7 @@ export const Multichannel = props => {
     newChildren = newChildren.map((c, index) =>
       index > 0 && typeof c === 'string' ? props.messageSeparator + c : c
     )
-    newChildren = (
-      <Text {...props} key={props.key}>
-        {newChildren}
-      </Text>
-    )
+    newChildren = <Text key={props.key}>{newChildren}</Text>
   }
   return (
     <MultichannelContext.Provider

--- a/packages/botonic-react/src/components/multichannel/multichannel.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel.jsx
@@ -19,14 +19,14 @@ export const Multichannel = props => {
   let newChildren = deepMapWithIndex(props.children, (child, index) => {
     if (child && child.type && child.type.name === 'Button') {
       return (
-        <MultichannelButton {...child.props}>
+        <MultichannelButton {...child.props} key={child.key}>
           {child.props.children}
         </MultichannelButton>
       )
     }
     if (child && child.type && child.type.name === 'Reply') {
       return (
-        <MultichannelReply {...child.props}>
+        <MultichannelReply {...child.props} key={child.key}>
           {child.props.children}
         </MultichannelReply>
       )
@@ -36,7 +36,7 @@ export const Multichannel = props => {
         <MultichannelText
           {...child.props}
           {...props.text}
-          key={props.key}
+          key={child.key}
           {...(props.messageSeparator &&
             index > 0 && { newline: props.messageSeparator })}
         >
@@ -49,7 +49,7 @@ export const Multichannel = props => {
         <MultichannelCarousel
           {...child.props}
           {...props.carousel}
-          key={props.key}
+          key={child.key}
         >
           {child.props.children}
         </MultichannelCarousel>

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-wrapper.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-wrapper.test.jsx.snap
@@ -3,8 +3,6 @@
 exports[`Multichannel wrapper 1 text in 1 single message 1`] = `
 <message
   delay={0}
-  messageSeparator="
-"
   type="text"
   typing={0}
 >
@@ -15,8 +13,6 @@ exports[`Multichannel wrapper 1 text in 1 single message 1`] = `
 exports[`Multichannel wrapper 2 text in 1 single message 1`] = `
 <message
   delay={0}
-  messageSeparator="
-"
   type="text"
   typing={0}
 >
@@ -29,8 +25,6 @@ Text2
 exports[`Multichannel wrapper 2 texts with buttons 1`] = `
 <message
   delay={0}
-  messageSeparator="
-"
   type="text"
   typing={0}
 >
@@ -146,17 +140,7 @@ Array [
 
 exports[`Multichannel wrapper text and carousel only show button text, 1 single message 1`] = `
 <message
-  carousel={
-    Object {
-      "indexMode": "letter",
-      "showSubtitle": false,
-      "showTitle": false,
-    }
-  }
   delay={0}
-  indexSeparator="."
-  messageSeparator="
-"
   type="text"
   typing={0}
 >


### PR DESCRIPTION
- Multichannel sometimes was not setting the keys of the contained components
- Bump version to alpha so that we can use multichannel changes
- don't copy Multichannel props to created Text to avoid error "React does not recognize the `firstIndex` prop on a DOM element...."
