### PR TITLE
fix(nlu): nlu to not process hidden files

### DIFF
--- a/packages/botonic-nlu/package-lock.json
+++ b/packages/botonic-nlu/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/nlu",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-nlu/package.json
+++ b/packages/botonic-nlu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/nlu",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "lib/index",
   "scripts": {
     "build": "rm -rf lib && babel src -d lib",

--- a/packages/botonic-nlu/src/file-utils.js
+++ b/packages/botonic-nlu/src/file-utils.js
@@ -18,7 +18,7 @@ const CONFIG_NOT_FOUND_EXCEPTION = flagLang =>
 
 export function readDir(dirPath) {
   try {
-    return fs.readdirSync(dirPath).filter(dirName => dirName !== '.DS_Store')
+    return fs.readdirSync(dirPath).filter(dirName => !dirName.startsWith('.'))
   } catch (e) {
     throw FILE_OPEN_EXCEPTION(e)
   }


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
* Fix nlu to not process hidden files.

## Context
With latest templates we included `.gitkeep` file to make it easier for the developer to have the directory structure already initialized, the nlu was processing this file if not removed, causing errors on predictions in `botonic serve` mode.
 
## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [X] doesn't need tests because... incoming new nlu
