### PR TITLE
fix(react): allow also urls for webchat properties

### DIFF
--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useContext } from 'react'
 import styled from 'styled-components'
 import uuid from 'uuid/v4'
+
 import { isBrowser, isNode, INPUT } from '@botonic/core'
-import { staticAsset, ConditionalWrapper, renderComponent } from '../utils'
+import { resolveImage, ConditionalWrapper, renderComponent } from '../utils'
+
 import { WebchatContext, RequestContext } from '../contexts'
 import { Button } from './button'
 import { Reply } from './reply'
@@ -206,7 +208,7 @@ export const Message = props => {
             >
               <img
                 style={{ width: '100%' }}
-                src={staticAsset(BotMessageImage)}
+                src={resolveImage(BotMessageImage)}
               />
             </BotMessageImageContainer>
           )}

--- a/packages/botonic-react/src/utils.js
+++ b/packages/botonic-react/src/utils.js
@@ -21,6 +21,18 @@ export const staticAsset = path => {
   }
 }
 
+export const isURL = urlPath => {
+  // @stephenhay (38 chars) from: https://mathiasbynens.be/demo/url-regex
+  const URL_PATTERN = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/
+  const pattern = new RegExp(URL_PATTERN)
+  return !!pattern.test(urlPath)
+}
+
+export const resolveImage = src => {
+  if (isURL(src)) return src
+  return staticAsset(src)
+}
+
 /**
  * given an object and a property, returns the property if exists (recursively), else undefined
  * ex:

--- a/packages/botonic-react/src/webchat/components/common.jsx
+++ b/packages/botonic-react/src/webchat/components/common.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
-import { staticAsset } from '../../utils'
+import { resolveImage } from '../../utils'
 
 const PointerImage = styled.img`
   cursor: pointer;
 `
-export const Icon = props => <PointerImage src={staticAsset(props.src)} />
+export const Icon = props => <PointerImage src={resolveImage(props.src)} />
 
 export const IconContainer = styled.div`
   display: flex;

--- a/packages/botonic-react/src/webchat/header.jsx
+++ b/packages/botonic-react/src/webchat/header.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import { WebchatContext } from '../contexts'
-import { staticAsset, ConditionalWrapper } from '../utils'
+import { resolveImage, ConditionalWrapper } from '../utils'
 import styled from 'styled-components'
 import { WEBCHAT, COLORS } from '../constants'
 import { Flex } from 'rebass'
@@ -68,7 +68,7 @@ export const DefaultHeader = props => {
     <Header color={props.color} style={{ ...getThemeProperty('header.style') }}>
       {headerImage && (
         <ImageContainer>
-          <Image src={staticAsset(headerImage)} />
+          <Image src={resolveImage(headerImage)} />
         </ImageContainer>
       )}
       <TextContainer ml={headerImage ? '0px' : '16px'}>

--- a/packages/botonic-react/src/webchat/message-list.jsx
+++ b/packages/botonic-react/src/webchat/message-list.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import { WebchatContext } from '../contexts'
 import { StyledScrollbar } from './components/styled-scrollbar'
-import { staticAsset, ConditionalWrapper } from '../utils'
+import { resolveImage, ConditionalWrapper } from '../utils'
 import Fade from 'react-reveal/Fade'
 import styled from 'styled-components'
 
@@ -36,7 +36,7 @@ export const WebchatMessageList = props => {
       style={{
         ...introStyle,
       }}
-      src={staticAsset(introImage)}
+      src={resolveImage(introImage)}
     />
   )
 

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -29,7 +29,7 @@ import { WebviewContainer } from './webview'
 import { msgToBotonic } from '../msg-to-botonic'
 import {
   isDev,
-  staticAsset,
+  resolveImage,
   _getThemeProperty,
   ConditionalWrapper,
   scrollToBottom,
@@ -525,7 +525,7 @@ export const Webchat = forwardRef((props, ref) => {
     }
     return (
       <StyledTriggerButton style={{ ...triggerButtonStyle }}>
-        {triggerImage && <TriggerImage src={staticAsset(triggerImage)} />}
+        {triggerImage && <TriggerImage src={resolveImage(triggerImage)} />}
       </StyledTriggerButton>
     )
   }


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
* Added method `isURL` to verify if string is URL.
* Added utility method `resolveImage` to automatically know if we need to handle the images with static assets or if it's just a plain URL.

## Context
Actually devs were not able to set with a URL the following webchat properties:
* `message.bot.image`
* `header.image`
* `intro.image`
* `triggerButton.image`

## Approach taken / Explain the design
Encapsulate the logic in `resolveImage` function.

## To documentate / Usage examples
* See `Context` section.
Code example:
```
export const webchat = {
  theme: {
    triggerButton: {
      image: "https://domain.com/my-logo.png",
    },
    message: {
      bot: {
        image: "https://domain.com/my-logo.png",
      },
    },
    header: {
      image: "https://domain.com/my-logo.png",
    },
    intro: {
      image: "https://domain.com/my-logo.png",
    },
  },
};
```
## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [X] doesn't need tests because... Using a well-known urlPattern, tested in dev and prod (npm run build + deploy) modes.
