### PR TITLE
feat(react): add borderRadius for persistentMenu

### DIFF
--- a/packages/botonic-react/src/components/button.jsx
+++ b/packages/botonic-react/src/components/button.jsx
@@ -96,6 +96,7 @@ export const Button = props => {
           color: buttonTextColor,
           backgroundColor: buttonBgColor,
         }}
+        bottom={props.bottom}
       >
         {props.children}
       </StyledButton>

--- a/packages/botonic-react/src/components/button.jsx
+++ b/packages/botonic-react/src/components/button.jsx
@@ -96,7 +96,7 @@ export const Button = props => {
           color: buttonTextColor,
           backgroundColor: buttonBgColor,
         }}
-        bottom={props.bottom}
+        bottom={props.bottomRadius}
       >
         {props.children}
       </StyledButton>

--- a/packages/botonic-react/src/webchat/components/persistent-menu.jsx
+++ b/packages/botonic-react/src/webchat/components/persistent-menu.jsx
@@ -12,7 +12,7 @@ const ButtonsContainer = styled.div`
   text-align: center;
 `
 
-export const OpenedPersistentMenu = ({ onClick, options }) => {
+export const OpenedPersistentMenu = ({ onClick, options, borderRadius }) => {
   let closeLabel = 'Cancel'
   try {
     closeLabel = options.filter(opt => opt.closeLabel !== undefined)[0]
@@ -35,7 +35,9 @@ export const OpenedPersistentMenu = ({ onClick, options }) => {
           )
         )
       })}
-      <Button onClick={onClick}>{closeLabel}</Button>
+      <Button onClick={onClick} bottom={borderRadius}>
+        {closeLabel}
+      </Button>
     </ButtonsContainer>
   )
 }

--- a/packages/botonic-react/src/webchat/components/persistent-menu.jsx
+++ b/packages/botonic-react/src/webchat/components/persistent-menu.jsx
@@ -35,7 +35,7 @@ export const OpenedPersistentMenu = ({ onClick, options, borderRadius }) => {
           )
         )
       })}
-      <Button onClick={onClick} bottom={borderRadius}>
+      <Button onClick={onClick} bottomRadius={borderRadius}>
         {closeLabel}
       </Button>
     </ButtonsContainer>

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -114,7 +114,7 @@ const DarkBackgroundMenu = styled.div`
   z-index: 1;
   right: 0;
   bottom: 0;
-  border-radius: 25px 25px 0px 0px;
+  border-radius: ${props => props.borderRadius || '25px'};
 `
 
 const createUser = () => {
@@ -715,6 +715,7 @@ export const Webchat = forwardRef((props, ref) => {
                   {darkBackgroundMenu && (
                     <DarkBackgroundMenu
                       onClick={closeMenu}
+                      borderRadius={webchatState.theme.style.borderRadius}
                       style={{
                         position: 'absolute',
                         width: '100%',
@@ -731,6 +732,9 @@ export const Webchat = forwardRef((props, ref) => {
                     <OpenedPersistentMenu
                       onClick={closeMenu}
                       options={persistentMenuOptions}
+                      borderRadius={
+                        webchatState.theme.style.borderRadius || '10px'
+                      }
                     />
                   )}
                 </div>


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description

Adds a bottom border radius for the persistent menu.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
When the persistent menu is open, the bottom radius of the webchat is always zero even if the webchat radius is not.
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

Pass the webchat border radius to the persistent menu and assigns it to the  bottom radius of the close button.

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [X] doesn't need tests because... is a style improvement.
