### PR TITLE
fix(react): parse only links for enduser inputs

### DIFF
--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -11,7 +11,7 @@ import { Reply } from './reply'
 import { WEBCHAT, COLORS } from '../constants'
 import Fade from 'react-reveal/Fade'
 import moment from 'moment'
-import { renderMarkdown, getMarkdownStyle } from './markdown'
+import { renderMarkdown, getMarkdownStyle, renderLinks } from './markdown'
 
 const MessageContainer = styled.div`
   display: flex;
@@ -112,9 +112,10 @@ export const Message = props => {
   const buttons = React.Children.toArray(children).filter(
     e => e.type === Button
   )
-  const textChildren = React.Children.toArray(children).filter(
+  let textChildren = React.Children.toArray(children).filter(
     e => ![Button, Reply].includes(e.type)
   )
+  if (from === 'user') textChildren = textChildren.map(e => renderLinks(e))
 
   const getTimestampFormat = () => {
     const timestampLocale = getThemeProperty(`message.timestamps.locale`, 'en')

--- a/packages/botonic-react/tests/components/render-markdown.test.jsx
+++ b/packages/botonic-react/tests/components/render-markdown.test.jsx
@@ -1,5 +1,6 @@
 import {
   renderMarkdown,
+  renderLinks,
   ESCAPED_LINE_BREAK,
 } from '../../src/components/markdown'
 
@@ -168,6 +169,26 @@ describe('Using renderMarkdown', () => {
         'console.log(foo(5));\n' +
         '</code></pre>\n' +
         '<h4>Was this useful?</h4>'
+    )
+  })
+})
+
+describe('Using renderMarkdown (only links mode):', () => {
+  const render = text => renderLinks(text).trim()
+
+  it('Renders only url', () => {
+    const toRender = 'This is a url www.google.com'
+    const sut = render(toRender)
+    expect(sut).toEqual(
+      '<p>This is a url <a href="http://www.google.com" target="_blank">www.google.com</a></p>'
+    )
+  })
+
+  it("Doesn't render common markdown", () => {
+    const toRender = '# I am a heading 1, but not gonna be rendered as <h1>'
+    const sut = render(toRender)
+    expect(sut).toEqual(
+      '<p># I am a heading 1, but not gonna be rendered as &lt;h1&gt;</p>'
     )
   })
 })


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
* Extract function `withLinksTarget` to be used by markdown and link renderers.
* Configure a linksRenderer (note you can initialize MarkdownIt with the 'zero' preset and enable only the required features) to linkify enduser inputs
* Add unit tests
* Tested locally in "prod" webchat mode.

## Context
As discussed in the demo, Markdown should not be applied for enduser inputs except for URLs patterns (we still want the enduser URL inputs to be clickable by default).

## Approach taken / Explain the design
Before rendering the message, check if this is from `user` and apply `renderLinks` to transforms raw url text into corresponding anchor tags if necessary.

<img width="322" alt="Screenshot 2020-05-27 at 11 23 38" src="https://user-images.githubusercontent.com/35448568/83001827-8b93ea80-a00c-11ea-820c-383a79e09deb.png">


## To documentate / Usage example
Doesn't need documentation, we only need to specify that the only thing that will be parsed from user inputs will be the links.

## Testing

The pull request...

- [X] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
