### PR TITLE
feat(core/react): dynamically resolve webchat visibility

### DIFF
--- a/packages/botonic-core/package-lock.json
+++ b/packages/botonic-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.12.0",
+  "version": "0.13.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.12.0",
+  "version": "0.13.0-alpha.0",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -86,4 +86,10 @@ export class HubtypeService {
       }
     )
   }
+
+  static async getWebchatVisibility({ appId }) {
+    return axios.get(
+      `${HUBTYPE_API_URL}/v1/provider_accounts/${appId}/get_webchat_visibility/`
+    )
+  }
 }

--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -89,7 +89,7 @@ export class HubtypeService {
 
   static async getWebchatVisibility({ appId }) {
     return axios.get(
-      `${HUBTYPE_API_URL}/v1/provider_accounts/${appId}/get_webchat_visibility/`
+      `${HUBTYPE_API_URL}/v1/provider_accounts/${appId}/visibility/`
     )
   }
 }

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.12.1",
+  "version": "0.13.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.12.1",
+  "version": "0.13.0-alpha.0",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "MIGRATION_GUIDE.md"
   ],
   "dependencies": {
-    "@botonic/core": "~0.12.0",
+    "@botonic/core": "0.13.0-alpha.0",
     "@rehooks/local-storage": "^2.2.3",
     "axios": "^0.19.2",
     "emoji-picker-react": "^3.1.7",

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -131,6 +131,13 @@ export class WebchatApp {
     this.webchatRef.current.clearMessages()
   }
 
+  async getVisibility() {
+    return this.resolveWebchatVisibility({
+      appId: this.appId,
+      visibility: this.visibility,
+    })
+  }
+
   getLastMessageUpdate() {
     return this.webchatRef.current.getLastMessageUpdate()
   }

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -201,8 +201,7 @@ export class WebchatApp {
       const { status } = await HubtypeService.getWebchatVisibility({
         appId,
       })
-      if (status === 200) return true
-      return false
+      return status === 200
     } catch (e) {
       return false
     }

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -212,10 +212,9 @@ export class WebchatApp {
     return false
   }
 
-  render(dest, optionsAtRuntime = {}) {
-    ;(async () => {
-      const isVisible = await this.resolveWebchatVisibility(optionsAtRuntime)
-      if (isVisible) render(this.getComponent(optionsAtRuntime), dest)
-    })()
+  async render(dest, optionsAtRuntime = {}) {
+    const isVisible = await this.resolveWebchatVisibility(optionsAtRuntime)
+    if (isVisible) render(this.getComponent(optionsAtRuntime), dest)
+    return null
   }
 }


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
* Modified webchat `render` logic to render it depending on visibility.

## Context
Coordinate with backend in order to determine whether webchat should be visible or not.

## Approach Taken

**API Description**:
Added `visibility` endpoint to determine if webchat should be visible or not.

Webchat visibility is determined by the following webchat settings:
* Checkbox is set to visible
* Requester url is in whitelisted domains
* Queue linked to webchat is open

Webchat will still be visible in the following cases:
* No settings defined (webchat which don't have these values set, previous versions)
* Whitelisted urls list is empty, `[]`

**Checks won't be done proactively.**

## To documentate / Usage example
**Default behavior**: an api call to backend will be done to determine (depending on Hubtype Desk settings) if webchat should be shown or not.

**Flexible behavior**:

In generated **index.html**, we can add `visibility` set to `true` if we want to make it always visible (also we can add a function returning `true/false`):
```
Botonic.render(document.getElementById("root"), {
          appId: "MY APP ID",
          visibility: true,
});
```
```
Botonic.render(document.getElementById("root"), {
          appId: "MY APP ID",
          visibility: function (){
                 const result = // do your api calls or other stuff
                 return Boolean(result)
          },
});
```

We can also declare above logic in **src/webchat/index.js** with the same identifier `visibility`, just like the ones we have for `onInit`, `onOpen`, ...

**Webchat SDK API**
It can also be called with the the public api `Botonic.getVisibility()`, or from `app` references,  which will return a promise resolving to `true/false` in case webchat should be visible (it will check both backend response and `visibility` passed option).
## Testing
The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [X] doesn't need tests because... 
