### PR TITLE
Contentful/prefer token match

### DIFF
--- a/packages/botonic-plugin-contentful/src/nlp/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/keywords.ts
@@ -49,6 +49,10 @@ export class Keyword {
     }
     return this.words.map(w => new Keyword(w.token, [w], w.isStopWord))
   }
+
+  joinedTokens(withStopWords: boolean): string {
+    return Word.joinedTokens(this.words, withStopWords)
+  }
 }
 
 export class CandidateWithKeywords<M> {

--- a/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
@@ -76,6 +76,10 @@ export class NormalizedUtterance {
   hasSameStems(other: NormalizedUtterance): boolean {
     return equalArrays(this.stems, other.stems)
   }
+
+  joinedTokens(withStopWords: boolean): string {
+    return Word.joinedTokens(this.words, withStopWords)
+  }
 }
 
 export class Normalizer {

--- a/packages/botonic-plugin-contentful/src/tools/search-performance.ts
+++ b/packages/botonic-plugin-contentful/src/tools/search-performance.ts
@@ -35,7 +35,7 @@ function ut(text: string): NormalizedUtterance {
   )
 }
 
-function perfom() {
+function perform() {
   const sut = new SimilarWordFinder<TestCandidate>(true)
   for (let i = 0; i < 50; i++) {
     sut.addCandidate(candidate([`kw${i}`]))
@@ -50,4 +50,4 @@ function perfom() {
   console.log(new Date())
 }
 
-perfom()
+perform()

--- a/packages/botonic-plugin-contentful/tests/nlp/keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/keywords.test.ts
@@ -1,11 +1,12 @@
 import 'jest-extended'
 import {
-  KeywordsParser,
-  Normalizer,
-  KeywordsOptions,
-  MatchType,
-  StemmingBlackList,
   Keyword,
+  KeywordsOptions,
+  KeywordsParser,
+  MatchType,
+  Normalizer,
+  SPANISH,
+  StemmingBlackList,
   Word,
 } from '../../src/nlp'
 
@@ -53,6 +54,29 @@ function testFindKeywords(
     expect(results.map(r => r.candidate)).toIncludeSameMembers(expectedMatch)
   }
 }
+
+test('TEST findCandidatesWithKeywordsAt matches tokens instead of stems if match is longer', () => {
+  const normalizer = new Normalizer()
+  const parser = new KeywordsParser<string>(
+    SPANISH,
+    MatchType.ONLY_KEYWORDS_FOUND,
+    normalizer,
+    new KeywordsOptions()
+  )
+
+  parser.addCandidate('candidate2', ['saluda'])
+  parser.addCandidate('candidate1', ['saludos'])
+
+  const tokens = normalizer.normalize(SPANISH, 'soludos')
+
+  const results = parser.findCandidatesWithKeywordsAt(tokens)
+
+  expect(results).toHaveLength(2)
+  expect(results[0].match).toEqual('soludos')
+  expect(results[0].distance).toEqual(1)
+  expect(results[1].match).toEqual('solud')
+  expect(results[1].distance).toEqual(1)
+})
 
 test.each<any>([
   ['quiero realiSar un pedido', { A: ['realizar pedido', 'comprar'] }, ['A']],

--- a/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/similar-words.test.ts
@@ -215,31 +215,3 @@ test.each<any>([
     expect(getMatchLength(w1.length, w2.length, distance)).toEqual(expected)
   }
 )
-
-// test('TEST: performance', () => {
-function perfom() {
-  const sut = new SimilarWordFinder<TestCandidate>(true)
-  for (let i = 0; i < 50; i++) {
-    sut.addCandidate(candidate([`kw${i}`]))
-  }
-  let utterance = ''
-  //ALL_WORDS_IN_KEYWORDS_MIXED_UP
-  // 50 => ms
-  // 100 2,2s
-  // 130 6s
-
-  //KEYWORDS_AND_OTHERS_FOUND
-  // 100 2,3s
-  // 130 6s
-  for (let i = 0; i < 100; i++) {
-    utterance += i + ' '
-  }
-  console.log(utterance.length)
-  console.log(new Date())
-  expect(
-    sut.find(MatchType.KEYWORDS_AND_OTHERS_FOUND, ut(utterance), 1)
-  ).toHaveLength(0)
-  console.log(new Date())
-}
-
-perfom()


### PR DESCRIPTION
## Description
When finding a user input in the keywords of CMS contents, we were matching only the stems and not the tokens in order to be tolerant to changes in gender, number, verbs conjugations...
However, it's better to provide that matched substring from the full token. In this way, in case this keyword has to compete with another keyword, we want to compare the length of the matching substring.

## Context

Only taking the stems into account was specially problematic when eg. comparing a keyword from a FAQwith a keyword from a chitchat text. We want to give priority to the FAQ one, but not if the one from the chitchat has a much longer match.

## Testing

The pull request...

- [x ] has unit tests
