### PR TITLE
fix(react): Webviews close correctly using MessengerExtensions

### DIFF
--- a/packages/botonic-react/src/webview.jsx
+++ b/packages/botonic-react/src/webview.jsx
@@ -44,7 +44,7 @@ class App extends React.Component {
       location.href = 'https://wa.me/' + this.state.session.user.imp_id
     } else {
       try {
-        window.WebviewSdk.close(
+        window.MessengerExtensions.requestCloseBrowser(
           () => undefined,
           err => console.log(err)
         )

--- a/packages/botonic-react/src/webview.template.html
+++ b/packages/botonic-react/src/webview.template.html
@@ -17,7 +17,7 @@
 
   <body>
     <script>
-      ;(function(d, s, id) {
+      ;(function (d, s, id) {
         var js,
           fjs = d.getElementsByTagName(s)[0]
         if (d.getElementById(id)) {
@@ -25,13 +25,13 @@
         }
         js = d.createElement(s)
         js.id = id
-        js.src = 'https://websdk.hubtype.com/webview-sdk.min.js'
+        js.src = 'https://connect.facebook.net/en_US/messenger.Extensions.js'
         fjs.parentNode.insertBefore(js, fjs)
-      })(document, 'script', 'WebviewSdkScript')
+      })(document, 'script', 'Messenger')
     </script>
     <div id="root"></div>
     <script type="text/javascript">
-      document.addEventListener('DOMContentLoaded', function(event) {
+      document.addEventListener('DOMContentLoaded', function (event) {
         BotonicWebview.render(document.getElementById('root'))
       })
     </script>


### PR DESCRIPTION
## Description
Use of MessengerExtensions instead of custom SDK.

## Context
A custom SDK was used to handle webviews close events, but it was outdated and it started to fail. By using the up to date sdk that facebook provides we are up to date again.