### PR TITLE
chore: script to upgrade dependencies

### DIFF
--- a/scripts/upgrade-deps.sh
+++ b/scripts/upgrade-deps.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$BIN_DIR/.." || exit 1
+
+# upgrade dependencies of all packages
+cd packages || exit 1
+for package in botonic-*; do
+  cd "$package" || exit
+  echo "Upgrading $package dependencies"
+  echo "===================================="
+  nice npm i -D > /dev/null
+  cd ..
+done
+
+# restart eslint_d in case any eslint plugin has been upgraded
+killall eslint_d 2> /dev/null
+killall -9 eslint_d 2> /dev/null


### PR DESCRIPTION
## Description
Script to upgrade all dependencies of all botonic packages.

## Context
Most dev dependencies are common for all packages. It's nice to have a single script to upgrade them all, and do any disk cache flush necessary to avoid conflict after upgrading dependencies which are backwards incompatible.


## Testing

The pull request...

- [ ] doesn't need tests because it's a chore addition
