### PR TITLE
pre-release-fixes

### DIFF
--- a/packages/botonic-cli/templates/blank/webpack.config.js
+++ b/packages/botonic-cli/templates/blank/webpack.config.js
@@ -228,7 +228,7 @@ const botonicServerConfig = {
   resolve: resolveConfig,
   devtool: 'source-map',
   plugins: [
-    new CleanWebpackPlugin({}),
+    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
     imageminPlugin,
     new webpack.EnvironmentPlugin({
       HUBTYPE_API_URL: null,
@@ -238,7 +238,7 @@ const botonicServerConfig = {
   ],
 }
 
-module.exports = function(env) {
+module.exports = function (env) {
   if (env.target === 'all') {
     return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
   } else if (env.target === 'dev') {

--- a/packages/botonic-cli/templates/childs/webpack.config.js
+++ b/packages/botonic-cli/templates/childs/webpack.config.js
@@ -227,7 +227,7 @@ const botonicServerConfig = {
   resolve: resolveConfig,
   devtool: 'source-map',
   plugins: [
-    new CleanWebpackPlugin({}),
+    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
     imageminPlugin,
     new webpack.EnvironmentPlugin({
       HUBTYPE_API_URL: null,
@@ -237,7 +237,7 @@ const botonicServerConfig = {
   ],
 }
 
-module.exports = function(env) {
+module.exports = function (env) {
   if (env.target === 'all') {
     return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
   } else if (env.target === 'dev') {

--- a/packages/botonic-cli/templates/custom-webchat/webpack.config.js
+++ b/packages/botonic-cli/templates/custom-webchat/webpack.config.js
@@ -228,7 +228,7 @@ const botonicServerConfig = {
   resolve: resolveConfig,
   devtool: 'source-map',
   plugins: [
-    new CleanWebpackPlugin({}),
+    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
     imageminPlugin,
     new webpack.EnvironmentPlugin({
       HUBTYPE_API_URL: null,
@@ -238,7 +238,7 @@ const botonicServerConfig = {
   ],
 }
 
-module.exports = function(env) {
+module.exports = function (env) {
   if (env.target === 'all') {
     return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
   } else if (env.target === 'dev') {

--- a/packages/botonic-cli/templates/dynamic-carousel/webpack.config.js
+++ b/packages/botonic-cli/templates/dynamic-carousel/webpack.config.js
@@ -228,7 +228,7 @@ const botonicServerConfig = {
   resolve: resolveConfig,
   devtool: 'source-map',
   plugins: [
-    new CleanWebpackPlugin({}),
+    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
     imageminPlugin,
     new webpack.EnvironmentPlugin({
       HUBTYPE_API_URL: null,
@@ -238,7 +238,7 @@ const botonicServerConfig = {
   ],
 }
 
-module.exports = function(env) {
+module.exports = function (env) {
   if (env.target === 'all') {
     return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
   } else if (env.target === 'dev') {

--- a/packages/botonic-cli/templates/handoff/webpack.config.js
+++ b/packages/botonic-cli/templates/handoff/webpack.config.js
@@ -228,7 +228,7 @@ const botonicServerConfig = {
   resolve: resolveConfig,
   devtool: 'source-map',
   plugins: [
-    new CleanWebpackPlugin({}),
+    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
     imageminPlugin,
     new webpack.EnvironmentPlugin({
       HUBTYPE_API_URL: null,
@@ -238,7 +238,7 @@ const botonicServerConfig = {
   ],
 }
 
-module.exports = function(env) {
+module.exports = function (env) {
   if (env.target === 'all') {
     return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
   } else if (env.target === 'dev') {

--- a/packages/botonic-cli/templates/intent/webpack.config.js
+++ b/packages/botonic-cli/templates/intent/webpack.config.js
@@ -228,7 +228,7 @@ const botonicServerConfig = {
   resolve: resolveConfig,
   devtool: 'source-map',
   plugins: [
-    new CleanWebpackPlugin({}),
+    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
     imageminPlugin,
     new webpack.EnvironmentPlugin({
       HUBTYPE_API_URL: null,
@@ -238,7 +238,7 @@ const botonicServerConfig = {
   ],
 }
 
-module.exports = function(env) {
+module.exports = function (env) {
   if (env.target === 'all') {
     return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
   } else if (env.target === 'dev') {

--- a/packages/botonic-cli/templates/nlu/webpack.config.js
+++ b/packages/botonic-cli/templates/nlu/webpack.config.js
@@ -229,7 +229,7 @@ const botonicServerConfig = {
   resolve: resolveConfig,
   devtool: 'source-map',
   plugins: [
-    new CleanWebpackPlugin({}),
+    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
     imageminPlugin,
     new webpack.EnvironmentPlugin({
       HUBTYPE_API_URL: null,
@@ -239,7 +239,7 @@ const botonicServerConfig = {
   ],
 }
 
-module.exports = function(env) {
+module.exports = function (env) {
   if (env.target === 'all') {
     return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
   } else if (env.target === 'dev') {

--- a/packages/botonic-cli/templates/tutorial/webpack.config.js
+++ b/packages/botonic-cli/templates/tutorial/webpack.config.js
@@ -228,7 +228,7 @@ const botonicServerConfig = {
   resolve: resolveConfig,
   devtool: 'source-map',
   plugins: [
-    new CleanWebpackPlugin({}),
+    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
     imageminPlugin,
     new webpack.EnvironmentPlugin({
       HUBTYPE_API_URL: null,
@@ -238,7 +238,7 @@ const botonicServerConfig = {
   ],
 }
 
-module.exports = function(env) {
+module.exports = function (env) {
   if (env.target === 'all') {
     return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
   } else if (env.target === 'dev') {

--- a/packages/botonic-react/src/components/button.jsx
+++ b/packages/botonic-react/src/components/button.jsx
@@ -40,7 +40,7 @@ export const Button = props => {
 
   const handleClick = event => {
     event.preventDefault()
-    const type = getThemeProperty('button.messageType', 'postback')
+    const type = getThemeProperty('button.messageType', INPUT.TEXT)
     if (props.webview) openWebview(props.webview, props.params)
     else if (props.path) {
       type == INPUT.POSTBACK

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -95,9 +95,9 @@ export const Message = props => {
     style,
     imageStyle,
     timestamps = true,
-    markdown = true,
     ...otherProps
   } = props
+  const markdown = props.markdown
   const {
     webchatState,
     addMessage,

--- a/packages/botonic-react/src/utils.js
+++ b/packages/botonic-react/src/utils.js
@@ -98,11 +98,13 @@ export const getScrollableArea = () => {
   }
 }
 
-export const scrollToBottom = (timeout = 200) => {
+export const scrollToBottom = ({ timeout = 200, behavior = 'smooth' } = {}) => {
   const frame = getScrollableArea().visible
   if (frame) {
-    frame.scrollTop = frame.scrollHeight
-    setTimeout(() => (frame.scrollTop = frame.scrollHeight), timeout)
+    setTimeout(
+      () => frame.scrollTo({ top: frame.scrollHeight, behavior: behavior }),
+      timeout
+    )
   }
 }
 

--- a/packages/botonic-react/src/webchat/components/styled-scrollbar.scss
+++ b/packages/botonic-react/src/webchat/components/styled-scrollbar.scss
@@ -1,6 +1,5 @@
 #botonic-scrollable-content {
   .simplebar-mask .simplebar-offset .simplebar-content-wrapper {
-    scroll-behavior: smooth;
     overscroll-behavior: contain; // https://css-tricks.com/almanac/properties/o/overscroll-behavior/
     -webkit-overflow-scrolling: touch;
   }

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -228,7 +228,7 @@ export const Webchat = forwardRef((props, ref) => {
   useEffect(() => {
     if (!webchatState.isWebchatOpen) return
     deviceAdapter.init()
-    scrollToBottom()
+    scrollToBottom({ behavior: 'auto' })
   }, [webchatState.isWebchatOpen])
 
   useEffect(() => {


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

I will add in this PR fixes I found before 0.12.0 release

## Description
* `markdown` prop should not be stored for all messages (only text messages).
* Set the webchat scrollbar to bottom when webchat is open (behavior: 'auto' for "jumping" directly to position, behavior:'smooth' to do it smoothly. 
Removed the css property as with `scrollTo` can be done programatically (not supported natively by Safari, see https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo) if it is necessary, then a polyfill should be used: https://www.npmjs.com/package/scroll-behavior-polyfill
* Added `cleanOnceBeforeBuildPatterns: ['dist']` to avoid race conditions when removing `dist` folder.
* Sending payload text button by default.

## Context
In this PR will try to fix little things I see during testings the templates and that have an affordable solution before the release.


## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
