### PR TITLE
fix: only render links coming from text elements

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.13.0-alpha.0",
+  "version": "0.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.13.0-alpha.0",
+  "version": "0.12.2",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -115,7 +115,10 @@ export const Message = props => {
   let textChildren = React.Children.toArray(children).filter(
     e => ![Button, Reply].includes(e.type)
   )
-  if (from === 'user') textChildren = textChildren.map(e => renderLinks(e))
+  if (from === 'user')
+    textChildren = textChildren.map(e =>
+      typeof e === 'string' ? renderLinks(e) : e
+    )
 
   const getTimestampFormat = () => {
     const timestampLocale = getThemeProperty(`message.timestamps.locale`, 'en')


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
* Call renderlinks only on text elements, bypass React elements.

## Context
When rendering a custom message with user props, it was treated as if it can only be a text. This was breaking a custom rate React component rendered from the user perspective. 