### PR TITLE
fix: handle keyboard issues for Safari Iphones

### DIFF
--- a/packages/botonic-react/src/keyboard-resizer.js
+++ b/packages/botonic-react/src/keyboard-resizer.js
@@ -1,0 +1,88 @@
+import {
+  getWebchatElement,
+  setWebchatElementHeight,
+  scrollToBottom,
+  getScrollableArea,
+} from './utils'
+
+export class KeyboardResizer {
+  constructor() {
+    this.isIphone = this.isIphone()
+  }
+
+  isIphone() {
+    // Detecting iOS solution, relying on navigator.platform: https://stackoverflow.com/a/9039885
+    return !!navigator.platform && navigator.platform.includes('iPhone')
+  }
+
+  onFocus() {
+    if (this.isIphone) {
+      /*
+        Based on Tip #4 from https://blog.opendigerati.com/the-eccentric-ways-of-ios-safari-with-the-keyboard-b5aa3f34228d,
+        taking window.innerHeight as the amount of pixels the virtual keyboard adds
+      */
+      const waitUntilKeyboardIsShown = 400
+      const calculateNewWebchatElementHeight = () => {
+        const webchatHeight = getWebchatElement().clientHeight
+        // Some iOS versions keep track of this height with VisualViewport API: https://stackoverflow.com/a/59056851
+        const keyboardOffset =
+          (window.visualViewport && window.visualViewport.height) ||
+          window.innerHeight
+        let newWebchatPercentualHeight = keyboardOffset / webchatHeight
+        const toTwoDecimal = toRound => Math.round(toRound * 100) / 100
+        newWebchatPercentualHeight =
+          toTwoDecimal(newWebchatPercentualHeight) * 100
+        return newWebchatPercentualHeight
+      }
+      setTimeout(() => {
+        setWebchatElementHeight(`${calculateNewWebchatElementHeight()}%`)
+        scrollToBottom()
+      }, waitUntilKeyboardIsShown)
+    }
+  }
+
+  onBlur() {
+    if (this.isIphone) setWebchatElementHeight('100%')
+  }
+
+  limitScrollbarBoundaries() {
+    if (this.isIphone) {
+      const frame = getScrollableArea()
+      const dStopAtScrollLimit = debounced(200, stopAtScrollLimit)
+      if (frame) {
+        if (window.addEventListener) {
+          frame.addEventListener(
+            'scroll',
+            () => dStopAtScrollLimit(frame),
+            true
+          )
+        } else if (window.attachEvent) {
+          frame.attachEvent('scroll', () => dStopAtScrollLimit(frame))
+        }
+      }
+    }
+  }
+  fontSize(defaultFontSize = 14) {
+    // Disabling auto-zoom on input (iPhone devices): https://stackoverflow.com/a/25614477
+    return this.isIphone ? 'initial' : defaultFontSize
+  }
+}
+
+const debounced = (delay, fn) => {
+  let timerId
+  return function (...args) {
+    if (timerId) {
+      clearTimeout(timerId)
+    }
+    timerId = setTimeout(() => {
+      fn(...args)
+      timerId = null
+    }, delay)
+  }
+}
+
+const stopAtScrollLimit = element => {
+  if (element.scrollTop === 0) element.scrollTop = 1
+  if (element.scrollHeight - element.scrollTop === element.clientHeight)
+    element.scrollTop -= 1
+}

--- a/packages/botonic-react/src/utils.js
+++ b/packages/botonic-react/src/utils.js
@@ -68,13 +68,18 @@ export const _getThemeProperty = theme => (
 export const ConditionalWrapper = ({ condition, wrapper, children }) =>
   condition ? wrapper(children) : children
 
-export const scrollToBottom = (timeout = 100) => {
-  const botonicScrollableArea = document.getElementById(
+export const getScrollableArea = () => {
+  const botonicScrollableContent = document.getElementById(
     'botonic-scrollable-content'
   )
-  const frame =
-    botonicScrollableArea &&
-    botonicScrollableArea.querySelectorAll('.simplebar-content-wrapper')[0]
+  const scrollableArea =
+    botonicScrollableContent &&
+    botonicScrollableContent.querySelectorAll('.simplebar-content-wrapper')[0]
+  return scrollableArea
+}
+
+export const scrollToBottom = (timeout = 200) => {
+  const frame = getScrollableArea()
   if (frame) {
     frame.scrollTop = frame.scrollHeight
     setTimeout(() => (frame.scrollTop = frame.scrollHeight), timeout)
@@ -93,36 +98,9 @@ export function renderComponent({ renderBrowser, renderNode }) {
   throw new Error('Unexpected process type. Not recognized as browser nor node')
 }
 
-export const isIphone = () => {
-  // Detecting iOS solution, relying on navigator.platform: https://stackoverflow.com/a/9039885
-  return !!navigator.platform && /iPhone/.test(navigator.platform)
-}
+export const getWebchatElement = () =>
+  document.getElementById('botonic-webchat')
 
-const getWebchatElement = () => document.getElementById('botonic-webchat')
-
-const setWebchatElementHeight = newHeight => {
+export const setWebchatElementHeight = newHeight => {
   getWebchatElement().style.height = newHeight
-}
-
-export const handleIphoneOnFocus = () => {
-  /*
-    Based on Tip #4 from https://blog.opendigerati.com/the-eccentric-ways-of-ios-safari-with-the-keyboard-b5aa3f34228d,
-    taking window.innerHeight as the amount of pixels the virtual keyboard adds
-  */
-  const waitUntilKeyboardIsShown = 200
-  const calculateNewWebchatElementHeight = () => {
-    const keyboardOffset = window.innerHeight
-    const webchatHeight = getWebchatElement().clientHeight
-    let newWebchatPercentualHeight = keyboardOffset / webchatHeight
-    const toTwoDecimal = toRound => Number(Math.round(toRound + 'e2') + 'e-2')
-    newWebchatPercentualHeight = toTwoDecimal(newWebchatPercentualHeight) * 100
-    return newWebchatPercentualHeight
-  }
-  setTimeout(() => {
-    setWebchatElementHeight(`${calculateNewWebchatElementHeight()}%`)
-    scrollToBottom()
-  }, waitUntilKeyboardIsShown)
-}
-export const handleIphoneOnBlur = () => {
-  setWebchatElementHeight('100%')
 }

--- a/packages/botonic-react/src/utils.js
+++ b/packages/botonic-react/src/utils.js
@@ -92,3 +92,37 @@ export function renderComponent({ renderBrowser, renderNode }) {
   else if (isNode()) return renderNode()
   throw new Error('Unexpected process type. Not recognized as browser nor node')
 }
+
+export const isIphone = () => {
+  // Detecting iOS solution, relying on navigator.platform: https://stackoverflow.com/a/9039885
+  return !!navigator.platform && /iPhone/.test(navigator.platform)
+}
+
+const getWebchatElement = () => document.getElementById('botonic-webchat')
+
+const setWebchatElementHeight = newHeight => {
+  getWebchatElement().style.height = newHeight
+}
+
+export const handleIphoneOnFocus = () => {
+  /*
+    Based on Tip #4 from https://blog.opendigerati.com/the-eccentric-ways-of-ios-safari-with-the-keyboard-b5aa3f34228d,
+    taking window.innerHeight as the amount of pixels the virtual keyboard adds
+  */
+  const waitUntilKeyboardIsShown = 200
+  const calculateNewWebchatElementHeight = () => {
+    const keyboardOffset = window.innerHeight
+    const webchatHeight = getWebchatElement().clientHeight
+    let newWebchatPercentualHeight = keyboardOffset / webchatHeight
+    const toTwoDecimal = toRound => Number(Math.round(toRound + 'e2') + 'e-2')
+    newWebchatPercentualHeight = toTwoDecimal(newWebchatPercentualHeight) * 100
+    return newWebchatPercentualHeight
+  }
+  setTimeout(() => {
+    setWebchatElementHeight(`${calculateNewWebchatElementHeight()}%`)
+    scrollToBottom()
+  }, waitUntilKeyboardIsShown)
+}
+export const handleIphoneOnBlur = () => {
+  setWebchatElementHeight('100%')
+}

--- a/packages/botonic-react/src/webchat/components/styled-scrollbar.scss
+++ b/packages/botonic-react/src/webchat/components/styled-scrollbar.scss
@@ -1,6 +1,11 @@
-#botonic-scrollable-content
-  .simplebar-mask
-  .simplebar-offset
-  .simplebar-content-wrapper {
-  scroll-behavior: smooth;
+#botonic-scrollable-content {
+  .simplebar-mask .simplebar-offset .simplebar-content-wrapper {
+    scroll-behavior: smooth;
+    overscroll-behavior: contain; // https://css-tricks.com/almanac/properties/o/overscroll-behavior/
+    -webkit-overflow-scrolling: touch;
+  }
+  ::-webkit-scrollbar {
+    // https://github.com/Grsmto/simplebar/issues/445#issuecomment-586902814
+    display: none;
+  }
 }

--- a/packages/botonic-react/src/webchat/message-list.jsx
+++ b/packages/botonic-react/src/webchat/message-list.jsx
@@ -42,6 +42,7 @@ export const WebchatMessageList = props => {
 
   return (
     <StyledScrollbar
+      // TODO: Distinguis between multiple instances of webchat, e.g. `${uniqueId}-botonic-scrollable`
       id='botonic-scrollable-content'
       scrollbar={scrollbarOptions}
       autoHide={scrollbarOptions.autoHide}

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -34,13 +34,11 @@ import {
   ConditionalWrapper,
   scrollToBottom,
   getParsedAction,
-  isIphone,
-  handleIphoneOnFocus,
-  handleIphoneOnBlur,
 } from '../utils'
 import { WEBCHAT, MIME_WHITELIST, COLORS } from '../constants'
 import { motion } from 'framer-motion'
 import styled from 'styled-components'
+import { KeyboardResizer } from '../keyboard-resizer'
 
 const getAttachmentType = fileType => {
   return Object.entries(MIME_WHITELIST)
@@ -161,6 +159,7 @@ export const Webchat = forwardRef((props, ref) => {
   const [persistentMenuIsOpened, setPersistentMenuIsOpened] = useState(false)
   const [emojiPickerIsOpened, setEmojiPickerIsOpened] = useState(false)
   const [attachment, setAttachment] = useState({})
+  const keyboardResizer = new KeyboardResizer()
 
   const getThemeProperty = _getThemeProperty(theme)
 
@@ -216,6 +215,7 @@ export const Webchat = forwardRef((props, ref) => {
 
   useEffect(() => {
     if (!webchatState.isWebchatOpen) return
+    keyboardResizer.limitScrollbarBoundaries()
     scrollToBottom()
   }, [webchatState.isWebchatOpen])
 
@@ -584,8 +584,8 @@ export const Webchat = forwardRef((props, ref) => {
           <TextAreaContainer>
             <Textarea
               name='text'
-              onFocus={() => isIphone() && handleIphoneOnFocus()}
-              onBlur={() => isIphone() && handleIphoneOnBlur()}
+              onFocus={() => keyboardResizer.onFocus()}
+              onBlur={() => keyboardResizer.onBlur()}
               maxRows={4}
               wrap='soft'
               maxLength='1000'
@@ -598,8 +598,7 @@ export const Webchat = forwardRef((props, ref) => {
               onKeyDown={e => onKeyDown(e)}
               style={{
                 display: 'flex',
-                // Disabling auto-zoom on input (iPhone devices): https://stackoverflow.com/a/25614477
-                fontSize: isIphone() ? 'initial' : 14,
+                fontSize: keyboardResizer.fontSize(14),
                 width: '100%',
                 border: 'none',
                 resize: 'none',
@@ -694,6 +693,7 @@ export const Webchat = forwardRef((props, ref) => {
       )}
       {webchatState.isWebchatOpen && (
         <StyledWebchat
+          // TODO: Distinguis between multiple instances of webchat, e.g. `${uniqueId}-botonic-webchat`
           id={'botonic-webchat'}
           width={webchatState.width}
           height={webchatState.height}

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -34,6 +34,9 @@ import {
   ConditionalWrapper,
   scrollToBottom,
   getParsedAction,
+  isIphone,
+  handleIphoneOnFocus,
+  handleIphoneOnBlur,
 } from '../utils'
 import { WEBCHAT, MIME_WHITELIST, COLORS } from '../constants'
 import { motion } from 'framer-motion'
@@ -581,6 +584,8 @@ export const Webchat = forwardRef((props, ref) => {
           <TextAreaContainer>
             <Textarea
               name='text'
+              onFocus={() => isIphone() && handleIphoneOnFocus()}
+              onBlur={() => isIphone() && handleIphoneOnBlur()}
               maxRows={4}
               wrap='soft'
               maxLength='1000'
@@ -593,7 +598,8 @@ export const Webchat = forwardRef((props, ref) => {
               onKeyDown={e => onKeyDown(e)}
               style={{
                 display: 'flex',
-                fontSize: 14,
+                // Disabling auto-zoom on input (iPhone devices): https://stackoverflow.com/a/25614477
+                fontSize: isIphone() ? 'initial' : 14,
                 width: '100%',
                 border: 'none',
                 resize: 'none',
@@ -688,6 +694,7 @@ export const Webchat = forwardRef((props, ref) => {
       )}
       {webchatState.isWebchatOpen && (
         <StyledWebchat
+          id={'botonic-webchat'}
           width={webchatState.width}
           height={webchatState.height}
           style={{


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
Added a general solution to try to solve iPhone keyboard issues.
* Added function to detect if device is an iPhone.
* Added handlers to act when input is focused/blurred and do a visual hack to avoid iPhone "intelligent" keyboards to apply visual side effects.
* Refactored into `keyboard-resizer.js` and using `window.visualViewport` as the preferable way to retrieve the window height when keyboard is shown.
* Set overscroll-behavior to contain to have "independent" scrolling bars.  
Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior
* Try to limit scroll boundaries and prevent scrolling whole window.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
Some people has reported having issues with virtual keyboard of iPhones with the webchat. 
I found this post https://blog.opendigerati.com/the-eccentric-ways-of-ios-safari-with-the-keyboard-b5aa3f34228d where it more specifically about this well-known issue.
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design
* Adding a little timeout to calculate how much the keyboard fills the screen (by checking the offset given by window.innerHeight) and set a new webchat height based on that when input is focused.
Attached video with before/after behavior.
[iphoneKeyboardComparison.zip](https://github.com/hubtype/botonic/files/4586409/iphoneKeyboardComparison.zip)

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [X] doesn't need tests because... it's a display/visual aspect
