### PR TITLE
feat(react): markdown support

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1626,6 +1626,14 @@
         }
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -3538,6 +3546,14 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "loader-utils": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
@@ -3634,6 +3650,30 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
+          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+        }
+      }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "memoize-one": {
       "version": "5.1.1",
@@ -4791,6 +4831,11 @@
         }
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -5009,6 +5054,11 @@
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "unescape": {
       "version": "1.0.1",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -28,6 +28,7 @@
     "axios": "^0.19.2",
     "emoji-picker-react": "^3.1.7",
     "framer-motion": "^1.8.3",
+    "markdown-it": "^10.0.0",
     "moment": "^2.24.0",
     "react": "^16.13.0",
     "react-children-utilities": "^2.1.0",

--- a/packages/botonic-react/src/components/markdown.js
+++ b/packages/botonic-react/src/components/markdown.js
@@ -1,0 +1,140 @@
+import MarkdownIt from 'markdown-it'
+
+const BR_STRING_TAG = '<br/>'
+const BR_STRING_TAG_REGEX = new RegExp('<br\\s*/?>', 'g')
+const ESCAPED_LINE_BREAK = '&lt;br&gt;'
+const ESCAPED_LINE_BREAK_REGEX = new RegExp(ESCAPED_LINE_BREAK, 'g')
+const isLineBreakElement = element => element.type === 'br'
+
+const configureMarkdownRenderer = () => {
+  const md = new MarkdownIt({
+    html: true,
+    linkify: true,
+    typographer: true,
+  })
+  // Support opening links in new tabs: https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
+  const renderer =
+    md.renderer.rules.link_open ||
+    function (tokens, idx, options, env, self) {
+      return self.renderToken(tokens, idx, options)
+    }
+  md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+    const aIndex = tokens[idx].attrIndex('target')
+    if (aIndex < 0) tokens[idx].attrPush(['target', '_blank'])
+    else tokens[idx].attrs[aIndex][1] = '_blank'
+    return renderer(tokens, idx, options, env, self)
+  }
+  return md
+}
+
+const md = configureMarkdownRenderer()
+
+export const renderMarkdown = text => {
+  // markdown-it renderer expects '<br/>' strings to render correctly line breaks
+  // Supporting multiline: https://stackoverflow.com/a/20543835
+  text = text
+    .map(e => {
+      if (isLineBreakElement(e)) return BR_STRING_TAG
+      else if (typeof e === 'string')
+        return e
+          .replace(BR_STRING_TAG_REGEX, BR_STRING_TAG)
+          .replace(ESCAPED_LINE_BREAK_REGEX, BR_STRING_TAG)
+      else return String(e)
+    })
+    .join('')
+  return md.render(text)
+}
+
+export const serializeMarkdown = children => {
+  children = Array.isArray(children) ? children : [children]
+  const text = children
+    .filter(e => isLineBreakElement(e) || !e.type)
+    .map(e => {
+      if (Array.isArray(e)) return serializeMarkdown(e)
+      if (isLineBreakElement(e)) return ESCAPED_LINE_BREAK
+      else return String(e).replace(BR_STRING_TAG_REGEX, ESCAPED_LINE_BREAK)
+    })
+    .join('')
+  return text
+}
+
+export const toMarkdownChildren = children =>
+  children.map(e => (isLineBreakElement(e) ? ESCAPED_LINE_BREAK : e))
+
+export const getMarkdownStyle = (getThemeFn, defaultColor) =>
+  getThemeFn('markdownStyle', getDefaultMarkdownStyle(defaultColor))
+
+export const getDefaultMarkdownStyle = color => `
+*{
+  margin: 0px;
+}
+
+a {
+  text-decoration:none;
+}
+
+a:link{
+  color:${color}; 
+}
+
+a:visited {
+  color:${color};
+}
+
+a:hover {
+  text-shadow: 0px 1px black;
+}
+
+blockquote {
+  margin: 0;
+  padding-left: 1.4rem;
+  border-left: 4px solid #dadada; 
+}
+
+pre code {
+  margin: 0;
+  padding: 0;
+  white-space: pre;
+  border: none;
+  background: transparent; 
+}
+
+pre {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-radius: 3px; 
+}
+
+code, tt {
+  margin: 0 2px;
+  padding: 0 5px;
+  white-space: nowrap;
+  border: 1px solid #eaeaea;
+  background-color: #f8f8f8;
+  border-radius: 3px; 
+}
+
+pre {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  font-size: 13px;
+  line-height: 19px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-radius: 3px; 
+}
+
+pre code, pre tt {
+  background-color: transparent;
+  border: none; 
+}
+  
+table, td, th {
+  border: 1px solid black;
+  padding:10px;
+}
+`

--- a/packages/botonic-react/src/components/markdown.js
+++ b/packages/botonic-react/src/components/markdown.js
@@ -2,7 +2,7 @@ import MarkdownIt from 'markdown-it'
 
 const BR_STRING_TAG = '<br/>'
 const BR_STRING_TAG_REGEX = new RegExp('<br\\s*/?>', 'g')
-const ESCAPED_LINE_BREAK = '&lt;br&gt;'
+export const ESCAPED_LINE_BREAK = '&lt;br&gt;'
 const ESCAPED_LINE_BREAK_REGEX = new RegExp(ESCAPED_LINE_BREAK, 'g')
 const isLineBreakElement = element => element.type === 'br'
 

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -11,6 +11,7 @@ import { Reply } from './reply'
 import { WEBCHAT, COLORS } from '../constants'
 import Fade from 'react-reveal/Fade'
 import moment from 'moment'
+import { renderMarkdown, getMarkdownStyle } from './markdown'
 
 const MessageContainer = styled.div`
   display: flex;
@@ -47,6 +48,7 @@ const BlobText = styled.div`
   display: flex;
   flex-direction: column;
   white-space: pre-line;
+  ${props => props.markdownstyle}
 `
 
 const TimestampContainer = styled.div`
@@ -93,9 +95,9 @@ export const Message = props => {
     style,
     imageStyle,
     timestamps = true,
+    markdown = true,
     ...otherProps
   } = props
-
   const {
     webchatState,
     addMessage,
@@ -135,6 +137,7 @@ export const Message = props => {
         type,
         data: decomposedChildren ? decomposedChildren : textChildren,
         timestamp: moment().format(timestampFormat),
+        markdown,
         from,
         buttons: buttons.map(b => ({
           payload: b.props.payload,
@@ -171,14 +174,12 @@ export const Message = props => {
 
   const isFromUser = () => from === 'user'
   const isFromBot = () => from === 'bot'
+  const brandColor = getThemeProperty('brand.color', COLORS.BOTONIC_BLUE)
 
   const getBgColor = () => {
     if (!blob) return COLORS.TRANSPARENT
     if (isFromUser()) {
-      return getThemeProperty(
-        'message.user.style.background',
-        getThemeProperty('brand.color', COLORS.BOTONIC_BLUE)
-      )
+      return getThemeProperty('message.user.style.background', brandColor)
     }
     return getThemeProperty(
       'message.bot.style.background',
@@ -271,7 +272,20 @@ export const Message = props => {
             }}
             {...otherProps}
           >
-            <BlobText blob={blob}>{textChildren}</BlobText>
+            {markdown ? (
+              <BlobText
+                blob={blob}
+                dangerouslySetInnerHTML={{
+                  __html: renderMarkdown(textChildren),
+                }}
+                markdownstyle={getMarkdownStyle(
+                  getThemeProperty,
+                  isFromUser() ? COLORS.SEASHELL_WHITE : brandColor
+                )}
+              />
+            ) : (
+              <BlobText blob={blob}>{textChildren}</BlobText>
+            )}
             {buttons}
             {blob && hasBlobTick() && getBlobTick(6)}
             {blob && hasBlobTick() && getBlobTick(5)}

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -82,7 +82,12 @@ export const MultichannelText = props => {
     if (multichannelContext.messageSeparator != null) {
       return elements
     }
-    return <Text {...props}>{elements}</Text>
+    return (
+      // We don't want to handle markdown here as this will be done internally by WhatsApp
+      <Text {...props} markdown={false}>
+        {elements}
+      </Text>
+    )
   } else {
     return <Text {...props}>{props.children}</Text>
   }

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -95,6 +95,7 @@ export const WEBCHAT = {
     customMenuButton: 'userInput.menuButton.custom',
     blockInputs: 'userInput.blockInputs',
     scrollbar: 'scrollbar',
+    markdownStyle: 'markdownStyle',
   },
 }
 

--- a/packages/botonic-react/tests/components/__snapshots__/text.test.jsx.snap
+++ b/packages/botonic-react/tests/components/__snapshots__/text.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Text Component Just one Text 1`] = `
 <message
   delay={0}
+  markdown={true}
   type="text"
   typing={0}
 >
@@ -14,6 +15,7 @@ exports[`Text Component N Text with N button  1`] = `
 Array [
   <message
     delay={0}
+    markdown={true}
     type="text"
     typing={0}
   >
@@ -28,6 +30,7 @@ Array [
   </message>,
   <message
     delay={0}
+    markdown={true}
     type="text"
     typing={0}
   >
@@ -47,6 +50,7 @@ exports[`Text Component N Text with N replies  1`] = `
 Array [
   <message
     delay={0}
+    markdown={true}
     type="text"
     typing={0}
   >
@@ -61,6 +65,7 @@ Array [
   </message>,
   <message
     delay={0}
+    markdown={true}
     type="text"
     typing={0}
   >
@@ -79,6 +84,7 @@ Array [
 exports[`Text Component Text with 1 button  1`] = `
 <message
   delay={0}
+  markdown={true}
   type="text"
   typing={0}
 >
@@ -94,6 +100,7 @@ exports[`Text Component Text with 1 button  1`] = `
 exports[`Text Component Text with 1 reply  1`] = `
 <message
   delay={0}
+  markdown={true}
   type="text"
   typing={0}
 >
@@ -109,6 +116,7 @@ exports[`Text Component Text with 1 reply  1`] = `
 exports[`Text Component Text with N button  1`] = `
 <message
   delay={0}
+  markdown={true}
   type="text"
   typing={0}
 >
@@ -129,6 +137,7 @@ exports[`Text Component Text with N button  1`] = `
 exports[`Text Component Text with N replies  1`] = `
 <message
   delay={0}
+  markdown={true}
   type="text"
   typing={0}
 >

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel-multibutton.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel-multibutton.test.jsx.snap
@@ -5,6 +5,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={0}
     type="text"
     typing={0}
@@ -16,6 +17,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={1}
     type="text"
     typing={0}
@@ -32,6 +34,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={0}
     type="text"
     typing={0}
@@ -45,6 +48,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={1}
     type="text"
     typing={0}
@@ -63,6 +67,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={0}
     type="text"
     typing={0}
@@ -76,6 +81,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={1}
     type="text"
     typing={0}

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel.test.jsx.snap
@@ -14,6 +14,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={0}
     type="text"
     typing={0}
@@ -23,6 +24,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={1}
     type="text"
     typing={0}
@@ -37,6 +39,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={0}
     type="text"
     typing={0}
@@ -48,6 +51,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={1}
     type="text"
     typing={0}
@@ -64,6 +68,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={0}
     type="text"
     typing={0}
@@ -75,6 +80,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={1}
     type="text"
     typing={0}

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-text.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-text.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`Multichannel text just text 1`] = `
 <message
   delay={0}
   indexMode="number"
+  markdown={false}
   type="text"
   typing={0}
 >
@@ -15,6 +16,7 @@ exports[`Multichannel text with buttons as array 1`] = `
 <message
   delay={0}
   indexMode="number"
+  markdown={false}
   type="text"
   typing={0}
 >
@@ -32,6 +34,7 @@ exports[`Multichannel text with buttons plain 1`] = `
 <message
   delay={0}
   indexMode="number"
+  markdown={false}
   type="text"
   typing={0}
 >
@@ -49,6 +52,7 @@ exports[`Multichannel text with replies as array 1`] = `
 <message
   delay={0}
   indexMode="number"
+  markdown={false}
   type="text"
   typing={0}
 >
@@ -64,6 +68,7 @@ exports[`Multichannel text with replies plain 1`] = `
 <message
   delay={0}
   indexMode="number"
+  markdown={false}
   type="text"
   typing={0}
 >

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-wrapper.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-wrapper.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Multichannel wrapper 1 text in 1 single message 1`] = `
 <message
   delay={0}
+  markdown={true}
   type="text"
   typing={0}
 >
@@ -13,6 +14,7 @@ exports[`Multichannel wrapper 1 text in 1 single message 1`] = `
 exports[`Multichannel wrapper 2 text in 1 single message 1`] = `
 <message
   delay={0}
+  markdown={true}
   type="text"
   typing={0}
 >
@@ -25,6 +27,7 @@ Text2
 exports[`Multichannel wrapper 2 texts with buttons 1`] = `
 <message
   delay={0}
+  markdown={true}
   type="text"
   typing={0}
 >
@@ -42,6 +45,7 @@ exports[`Multichannel wrapper just text 1`] = `
 <message
   delay={0}
   indexMode="number"
+  markdown={false}
   type="text"
   typing={0}
 >
@@ -54,6 +58,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     type="text"
     typing={0}
   >
@@ -66,6 +71,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     type="text"
     typing={0}
   >
@@ -78,6 +84,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     type="text"
     typing={0}
   >
@@ -95,6 +102,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     type="text"
     typing={0}
   >
@@ -103,6 +111,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={0}
     type="text"
     typing={0}
@@ -114,6 +123,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={1}
     type="text"
     typing={0}
@@ -127,6 +137,7 @@ Array [
   <message
     delay={0}
     indexMode="number"
+    markdown={false}
     newkey={2}
     type="text"
     typing={0}
@@ -141,6 +152,7 @@ Array [
 exports[`Multichannel wrapper text and carousel only show button text, 1 single message 1`] = `
 <message
   delay={0}
+  markdown={true}
   type="text"
   typing={0}
 >
@@ -156,6 +168,7 @@ exports[`Multichannel wrapper text with buttons 1`] = `
 <message
   delay={0}
   indexMode="number"
+  markdown={false}
   type="text"
   typing={0}
 >
@@ -173,6 +186,7 @@ exports[`Multichannel wrapper text with replies 1`] = `
 <message
   delay={0}
   indexMode="number"
+  markdown={false}
   type="text"
   typing={0}
 >

--- a/packages/botonic-react/tests/components/render-markdown.test.jsx
+++ b/packages/botonic-react/tests/components/render-markdown.test.jsx
@@ -1,0 +1,170 @@
+import { renderMarkdown } from '../../src/components/markdown'
+
+describe('Using renderMarkdown', () => {
+  // Markdown renderer adding an extra blank space after each render
+  // Examples taken from: https://markdown-it.github.io/
+  const render = text => renderMarkdown(text).trim()
+
+  it('Renders correctly a text', () => {
+    const toRender = ['text']
+    const sut = render(toRender)
+    expect(sut).toEqual('<p>text</p>')
+  })
+
+  it('Renders some links', () => {
+    const toRender = [
+      '## Links Examples',
+      '&lt;br&gt;',
+      '&lt;br&gt;',
+      '\n',
+      '---',
+      '\n',
+      '__Advertisement :)__',
+      '\n',
+      '- __[pica](https://nodeca.github.io/pica/demo/)__ - high quality and fast image resize in browser.',
+      '\n',
+      ' - __[babelfish](https://github.com/nodeca/babelfish/)__ - developer friendly i18n with plurals support and easy syntax. You will like those projects!',
+      '\n',
+      '---',
+    ]
+    const sut = render(toRender)
+    expect(sut).toEqual(
+      '<h2>Links Examples<br/><br/></h2>\n' +
+        '<hr>\n' +
+        '<p><strong>Advertisement :)</strong></p>\n' +
+        '<ul>\n' +
+        '<li><strong><a href="https://nodeca.github.io/pica/demo/" target="_blank">pica</a></strong> - high quality and fast image resize in browser.</li>\n' +
+        '<li><strong><a href="https://github.com/nodeca/babelfish/" target="_blank">babelfish</a></strong> - developer friendly i18n with plurals support and easy syntax. You will like those projects!</li>\n' +
+        '</ul>\n' +
+        '<hr>'
+    )
+  })
+
+  it('Renders headings', () => {
+    const toRender = [
+      '# Headings',
+      '&lt;br&gt;',
+      '&lt;br&gt;',
+      '\n',
+      '# h1 Heading',
+      '\n',
+      '## h2 Heading',
+      '\n',
+      '### h3 Heading',
+      '\n',
+      '#### h4 Heading',
+      '\n',
+      '##### h5 Heading',
+      '\n',
+      '###### h6 Heading',
+    ]
+    const sut = render(toRender)
+    expect(sut).toEqual(
+      '<h1>Headings<br/><br/></h1>\n' +
+        '<h1>h1 Heading</h1>\n' +
+        '<h2>h2 Heading</h2>\n' +
+        '<h3>h3 Heading</h3>\n' +
+        '<h4>h4 Heading</h4>\n' +
+        '<h5>h5 Heading</h5>\n' +
+        '<h6>h6 Heading</h6>'
+    )
+  })
+
+  it('Renders emphasis', () => {
+    const toRender = [
+      '## Emphasis',
+      '\n',
+      '**This is bold text**',
+      '\n',
+      '__This is bold text__',
+      '\n',
+      '*This is italic text*',
+      '\n',
+      '_This is italic text_',
+      '\n',
+      '~~Strikethrough~~',
+    ]
+    const sut = render(toRender)
+    expect(sut).toEqual(
+      '<h2>Emphasis</h2>\n' +
+        '<p><strong>This is bold text</strong>\n' +
+        '<strong>This is bold text</strong>\n' +
+        '<em>This is italic text</em>\n' +
+        '<em>This is italic text</em>\n' +
+        '<s>Strikethrough</s></p>'
+    )
+  })
+
+  it('Renders blockquotes', () => {
+    const toRender = [
+      '## Blockquotes',
+      '\n',
+      '> Blockquotes can also be nested...',
+      '\n',
+      '>> ...by using additional greater-than signs right next to each other...',
+      '\n',
+      '>>> ...or with spaces between arrows.',
+    ]
+    const sut = render(toRender)
+    expect(sut).toEqual(
+      '<h2>Blockquotes</h2>\n' +
+        '<blockquote>\n' +
+        '<p>Blockquotes can also be nested…</p>\n' +
+        '<blockquote>\n' +
+        '<p>…by using additional greater-than signs right next to each other…</p>\n' +
+        '<blockquote>\n' +
+        '<p>…or with spaces between arrows.</p>\n' +
+        '</blockquote>\n' +
+        '</blockquote>\n' +
+        '</blockquote>'
+    )
+  })
+
+  it('Renders tables', () => {
+    const toRender = [
+      '## Tables\n| Option | Description |\n| ------ | ----------- |\n| data   | path to data files to supply the data that will be passed into templates. |\n| engine | engine to be used for processing templates. Handlebars is the default. |\n| ext    | extension to be used for dest files. |\n<br/><br/>\n',
+    ]
+    const sut = render(toRender)
+    expect(sut).toEqual(
+      '<h2>Tables</h2>\n' +
+        '<table>\n' +
+        '<thead>\n' +
+        '<tr>\n' +
+        '<th>Option</th>\n' +
+        '<th>Description</th>\n' +
+        '</tr>\n' +
+        '</thead>\n' +
+        '<tbody>\n' +
+        '<tr>\n' +
+        '<td>data</td>\n' +
+        '<td>path to data files to supply the data that will be passed into templates.</td>\n' +
+        '</tr>\n' +
+        '<tr>\n' +
+        '<td>engine</td>\n' +
+        '<td>engine to be used for processing templates. Handlebars is the default.</td>\n' +
+        '</tr>\n' +
+        '<tr>\n' +
+        '<td>ext</td>\n' +
+        '<td>extension to be used for dest files.</td>\n' +
+        '</tr>\n' +
+        '</tbody>\n' +
+        '</table>\n' +
+        '<p><br/><br/></p>'
+    )
+  })
+
+  it('Renders code blocks', () => {
+    const toRender = [
+      '``` js\nvar foo = function (bar) {\n    return bar++;\n};\nconsole.log(foo(5));\n```\n#### Was this useful?',
+    ]
+    const sut = render(toRender)
+    expect(sut).toEqual(
+      '<pre><code class="language-js">var foo = function (bar) {\n' +
+        '    return bar++;\n' +
+        '};\n' +
+        'console.log(foo(5));\n' +
+        '</code></pre>\n' +
+        '<h4>Was this useful?</h4>'
+    )
+  })
+})

--- a/packages/botonic-react/tests/components/render-markdown.test.jsx
+++ b/packages/botonic-react/tests/components/render-markdown.test.jsx
@@ -1,10 +1,13 @@
-import { renderMarkdown } from '../../src/components/markdown'
+import {
+  renderMarkdown,
+  ESCAPED_LINE_BREAK,
+} from '../../src/components/markdown'
 
 describe('Using renderMarkdown', () => {
-  // Markdown renderer adding an extra blank space after each render
-  // Examples taken from: https://markdown-it.github.io/
+  // MarkdownIt renderer adds an extra blank space after each tag, hence the trim.
   const render = text => renderMarkdown(text).trim()
 
+  // Examples taken from: https://markdown-it.github.io/
   it('Renders correctly a text', () => {
     const toRender = ['text']
     const sut = render(toRender)
@@ -14,8 +17,8 @@ describe('Using renderMarkdown', () => {
   it('Renders some links', () => {
     const toRender = [
       '## Links Examples',
-      '&lt;br&gt;',
-      '&lt;br&gt;',
+      ESCAPED_LINE_BREAK,
+      ESCAPED_LINE_BREAK,
       '\n',
       '---',
       '\n',
@@ -43,8 +46,8 @@ describe('Using renderMarkdown', () => {
   it('Renders headings', () => {
     const toRender = [
       '# Headings',
-      '&lt;br&gt;',
-      '&lt;br&gt;',
+      ESCAPED_LINE_BREAK,
+      ESCAPED_LINE_BREAK,
       '\n',
       '# h1 Heading',
       '\n',

--- a/packages/botonic-react/tests/components/text-serialization.test.jsx
+++ b/packages/botonic-react/tests/components/text-serialization.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { Text } from '../../src/components/text'
+import { Button } from '../../src/components/button'
+
+describe('Text serialization', () => {
+  it('Serializes a simple text', () => {
+    const text = <Text markdown={true}>Just text</Text>
+    const sut = Text.serialize(text.props)
+    expect(sut).toEqual({ text: 'Just text' })
+  })
+
+  it('Serializes a simple text (markdown={false})', () => {
+    const text = <Text markdown={false}>Just text</Text>
+    const sut = Text.serialize(text.props)
+    expect(sut).toEqual({ text: 'Just text' })
+  })
+
+  it('Serializes a simple markdown heading', () => {
+    const text = <Text markdown={true}># Heading 1</Text>
+    const sut = Text.serialize(text.props)
+    expect(sut).toEqual({ text: '# Heading 1' })
+  })
+
+  it('Serializes a simple markdown heading (markdown={false})', () => {
+    const text = <Text markdown={false}># Heading 1</Text>
+    const sut = Text.serialize(text.props)
+    expect(sut).toEqual({ text: '# Heading 1' })
+  })
+
+  it('Not converted to Markdown as markdown={false}', () => {
+    const component = (
+      <Text markdown={false}>
+        # H1
+        {'\n'}
+        {'\n'}## H2
+      </Text>
+    )
+    const sut = Text.serialize(component.props)
+    expect(sut).toEqual({
+      text: '# H1\n\n## H2',
+    })
+  })
+
+  it('Serializes correctly Markdown (mode 1)', () => {
+    const component = (
+      <Text markdown={true}>
+        # H1
+        {'\n'}
+        <br />
+        <br />
+        {'\n'}## H2
+      </Text>
+    )
+    const sut = Text.serialize(component.props)
+    expect(sut).toEqual({
+      text: '# H1\n&lt;br&gt;&lt;br&gt;\n## H2',
+    })
+  })
+
+  it('Serializes correctly Markdown (mode 2)', () => {
+    const generateMd = () => '# H1\n<br/><br/>\n## H2'
+    const component = <Text markdown={true}>{generateMd()}</Text>
+    const sut = Text.serialize(component.props)
+    expect(sut).toEqual({
+      text: '# H1\n&lt;br&gt;&lt;br&gt;\n## H2',
+    })
+  })
+})

--- a/packages/botonic-react/tests/components/text-serialization.test.jsx
+++ b/packages/botonic-react/tests/components/text-serialization.test.jsx
@@ -3,28 +3,22 @@ import { Text } from '../../src/components/text'
 import { Button } from '../../src/components/button'
 
 describe('Text serialization', () => {
-  it('Serializes a simple text', () => {
-    const text = <Text markdown={true}>Just text</Text>
-    const sut = Text.serialize(text.props)
-    expect(sut).toEqual({ text: 'Just text' })
-  })
-
-  it('Serializes a simple text (markdown={false})', () => {
-    const text = <Text markdown={false}>Just text</Text>
-    const sut = Text.serialize(text.props)
-    expect(sut).toEqual({ text: 'Just text' })
-  })
-
-  it('Serializes a simple markdown heading', () => {
-    const text = <Text markdown={true}># Heading 1</Text>
-    const sut = Text.serialize(text.props)
-    expect(sut).toEqual({ text: '# Heading 1' })
-  })
-
-  it('Serializes a simple markdown heading (markdown={false})', () => {
-    const text = <Text markdown={false}># Heading 1</Text>
-    const sut = Text.serialize(text.props)
-    expect(sut).toEqual({ text: '# Heading 1' })
+  test.each([
+    <Text key={'msgSimple1'} markdown={true}>
+      Just text
+    </Text>,
+    <Text key={'msgSimple2'} markdown={false}>
+      Just text
+    </Text>,
+    <Text key={'heading1Simple1'} markdown={true}>
+      # Heading 1
+    </Text>,
+    <Text key={'heading1Simple2'} markdown={false}>
+      # Heading 1
+    </Text>,
+  ])(`Simple text`, textComponent => {
+    const sut = Text.serialize(textComponent.props)
+    expect(sut).toEqual({ text: textComponent.props.children })
   })
 
   it('Not converted to Markdown as markdown={false}', () => {


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
* Improve `Text.serialize` method.
* Added a markdown renderer for Webchat. After trying different libraries (react-markdown, markdown-to-jsx, ...), I found this is in the best ones https://www.npmjs.com/package/markdown-it (also used by MD Editors like https://stackedit.io/). Demo here: https://markdown-it.github.io/
* Added a way to customize styles for markdown.
* Configure renderer in order to support linking for links
* Updated snapshots and add unit tests for Markdown rendering and Text serialization.

## Context
Many users requested to be able to render markdown in Webchat channel.

## Approach taken / Explain the design
![Screenshot 2020-05-18 at 11 27 10](https://user-images.githubusercontent.com/35448568/82196959-a4a8e700-98fa-11ea-9d40-6d428bdf4405.png)
![Screenshot 2020-05-18 at 11 27 39](https://user-images.githubusercontent.com/35448568/82197002-b7232080-98fa-11ea-9063-56d6a2a4c10e.png)
![Screenshot 2020-05-18 at 11 27 43](https://user-images.githubusercontent.com/35448568/82197029-c1451f00-98fa-11ea-9705-c91dabde06fb.png)



## To documentate / Usage example 
**How to style Markdown in webchat?**

You can pass the css styles with a template string as shown below. (If you need further details about what are the generated html, feel free to inspect with the console).

**Usage Examples**
```
export default class extends React.Component {
  render() {
    const renderTable = () => {
      return (
        "## Tables\n" +
        "| Option | Description |\n" +
        "| ------ | ----------- |\n" +
        "| data   | path to data files to supply the data that will be passed into templates. |\n" +
        "| engine | engine to be used for processing templates. Handlebars is the default. |\n" +
        "| ext    | extension to be used for dest files. |\n" +
        "<br/><br/>\n"
      );
    };
    return <Text>{renderTable}</Text>;
  }
}

export default class extends React.Component {
  render() {
    // markdown={true} will be set by default
    return (
      <Text>
        # Heading 1{"\n"}
        ## Heading 2{"\n"}
        ### Heading3
      </Text>
    );
  }
}

**Customization**

```
_webchat/index.js_
```
theme: {
    markdownStyle: `
    * {
      margin: 0px;
    }
    a {
      text-decoration:none;
      font-weight:bold;
    }
    h1 {
      color: green;
    }
    h2 {
      color: purple;
    }
    a:visited {
      color: blue;
    }`,
  },
```

**Multiline support**
In order to have multiple line breaks, you need to add `<br/>` tags in your JSX, or have a function which returns `<br/>` tags inside the string. This will produce an additional line break between "## Links Examples" and  "---" separator.
```
return(
          <Text>
          ## Links Examples
          <br />
          <br />
          {"\n"}---
          {"\n"}__Advertisement :)__
          {"\n"}- __[pica](https://nodeca.github.io/pica/demo/)__ - high quality
          and fast image resize in browser.
          {"\n"} - __[babelfish](https://github.com/nodeca/babelfish/)__ -
          developer friendly i18n with plurals support and easy syntax. You will
          like those projects!
          {"\n"}---
        </Text>
)
```
<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- [X] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
