### PR TITLE
Chore/coverage tsnode cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3914,6 +3914,12 @@
         }
       }
     },
+    "cloc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/cloc/-/cloc-2.5.1.tgz",
+      "integrity": "sha512-ZHJ592HbnHAshQ7gtnrgeZaVyvou+a+7TM/E/oTZth2c9Mycp4Ymp3/npQ/Qhxgq9ksf8GjTLB9bEyCMTf42BA==",
+      "dev": true
+    },
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
     "babel-eslint": "^10.0.3",
-     "cloc": "^2.5.1",
+    "cloc": "^2.5.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-filenames": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
     "babel-eslint": "^10.0.3",
+     "cloc": "^2.5.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-filenames": "^1.3.2",

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -53,6 +53,8 @@
   },
   "repository": "hubtype/botonic",
   "scripts": {
+    "cloc": "../../scripts/qa/cloc-package.sh .",
+    "ts-node": "ts-node",
     "prepare": "node ../../preinstall.js",
     "build": "rm -rf lib && ../../node_modules/.bin/tsc",
     "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json",

--- a/packages/botonic-cli/tsconfig.json
+++ b/packages/botonic-cli/tsconfig.json
@@ -2,8 +2,12 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
-	},
+		"outDir": "lib",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true
+//    "noUnusedLocals": true added after eslint plugin-import branch merged
+  },
   "include": [
     ".*.js",
     "*.js",

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -8,7 +8,8 @@
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_ci -- --fix",
     "lint_ci": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' '*.js' 'src/**/*.js*' '**/*.d.ts'",
-    "build": "rm -rf lib && babel src --out-dir lib --source-maps --copy-files"
+    "build": "rm -rf lib && babel src --out-dir lib --source-maps --copy-files",
+    "cloc": "../../scripts/qa/cloc-package.sh ."
   },
   "repository": {
     "type": "git",

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -2,7 +2,9 @@
   "scripts": {
     "build": "rm -rf lib && ../../node_modules/.bin/tsc",
     "build_with_tests": "tsc -b tests/tsconfig.json",
-    "test": "../../node_modules/.bin/jest",
+    "test": "../../node_modules/.bin/jest --coverage",
+    "ts-node": "ts-node -O '{ \"noUnusedLocals\":false}'",
+    "cloc": "../../scripts/qa/cloc-package.sh .",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core -- -c .eslintrc_slow.js",
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' '*.js' 'src/**/*.ts*' 'tests/**/*.ts*'",

--- a/packages/botonic-plugin-dashbot/package.json
+++ b/packages/botonic-plugin-dashbot/package.json
@@ -3,6 +3,7 @@
   "version": "0.11.0",
   "main": "src/index.js",
   "scripts": {
+    "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",

--- a/packages/botonic-plugin-dialogflow/package.json
+++ b/packages/botonic-plugin-dialogflow/package.json
@@ -3,6 +3,7 @@
   "version": "0.11.0",
   "main": "src/index.js",
   "scripts": {
+    "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",

--- a/packages/botonic-plugin-dynamodb/package.json
+++ b/packages/botonic-plugin-dynamodb/package.json
@@ -2,7 +2,9 @@
   "scripts": {
     "build": "rm -rf lib && ../../node_modules/.bin/tsc",
     "build_with_tests": "tsc -b tests/tsconfig.json",
-    "test": "../../node_modules/.bin/jest",
+    "test": "../../node_modules/.bin/jest --coverage",
+    "cloc": "../../scripts/qa/cloc-package.sh .",
+    "ts-node": "ts-node -O '{ \"noUnusedLocals\":false}'",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core -- -c .eslintrc_slow.js",
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' '*.js' 'src/**/*.ts*' 'tests/**/*.ts*'",

--- a/packages/botonic-plugin-luis/package.json
+++ b/packages/botonic-plugin-luis/package.json
@@ -3,6 +3,7 @@
   "version": "0.11.0",
   "main": "src/index.js",
   "scripts": {
+    "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",

--- a/packages/botonic-plugin-nlu/package.json
+++ b/packages/botonic-plugin-nlu/package.json
@@ -3,6 +3,7 @@
   "version": "0.11.0",
   "main": "src/index.js",
   "scripts": {
+    "cloc": "../../scripts/qa/cloc-package.sh .",
     "build": "rm -rf dist && babel src -d dist",
     "test": "jest",
     "prepare": "node ../../preinstall.js",

--- a/packages/botonic-plugin-segment/package.json
+++ b/packages/botonic-plugin-segment/package.json
@@ -3,6 +3,7 @@
   "version": "0.11.0",
   "main": "src/index.js",
   "scripts": {
+    "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",

--- a/packages/botonic-plugin-watson/package.json
+++ b/packages/botonic-plugin-watson/package.json
@@ -3,6 +3,7 @@
   "version": "0.11.0",
   "main": "src/index.js",
   "scripts": {
+    "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "../../node_modules/.bin/jest --coverage",
+    "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "build": "rm -rf lib && babel src --out-dir lib --source-maps --copy-files",
     "lint": "npm run lint_core -- --fix",

--- a/scripts/qa/cloc-all-packages.sh
+++ b/scripts/qa/cloc-all-packages.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$BIN_DIR" || exit 1
+PACKAGES_DIR="$BIN_DIR/../../packages"
+
+for package in $PACKAGES_DIR/botonic-*; do
+  ./cloc-package.sh $package
+done

--- a/scripts/qa/cloc-package.sh
+++ b/scripts/qa/cloc-package.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#cd "$BIN_DIR" || exit 1
+ROOT_DIR="$BIN_DIR/../../"
+
+PACKAGE_PATH=$(cd $1 && pwd)
+
+echo "Lines at '$(basename $PACKAGE_PATH)'"
+"$ROOT_DIR"/node_modules/.bin/cloc --match-f='js|js|ts|tsx' --not-match-f='\.test\.*' --not-match-d=node_modules $PACKAGE_PATH/src --json| grep SUM -A3| grep code
+

--- a/scripts/qa/lint-all-packages.sh
+++ b/scripts/qa/lint-all-packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd "$BIN_BIN_DIR" || exit 1
+cd "$BIN_DIR" || exit 1
 
 for package in ../../packages/botonic-*; do
   ./lint-package.sh $package


### PR DESCRIPTION
## Description
Several chore improvements:
* "npm run ts-node" for typescript packages to interactively test the code
* scripts/qa/cloc- scripts and "npm run cloc" to Count Lines Of Code. Useful for averaging % of test coverage amongst several packages.
* Add typescript checks to botonic clic

## Testing

The pull request...

- [ ] doesn't need tests because it's only checks