### PR TITLE
feat(inbenta): add session token to Inbenta queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,16 @@ All notable changes to Botonic will be documented in this file.
   - Fixed enduser inputs to only process links instead of full markdown. Allow also custom messages defined with from `user` props.
   - Fixed wrong value being send when button of persistent menu is clicked and its text is send to the chat.
   - Fixed and updated Facebook `Messenger Extensions SDK` which was causing issues with Webviews.
+  - Added missing webchat property `enableUserInput`.p
 
 - [@botonic/nlu](https://www.npmjs.com/package/@botonic/nlu)
 
   - Fixed nlu processing hidden files. This affected on the results obtained in development mode.
   - Updated and freezed `@tensorflow/tfjs-node` and `@tensorflow/tfjs` dependencies to 1.7.3 which were automatically updating to higher versions with bugs, introducing bugs to training processes.
+
+* [@botonic/plugin-inbenta](https://www.npmjs.com/package/@botonic/plugin-inbenta)
+
+  - Added a session token to Inbenta search queries to track user actions.
 
 * [@botonic/plugin-nlu](https://www.npmjs.com/package/@botonic/plugin-nlu)
 

--- a/packages/botonic-cli/templates/blank/package.json
+++ b/packages/botonic-cli/templates/blank/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "webpack --env.target=all --mode=production",
-    "start": "webpack-dev-server --env.target=dev",
+    "start": "webpack-dev-server --env.target=dev --mode=development",
     "test": "jest"
   },
   "jest": {

--- a/packages/botonic-cli/templates/blank/webpack.config.js
+++ b/packages/botonic-cli/templates/blank/webpack.config.js
@@ -18,6 +18,36 @@ const terserPlugin = new TerserPlugin({
   },
 })
 
+const MODE_DEV = 'development'
+const MODE_PROD = 'production'
+
+const BOTONIC_TARGETS = {
+  DEV: 'dev',
+  NODE: 'node',
+  WEBVIEWS: 'webviews',
+  WEBCHAT: 'webchat',
+}
+
+function sourceMap(mode) {
+  console.log('Webpack running on mode:', mode)
+  // changing it from inline-source-map to cheap-eval-source-map, build time improved from 48s to 40s
+  if (mode === MODE_PROD) {
+    // Typescript: "inline-source-map" does not map Typescript correctly but there's a patch I didn't test https://github.com/webpack/webpack/issues/7172#issuecomment-414115819
+    // from https://webpack.js.org/configuration/devtool/ inline-source-map is slow and not good for production
+    //return 'cheap-eval-source-map'; // fast builds, not for production, transformed code (lines only)
+    // slow, good for production. A full SourceMap is emitted as a separate file. but doesn't add a reference comment to the bundle. Useful if you only want SourceMaps to map error stack traces from error reports, but don't want to expose your SourceMap for the browser development tools.
+    return 'hidden-source-map'
+  } else if (mode === MODE_DEV) {
+    // 'eval-source-map' would be a good fit for staging (slow but generates original code)
+    // from documentation: quick build time, very quick rebuild, transformed code (lines only)
+    return 'cheap-eval-source-map' //callstacks show links to TS code
+  } else {
+    throw new Error(
+      'Invalid mode argument (' + mode + '). See package.json scripts'
+    )
+  }
+}
+
 const resolveConfig = {
   extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
   alias: {
@@ -84,170 +114,184 @@ const imageminPlugin = new ImageminPlugin({
   },
 })
 
-const botonicDevConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  devServer: {
-    contentBase: [
-      path.join(__dirname, 'dist'),
-      path.join(__dirname, 'src', 'nlu', 'models'),
+function botonicDevConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    devServer: {
+      contentBase: [
+        path.join(__dirname, 'dist'),
+        path.join(__dirname, 'src', 'nlu', 'models'),
+      ],
+      watchContentBase: true,
+      historyApiFallback: true,
+      publicPath: '/',
+      hot: true,
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      new webpack.HotModuleReplacementPlugin(),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
+      }),
     ],
-    watchContentBase: true,
-    historyApiFallback: true,
-    publicPath: '/',
-    hot: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    new webpack.HotModuleReplacementPlugin(),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'dev',
-    }),
-  ],
+  }
 }
 
-const botonicWebchatConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      WEBCHAT_PUSHER_KEY: null,
-      BOTONIC_TARGET: 'webchat',
-    }),
-  ],
+function botonicWebchatConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        WEBCHAT_PUSHER_KEY: null,
+        BOTONIC_TARGET: 'webchat',
+      }),
+    ],
+  }
 }
 
-const botonicWebviewsConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    path: path.resolve(__dirname, 'dist/webviews'),
-    filename: 'webviews.js',
-    library: 'BotonicWebview',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [
-      babelLoaderConfig,
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              outputPath: '../assets',
+function botonicWebviewsConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      path: path.resolve(__dirname, 'dist/webviews'),
+      filename: 'webviews.js',
+      library: 'BotonicWebview',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [
+        babelLoaderConfig,
+        {
+          test: /\.(png|svg|jpg|gif)$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                outputPath: '../assets',
+              },
             },
-          },
-        ],
-      },
-      stylesLoaderConfig,
+          ],
+        },
+        stylesLoaderConfig,
+      ],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webview.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'webviews',
+      }),
     ],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webview.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'webviews',
-    }),
-  ],
+  }
 }
 
-const botonicServerConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  context: root,
-  mode: 'development',
-  target: 'node',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    filename: 'bot.js',
-    library: 'bot',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'node',
-    }),
-    new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-  ],
+function botonicServerConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    context: root,
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'node',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      filename: 'bot.js',
+      library: 'bot',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'node',
+      }),
+      new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
+    ],
+  }
 }
 
-module.exports = function (env) {
+module.exports = function (env, argv) {
   if (env.target === 'all') {
-    return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
-  } else if (env.target === 'dev') {
-    return [botonicDevConfig]
-  } else if (env.target === 'node') {
-    return [botonicServerConfig]
-  } else if (env.target === 'webviews') {
-    return [botonicWebviewsConfig]
-  } else if (env.target === 'webchat') {
-    return [botonicWebchatConfig]
+    return [
+      botonicServerConfig(argv.mode),
+      botonicWebviewsConfig(argv.mode),
+      botonicWebchatConfig(argv.mode),
+    ]
+  } else if (env.target === BOTONIC_TARGETS.DEV) {
+    return [botonicDevConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.NODE) {
+    return [botonicServerConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBVIEWS) {
+    return [botonicWebviewsConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBCHAT) {
+    return [botonicWebchatConfig(argv.mode)]
+  } else {
+    return null
   }
 }

--- a/packages/botonic-cli/templates/childs/package.json
+++ b/packages/botonic-cli/templates/childs/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "webpack --env.target=all --mode=production",
-    "start": "webpack-dev-server --env.target=dev",
+    "start": "webpack-dev-server --env.target=dev --mode=development",
     "test": "jest"
   },
   "jest": {

--- a/packages/botonic-cli/templates/childs/webpack.config.js
+++ b/packages/botonic-cli/templates/childs/webpack.config.js
@@ -1,9 +1,10 @@
 const path = require('path')
 const ImageminPlugin = require('imagemin-webpack')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
+const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
-const CopyPlugin = require('copy-webpack-plugin')
+
 const webpack = require('webpack')
 
 const root = path.resolve(__dirname, 'src')
@@ -16,6 +17,36 @@ const terserPlugin = new TerserPlugin({
     keep_fnames: true,
   },
 })
+
+const MODE_DEV = 'development'
+const MODE_PROD = 'production'
+
+const BOTONIC_TARGETS = {
+  DEV: 'dev',
+  NODE: 'node',
+  WEBVIEWS: 'webviews',
+  WEBCHAT: 'webchat',
+}
+
+function sourceMap(mode) {
+  console.log('Webpack running on mode:', mode)
+  // changing it from inline-source-map to cheap-eval-source-map, build time improved from 48s to 40s
+  if (mode === MODE_PROD) {
+    // Typescript: "inline-source-map" does not map Typescript correctly but there's a patch I didn't test https://github.com/webpack/webpack/issues/7172#issuecomment-414115819
+    // from https://webpack.js.org/configuration/devtool/ inline-source-map is slow and not good for production
+    //return 'cheap-eval-source-map'; // fast builds, not for production, transformed code (lines only)
+    // slow, good for production. A full SourceMap is emitted as a separate file. but doesn't add a reference comment to the bundle. Useful if you only want SourceMaps to map error stack traces from error reports, but don't want to expose your SourceMap for the browser development tools.
+    return 'hidden-source-map'
+  } else if (mode === MODE_DEV) {
+    // 'eval-source-map' would be a good fit for staging (slow but generates original code)
+    // from documentation: quick build time, very quick rebuild, transformed code (lines only)
+    return 'cheap-eval-source-map' //callstacks show links to TS code
+  } else {
+    throw new Error(
+      'Invalid mode argument (' + mode + '). See package.json scripts'
+    )
+  }
+}
 
 const resolveConfig = {
   extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
@@ -83,170 +114,184 @@ const imageminPlugin = new ImageminPlugin({
   },
 })
 
-const botonicDevConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  devServer: {
-    contentBase: [
-      path.join(__dirname, 'dist'),
-      path.join(__dirname, 'src', 'nlu', 'models'),
+function botonicDevConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    devServer: {
+      contentBase: [
+        path.join(__dirname, 'dist'),
+        path.join(__dirname, 'src', 'nlu', 'models'),
+      ],
+      watchContentBase: true,
+      historyApiFallback: true,
+      publicPath: '/',
+      hot: true,
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      new webpack.HotModuleReplacementPlugin(),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
+      }),
     ],
-    watchContentBase: true,
-    historyApiFallback: true,
-    publicPath: '/',
-    hot: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    new webpack.HotModuleReplacementPlugin(),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'dev',
-    }),
-  ],
+  }
 }
 
-const botonicWebchatConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      WEBCHAT_PUSHER_KEY: null,
-      BOTONIC_TARGET: 'webchat',
-    }),
-  ],
+function botonicWebchatConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        WEBCHAT_PUSHER_KEY: null,
+        BOTONIC_TARGET: 'webchat',
+      }),
+    ],
+  }
 }
 
-const botonicWebviewsConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    path: path.resolve(__dirname, 'dist/webviews'),
-    filename: 'webviews.js',
-    library: 'BotonicWebview',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [
-      babelLoaderConfig,
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              outputPath: '../assets',
+function botonicWebviewsConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      path: path.resolve(__dirname, 'dist/webviews'),
+      filename: 'webviews.js',
+      library: 'BotonicWebview',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [
+        babelLoaderConfig,
+        {
+          test: /\.(png|svg|jpg|gif)$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                outputPath: '../assets',
+              },
             },
-          },
-        ],
-      },
-      stylesLoaderConfig,
+          ],
+        },
+        stylesLoaderConfig,
+      ],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webview.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'webviews',
+      }),
     ],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webview.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'webviews',
-    }),
-  ],
+  }
 }
 
-const botonicServerConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  context: root,
-  mode: 'development',
-  target: 'node',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    filename: 'bot.js',
-    library: 'bot',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'node',
-    }),
-    new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-  ],
+function botonicServerConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    context: root,
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'node',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      filename: 'bot.js',
+      library: 'bot',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'node',
+      }),
+      new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
+    ],
+  }
 }
 
-module.exports = function (env) {
+module.exports = function (env, argv) {
   if (env.target === 'all') {
-    return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
-  } else if (env.target === 'dev') {
-    return [botonicDevConfig]
-  } else if (env.target === 'node') {
-    return [botonicServerConfig]
-  } else if (env.target === 'webviews') {
-    return [botonicWebviewsConfig]
-  } else if (env.target === 'webchat') {
-    return [botonicWebchatConfig]
+    return [
+      botonicServerConfig(argv.mode),
+      botonicWebviewsConfig(argv.mode),
+      botonicWebchatConfig(argv.mode),
+    ]
+  } else if (env.target === BOTONIC_TARGETS.DEV) {
+    return [botonicDevConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.NODE) {
+    return [botonicServerConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBVIEWS) {
+    return [botonicWebviewsConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBCHAT) {
+    return [botonicWebchatConfig(argv.mode)]
+  } else {
+    return null
   }
 }

--- a/packages/botonic-cli/templates/custom-webchat/package.json
+++ b/packages/botonic-cli/templates/custom-webchat/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "webpack --env.target=all --mode=production",
-    "start": "webpack-dev-server --env.target=dev",
+    "start": "webpack-dev-server --env.target=dev --mode=development",
     "test": "jest"
   },
   "jest": {

--- a/packages/botonic-cli/templates/custom-webchat/webpack.config.js
+++ b/packages/botonic-cli/templates/custom-webchat/webpack.config.js
@@ -18,6 +18,36 @@ const terserPlugin = new TerserPlugin({
   },
 })
 
+const MODE_DEV = 'development'
+const MODE_PROD = 'production'
+
+const BOTONIC_TARGETS = {
+  DEV: 'dev',
+  NODE: 'node',
+  WEBVIEWS: 'webviews',
+  WEBCHAT: 'webchat',
+}
+
+function sourceMap(mode) {
+  console.log('Webpack running on mode:', mode)
+  // changing it from inline-source-map to cheap-eval-source-map, build time improved from 48s to 40s
+  if (mode === MODE_PROD) {
+    // Typescript: "inline-source-map" does not map Typescript correctly but there's a patch I didn't test https://github.com/webpack/webpack/issues/7172#issuecomment-414115819
+    // from https://webpack.js.org/configuration/devtool/ inline-source-map is slow and not good for production
+    //return 'cheap-eval-source-map'; // fast builds, not for production, transformed code (lines only)
+    // slow, good for production. A full SourceMap is emitted as a separate file. but doesn't add a reference comment to the bundle. Useful if you only want SourceMaps to map error stack traces from error reports, but don't want to expose your SourceMap for the browser development tools.
+    return 'hidden-source-map'
+  } else if (mode === MODE_DEV) {
+    // 'eval-source-map' would be a good fit for staging (slow but generates original code)
+    // from documentation: quick build time, very quick rebuild, transformed code (lines only)
+    return 'cheap-eval-source-map' //callstacks show links to TS code
+  } else {
+    throw new Error(
+      'Invalid mode argument (' + mode + '). See package.json scripts'
+    )
+  }
+}
+
 const resolveConfig = {
   extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
   alias: {
@@ -84,170 +114,184 @@ const imageminPlugin = new ImageminPlugin({
   },
 })
 
-const botonicDevConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  devServer: {
-    contentBase: [
-      path.join(__dirname, 'dist'),
-      path.join(__dirname, 'src', 'nlu', 'models'),
+function botonicDevConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    devServer: {
+      contentBase: [
+        path.join(__dirname, 'dist'),
+        path.join(__dirname, 'src', 'nlu', 'models'),
+      ],
+      watchContentBase: true,
+      historyApiFallback: true,
+      publicPath: '/',
+      hot: true,
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      new webpack.HotModuleReplacementPlugin(),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
+      }),
     ],
-    watchContentBase: true,
-    historyApiFallback: true,
-    publicPath: '/',
-    hot: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    new webpack.HotModuleReplacementPlugin(),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'dev',
-    }),
-  ],
+  }
 }
 
-const botonicWebchatConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      WEBCHAT_PUSHER_KEY: null,
-      BOTONIC_TARGET: 'webchat',
-    }),
-  ],
+function botonicWebchatConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        WEBCHAT_PUSHER_KEY: null,
+        BOTONIC_TARGET: 'webchat',
+      }),
+    ],
+  }
 }
 
-const botonicWebviewsConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    path: path.resolve(__dirname, 'dist/webviews'),
-    filename: 'webviews.js',
-    library: 'BotonicWebview',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [
-      babelLoaderConfig,
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              outputPath: '../assets',
+function botonicWebviewsConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      path: path.resolve(__dirname, 'dist/webviews'),
+      filename: 'webviews.js',
+      library: 'BotonicWebview',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [
+        babelLoaderConfig,
+        {
+          test: /\.(png|svg|jpg|gif)$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                outputPath: '../assets',
+              },
             },
-          },
-        ],
-      },
-      stylesLoaderConfig,
+          ],
+        },
+        stylesLoaderConfig,
+      ],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webview.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'webviews',
+      }),
     ],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webview.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'webviews',
-    }),
-  ],
+  }
 }
 
-const botonicServerConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  context: root,
-  mode: 'development',
-  target: 'node',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    filename: 'bot.js',
-    library: 'bot',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'node',
-    }),
-    new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-  ],
+function botonicServerConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    context: root,
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'node',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      filename: 'bot.js',
+      library: 'bot',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'node',
+      }),
+      new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
+    ],
+  }
 }
 
-module.exports = function (env) {
+module.exports = function (env, argv) {
   if (env.target === 'all') {
-    return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
-  } else if (env.target === 'dev') {
-    return [botonicDevConfig]
-  } else if (env.target === 'node') {
-    return [botonicServerConfig]
-  } else if (env.target === 'webviews') {
-    return [botonicWebviewsConfig]
-  } else if (env.target === 'webchat') {
-    return [botonicWebchatConfig]
+    return [
+      botonicServerConfig(argv.mode),
+      botonicWebviewsConfig(argv.mode),
+      botonicWebchatConfig(argv.mode),
+    ]
+  } else if (env.target === BOTONIC_TARGETS.DEV) {
+    return [botonicDevConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.NODE) {
+    return [botonicServerConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBVIEWS) {
+    return [botonicWebviewsConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBCHAT) {
+    return [botonicWebchatConfig(argv.mode)]
+  } else {
+    return null
   }
 }

--- a/packages/botonic-cli/templates/dynamic-carousel/package.json
+++ b/packages/botonic-cli/templates/dynamic-carousel/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "webpack --env.target=all --mode=production",
-    "start": "webpack-dev-server --env.target=dev",
+    "start": "webpack-dev-server --env.target=dev --mode=development",
     "test": "jest"
   },
   "jest": {

--- a/packages/botonic-cli/templates/dynamic-carousel/webpack.config.js
+++ b/packages/botonic-cli/templates/dynamic-carousel/webpack.config.js
@@ -18,6 +18,36 @@ const terserPlugin = new TerserPlugin({
   },
 })
 
+const MODE_DEV = 'development'
+const MODE_PROD = 'production'
+
+const BOTONIC_TARGETS = {
+  DEV: 'dev',
+  NODE: 'node',
+  WEBVIEWS: 'webviews',
+  WEBCHAT: 'webchat',
+}
+
+function sourceMap(mode) {
+  console.log('Webpack running on mode:', mode)
+  // changing it from inline-source-map to cheap-eval-source-map, build time improved from 48s to 40s
+  if (mode === MODE_PROD) {
+    // Typescript: "inline-source-map" does not map Typescript correctly but there's a patch I didn't test https://github.com/webpack/webpack/issues/7172#issuecomment-414115819
+    // from https://webpack.js.org/configuration/devtool/ inline-source-map is slow and not good for production
+    //return 'cheap-eval-source-map'; // fast builds, not for production, transformed code (lines only)
+    // slow, good for production. A full SourceMap is emitted as a separate file. but doesn't add a reference comment to the bundle. Useful if you only want SourceMaps to map error stack traces from error reports, but don't want to expose your SourceMap for the browser development tools.
+    return 'hidden-source-map'
+  } else if (mode === MODE_DEV) {
+    // 'eval-source-map' would be a good fit for staging (slow but generates original code)
+    // from documentation: quick build time, very quick rebuild, transformed code (lines only)
+    return 'cheap-eval-source-map' //callstacks show links to TS code
+  } else {
+    throw new Error(
+      'Invalid mode argument (' + mode + '). See package.json scripts'
+    )
+  }
+}
+
 const resolveConfig = {
   extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
   alias: {
@@ -84,170 +114,184 @@ const imageminPlugin = new ImageminPlugin({
   },
 })
 
-const botonicDevConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  devServer: {
-    contentBase: [
-      path.join(__dirname, 'dist'),
-      path.join(__dirname, 'src', 'nlu', 'models'),
+function botonicDevConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    devServer: {
+      contentBase: [
+        path.join(__dirname, 'dist'),
+        path.join(__dirname, 'src', 'nlu', 'models'),
+      ],
+      watchContentBase: true,
+      historyApiFallback: true,
+      publicPath: '/',
+      hot: true,
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      new webpack.HotModuleReplacementPlugin(),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
+      }),
     ],
-    watchContentBase: true,
-    historyApiFallback: true,
-    publicPath: '/',
-    hot: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    new webpack.HotModuleReplacementPlugin(),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'dev',
-    }),
-  ],
+  }
 }
 
-const botonicWebchatConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      WEBCHAT_PUSHER_KEY: null,
-      BOTONIC_TARGET: 'webchat',
-    }),
-  ],
+function botonicWebchatConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        WEBCHAT_PUSHER_KEY: null,
+        BOTONIC_TARGET: 'webchat',
+      }),
+    ],
+  }
 }
 
-const botonicWebviewsConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    path: path.resolve(__dirname, 'dist/webviews'),
-    filename: 'webviews.js',
-    library: 'BotonicWebview',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [
-      babelLoaderConfig,
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              outputPath: '../assets',
+function botonicWebviewsConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      path: path.resolve(__dirname, 'dist/webviews'),
+      filename: 'webviews.js',
+      library: 'BotonicWebview',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [
+        babelLoaderConfig,
+        {
+          test: /\.(png|svg|jpg|gif)$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                outputPath: '../assets',
+              },
             },
-          },
-        ],
-      },
-      stylesLoaderConfig,
+          ],
+        },
+        stylesLoaderConfig,
+      ],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webview.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'webviews',
+      }),
     ],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webview.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'webviews',
-    }),
-  ],
+  }
 }
 
-const botonicServerConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  context: root,
-  mode: 'development',
-  target: 'node',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    filename: 'bot.js',
-    library: 'bot',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'node',
-    }),
-    new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-  ],
+function botonicServerConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    context: root,
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'node',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      filename: 'bot.js',
+      library: 'bot',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'node',
+      }),
+      new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
+    ],
+  }
 }
 
-module.exports = function (env) {
+module.exports = function (env, argv) {
   if (env.target === 'all') {
-    return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
-  } else if (env.target === 'dev') {
-    return [botonicDevConfig]
-  } else if (env.target === 'node') {
-    return [botonicServerConfig]
-  } else if (env.target === 'webviews') {
-    return [botonicWebviewsConfig]
-  } else if (env.target === 'webchat') {
-    return [botonicWebchatConfig]
+    return [
+      botonicServerConfig(argv.mode),
+      botonicWebviewsConfig(argv.mode),
+      botonicWebchatConfig(argv.mode),
+    ]
+  } else if (env.target === BOTONIC_TARGETS.DEV) {
+    return [botonicDevConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.NODE) {
+    return [botonicServerConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBVIEWS) {
+    return [botonicWebviewsConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBCHAT) {
+    return [botonicWebchatConfig(argv.mode)]
+  } else {
+    return null
   }
 }

--- a/packages/botonic-cli/templates/handoff/package.json
+++ b/packages/botonic-cli/templates/handoff/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "webpack --env.target=all --mode=production",
-    "start": "webpack-dev-server --env.target=dev",
+    "start": "webpack-dev-server --env.target=dev --mode=development",
     "test": "jest"
   },
   "jest": {

--- a/packages/botonic-cli/templates/handoff/webpack.config.js
+++ b/packages/botonic-cli/templates/handoff/webpack.config.js
@@ -18,6 +18,36 @@ const terserPlugin = new TerserPlugin({
   },
 })
 
+const MODE_DEV = 'development'
+const MODE_PROD = 'production'
+
+const BOTONIC_TARGETS = {
+  DEV: 'dev',
+  NODE: 'node',
+  WEBVIEWS: 'webviews',
+  WEBCHAT: 'webchat',
+}
+
+function sourceMap(mode) {
+  console.log('Webpack running on mode:', mode)
+  // changing it from inline-source-map to cheap-eval-source-map, build time improved from 48s to 40s
+  if (mode === MODE_PROD) {
+    // Typescript: "inline-source-map" does not map Typescript correctly but there's a patch I didn't test https://github.com/webpack/webpack/issues/7172#issuecomment-414115819
+    // from https://webpack.js.org/configuration/devtool/ inline-source-map is slow and not good for production
+    //return 'cheap-eval-source-map'; // fast builds, not for production, transformed code (lines only)
+    // slow, good for production. A full SourceMap is emitted as a separate file. but doesn't add a reference comment to the bundle. Useful if you only want SourceMaps to map error stack traces from error reports, but don't want to expose your SourceMap for the browser development tools.
+    return 'hidden-source-map'
+  } else if (mode === MODE_DEV) {
+    // 'eval-source-map' would be a good fit for staging (slow but generates original code)
+    // from documentation: quick build time, very quick rebuild, transformed code (lines only)
+    return 'cheap-eval-source-map' //callstacks show links to TS code
+  } else {
+    throw new Error(
+      'Invalid mode argument (' + mode + '). See package.json scripts'
+    )
+  }
+}
+
 const resolveConfig = {
   extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
   alias: {
@@ -84,170 +114,184 @@ const imageminPlugin = new ImageminPlugin({
   },
 })
 
-const botonicDevConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  devServer: {
-    contentBase: [
-      path.join(__dirname, 'dist'),
-      path.join(__dirname, 'src', 'nlu', 'models'),
+function botonicDevConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    devServer: {
+      contentBase: [
+        path.join(__dirname, 'dist'),
+        path.join(__dirname, 'src', 'nlu', 'models'),
+      ],
+      watchContentBase: true,
+      historyApiFallback: true,
+      publicPath: '/',
+      hot: true,
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      new webpack.HotModuleReplacementPlugin(),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
+      }),
     ],
-    watchContentBase: true,
-    historyApiFallback: true,
-    publicPath: '/',
-    hot: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    new webpack.HotModuleReplacementPlugin(),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'dev',
-    }),
-  ],
+  }
 }
 
-const botonicWebchatConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      WEBCHAT_PUSHER_KEY: null,
-      BOTONIC_TARGET: 'webchat',
-    }),
-  ],
+function botonicWebchatConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        WEBCHAT_PUSHER_KEY: null,
+        BOTONIC_TARGET: 'webchat',
+      }),
+    ],
+  }
 }
 
-const botonicWebviewsConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    path: path.resolve(__dirname, 'dist/webviews'),
-    filename: 'webviews.js',
-    library: 'BotonicWebview',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [
-      babelLoaderConfig,
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              outputPath: '../assets',
+function botonicWebviewsConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      path: path.resolve(__dirname, 'dist/webviews'),
+      filename: 'webviews.js',
+      library: 'BotonicWebview',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [
+        babelLoaderConfig,
+        {
+          test: /\.(png|svg|jpg|gif)$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                outputPath: '../assets',
+              },
             },
-          },
-        ],
-      },
-      stylesLoaderConfig,
+          ],
+        },
+        stylesLoaderConfig,
+      ],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webview.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'webviews',
+      }),
     ],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webview.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'webviews',
-    }),
-  ],
+  }
 }
 
-const botonicServerConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  context: root,
-  mode: 'development',
-  target: 'node',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    filename: 'bot.js',
-    library: 'bot',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'node',
-    }),
-    new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-  ],
+function botonicServerConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    context: root,
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'node',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      filename: 'bot.js',
+      library: 'bot',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'node',
+      }),
+      new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
+    ],
+  }
 }
 
-module.exports = function (env) {
+module.exports = function (env, argv) {
   if (env.target === 'all') {
-    return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
-  } else if (env.target === 'dev') {
-    return [botonicDevConfig]
-  } else if (env.target === 'node') {
-    return [botonicServerConfig]
-  } else if (env.target === 'webviews') {
-    return [botonicWebviewsConfig]
-  } else if (env.target === 'webchat') {
-    return [botonicWebchatConfig]
+    return [
+      botonicServerConfig(argv.mode),
+      botonicWebviewsConfig(argv.mode),
+      botonicWebchatConfig(argv.mode),
+    ]
+  } else if (env.target === BOTONIC_TARGETS.DEV) {
+    return [botonicDevConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.NODE) {
+    return [botonicServerConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBVIEWS) {
+    return [botonicWebviewsConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBCHAT) {
+    return [botonicWebchatConfig(argv.mode)]
+  } else {
+    return null
   }
 }

--- a/packages/botonic-cli/templates/intent/package.json
+++ b/packages/botonic-cli/templates/intent/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "webpack --env.target=all --mode=production",
-    "start": "webpack-dev-server --env.target=dev",
+    "start": "webpack-dev-server --env.target=dev --mode=development",
     "test": "jest"
   },
   "jest": {

--- a/packages/botonic-cli/templates/intent/webpack.config.js
+++ b/packages/botonic-cli/templates/intent/webpack.config.js
@@ -18,6 +18,36 @@ const terserPlugin = new TerserPlugin({
   },
 })
 
+const MODE_DEV = 'development'
+const MODE_PROD = 'production'
+
+const BOTONIC_TARGETS = {
+  DEV: 'dev',
+  NODE: 'node',
+  WEBVIEWS: 'webviews',
+  WEBCHAT: 'webchat',
+}
+
+function sourceMap(mode) {
+  console.log('Webpack running on mode:', mode)
+  // changing it from inline-source-map to cheap-eval-source-map, build time improved from 48s to 40s
+  if (mode === MODE_PROD) {
+    // Typescript: "inline-source-map" does not map Typescript correctly but there's a patch I didn't test https://github.com/webpack/webpack/issues/7172#issuecomment-414115819
+    // from https://webpack.js.org/configuration/devtool/ inline-source-map is slow and not good for production
+    //return 'cheap-eval-source-map'; // fast builds, not for production, transformed code (lines only)
+    // slow, good for production. A full SourceMap is emitted as a separate file. but doesn't add a reference comment to the bundle. Useful if you only want SourceMaps to map error stack traces from error reports, but don't want to expose your SourceMap for the browser development tools.
+    return 'hidden-source-map'
+  } else if (mode === MODE_DEV) {
+    // 'eval-source-map' would be a good fit for staging (slow but generates original code)
+    // from documentation: quick build time, very quick rebuild, transformed code (lines only)
+    return 'cheap-eval-source-map' //callstacks show links to TS code
+  } else {
+    throw new Error(
+      'Invalid mode argument (' + mode + '). See package.json scripts'
+    )
+  }
+}
+
 const resolveConfig = {
   extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
   alias: {
@@ -84,170 +114,184 @@ const imageminPlugin = new ImageminPlugin({
   },
 })
 
-const botonicDevConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  devServer: {
-    contentBase: [
-      path.join(__dirname, 'dist'),
-      path.join(__dirname, 'src', 'nlu', 'models'),
+function botonicDevConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    devServer: {
+      contentBase: [
+        path.join(__dirname, 'dist'),
+        path.join(__dirname, 'src', 'nlu', 'models'),
+      ],
+      watchContentBase: true,
+      historyApiFallback: true,
+      publicPath: '/',
+      hot: true,
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      new webpack.HotModuleReplacementPlugin(),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
+      }),
     ],
-    watchContentBase: true,
-    historyApiFallback: true,
-    publicPath: '/',
-    hot: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    new webpack.HotModuleReplacementPlugin(),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'dev',
-    }),
-  ],
+  }
 }
 
-const botonicWebchatConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      WEBCHAT_PUSHER_KEY: null,
-      BOTONIC_TARGET: 'webchat',
-    }),
-  ],
+function botonicWebchatConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        WEBCHAT_PUSHER_KEY: null,
+        BOTONIC_TARGET: 'webchat',
+      }),
+    ],
+  }
 }
 
-const botonicWebviewsConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    path: path.resolve(__dirname, 'dist/webviews'),
-    filename: 'webviews.js',
-    library: 'BotonicWebview',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [
-      babelLoaderConfig,
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              outputPath: '../assets',
+function botonicWebviewsConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      path: path.resolve(__dirname, 'dist/webviews'),
+      filename: 'webviews.js',
+      library: 'BotonicWebview',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [
+        babelLoaderConfig,
+        {
+          test: /\.(png|svg|jpg|gif)$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                outputPath: '../assets',
+              },
             },
-          },
-        ],
-      },
-      stylesLoaderConfig,
+          ],
+        },
+        stylesLoaderConfig,
+      ],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webview.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'webviews',
+      }),
     ],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webview.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'webviews',
-    }),
-  ],
+  }
 }
 
-const botonicServerConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  context: root,
-  mode: 'development',
-  target: 'node',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    filename: 'bot.js',
-    library: 'bot',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'node',
-    }),
-    new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-  ],
+function botonicServerConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    context: root,
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'node',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      filename: 'bot.js',
+      library: 'bot',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'node',
+      }),
+      new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
+    ],
+  }
 }
 
-module.exports = function (env) {
+module.exports = function (env, argv) {
   if (env.target === 'all') {
-    return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
-  } else if (env.target === 'dev') {
-    return [botonicDevConfig]
-  } else if (env.target === 'node') {
-    return [botonicServerConfig]
-  } else if (env.target === 'webviews') {
-    return [botonicWebviewsConfig]
-  } else if (env.target === 'webchat') {
-    return [botonicWebchatConfig]
+    return [
+      botonicServerConfig(argv.mode),
+      botonicWebviewsConfig(argv.mode),
+      botonicWebchatConfig(argv.mode),
+    ]
+  } else if (env.target === BOTONIC_TARGETS.DEV) {
+    return [botonicDevConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.NODE) {
+    return [botonicServerConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBVIEWS) {
+    return [botonicWebviewsConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBCHAT) {
+    return [botonicWebchatConfig(argv.mode)]
+  } else {
+    return null
   }
 }

--- a/packages/botonic-cli/templates/nlu/package.json
+++ b/packages/botonic-cli/templates/nlu/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "webpack --env.target=all --mode=production",
-    "start": "webpack-dev-server --env.target=dev",
+    "start": "webpack-dev-server --env.target=dev --mode=development",
     "test": "jest"
   },
   "jest": {

--- a/packages/botonic-cli/templates/nlu/webpack.config.js
+++ b/packages/botonic-cli/templates/nlu/webpack.config.js
@@ -18,6 +18,36 @@ const terserPlugin = new TerserPlugin({
   },
 })
 
+const MODE_DEV = 'development'
+const MODE_PROD = 'production'
+
+const BOTONIC_TARGETS = {
+  DEV: 'dev',
+  NODE: 'node',
+  WEBVIEWS: 'webviews',
+  WEBCHAT: 'webchat',
+}
+
+function sourceMap(mode) {
+  console.log('Webpack running on mode:', mode)
+  // changing it from inline-source-map to cheap-eval-source-map, build time improved from 48s to 40s
+  if (mode === MODE_PROD) {
+    // Typescript: "inline-source-map" does not map Typescript correctly but there's a patch I didn't test https://github.com/webpack/webpack/issues/7172#issuecomment-414115819
+    // from https://webpack.js.org/configuration/devtool/ inline-source-map is slow and not good for production
+    //return 'cheap-eval-source-map'; // fast builds, not for production, transformed code (lines only)
+    // slow, good for production. A full SourceMap is emitted as a separate file. but doesn't add a reference comment to the bundle. Useful if you only want SourceMaps to map error stack traces from error reports, but don't want to expose your SourceMap for the browser development tools.
+    return 'hidden-source-map'
+  } else if (mode === MODE_DEV) {
+    // 'eval-source-map' would be a good fit for staging (slow but generates original code)
+    // from documentation: quick build time, very quick rebuild, transformed code (lines only)
+    return 'cheap-eval-source-map' //callstacks show links to TS code
+  } else {
+    throw new Error(
+      'Invalid mode argument (' + mode + '). See package.json scripts'
+    )
+  }
+}
+
 const resolveConfig = {
   extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
   alias: {
@@ -44,7 +74,6 @@ const babelLoaderConfig = {
         require('@babel/plugin-proposal-class-properties'),
         require('babel-plugin-add-module-exports'),
         require('@babel/plugin-transform-runtime'),
-        require('@babel/plugin-syntax-dynamic-import'),
       ],
     },
   },
@@ -85,170 +114,184 @@ const imageminPlugin = new ImageminPlugin({
   },
 })
 
-const botonicDevConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  devServer: {
-    contentBase: [
-      path.join(__dirname, 'dist'),
-      path.join(__dirname, 'src', 'nlu', 'models'),
+function botonicDevConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    devServer: {
+      contentBase: [
+        path.join(__dirname, 'dist'),
+        path.join(__dirname, 'src', 'nlu', 'models'),
+      ],
+      watchContentBase: true,
+      historyApiFallback: true,
+      publicPath: '/',
+      hot: true,
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      new webpack.HotModuleReplacementPlugin(),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
+      }),
     ],
-    watchContentBase: true,
-    historyApiFallback: true,
-    publicPath: '/',
-    hot: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    new webpack.HotModuleReplacementPlugin(),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'dev',
-    }),
-  ],
+  }
 }
 
-const botonicWebchatConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      WEBCHAT_PUSHER_KEY: null,
-      BOTONIC_TARGET: 'webchat',
-    }),
-  ],
+function botonicWebchatConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        WEBCHAT_PUSHER_KEY: null,
+        BOTONIC_TARGET: 'webchat',
+      }),
+    ],
+  }
 }
 
-const botonicWebviewsConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    path: path.resolve(__dirname, 'dist/webviews'),
-    filename: 'webviews.js',
-    library: 'BotonicWebview',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [
-      babelLoaderConfig,
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              outputPath: '../assets',
+function botonicWebviewsConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      path: path.resolve(__dirname, 'dist/webviews'),
+      filename: 'webviews.js',
+      library: 'BotonicWebview',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [
+        babelLoaderConfig,
+        {
+          test: /\.(png|svg|jpg|gif)$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                outputPath: '../assets',
+              },
             },
-          },
-        ],
-      },
-      stylesLoaderConfig,
+          ],
+        },
+        stylesLoaderConfig,
+      ],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webview.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'webviews',
+      }),
     ],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webview.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'webviews',
-    }),
-  ],
+  }
 }
 
-const botonicServerConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  context: root,
-  mode: 'development',
-  target: 'node',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    filename: 'bot.js',
-    library: 'bot',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'node',
-    }),
-    new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-  ],
+function botonicServerConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    context: root,
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'node',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      filename: 'bot.js',
+      library: 'bot',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'node',
+      }),
+      new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
+    ],
+  }
 }
 
-module.exports = function (env) {
+module.exports = function (env, argv) {
   if (env.target === 'all') {
-    return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
-  } else if (env.target === 'dev') {
-    return [botonicDevConfig]
-  } else if (env.target === 'node') {
-    return [botonicServerConfig]
-  } else if (env.target === 'webviews') {
-    return [botonicWebviewsConfig]
-  } else if (env.target === 'webchat') {
-    return [botonicWebchatConfig]
+    return [
+      botonicServerConfig(argv.mode),
+      botonicWebviewsConfig(argv.mode),
+      botonicWebchatConfig(argv.mode),
+    ]
+  } else if (env.target === BOTONIC_TARGETS.DEV) {
+    return [botonicDevConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.NODE) {
+    return [botonicServerConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBVIEWS) {
+    return [botonicWebviewsConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBCHAT) {
+    return [botonicWebchatConfig(argv.mode)]
+  } else {
+    return null
   }
 }

--- a/packages/botonic-cli/templates/tutorial/package.json
+++ b/packages/botonic-cli/templates/tutorial/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "webpack --env.target=all --mode=production",
-    "start": "webpack-dev-server --env.target=dev",
+    "start": "webpack-dev-server --env.target=dev --mode=development",
     "test": "jest"
   },
   "jest": {

--- a/packages/botonic-cli/templates/tutorial/webpack.config.js
+++ b/packages/botonic-cli/templates/tutorial/webpack.config.js
@@ -18,6 +18,36 @@ const terserPlugin = new TerserPlugin({
   },
 })
 
+const MODE_DEV = 'development'
+const MODE_PROD = 'production'
+
+const BOTONIC_TARGETS = {
+  DEV: 'dev',
+  NODE: 'node',
+  WEBVIEWS: 'webviews',
+  WEBCHAT: 'webchat',
+}
+
+function sourceMap(mode) {
+  console.log('Webpack running on mode:', mode)
+  // changing it from inline-source-map to cheap-eval-source-map, build time improved from 48s to 40s
+  if (mode === MODE_PROD) {
+    // Typescript: "inline-source-map" does not map Typescript correctly but there's a patch I didn't test https://github.com/webpack/webpack/issues/7172#issuecomment-414115819
+    // from https://webpack.js.org/configuration/devtool/ inline-source-map is slow and not good for production
+    //return 'cheap-eval-source-map'; // fast builds, not for production, transformed code (lines only)
+    // slow, good for production. A full SourceMap is emitted as a separate file. but doesn't add a reference comment to the bundle. Useful if you only want SourceMaps to map error stack traces from error reports, but don't want to expose your SourceMap for the browser development tools.
+    return 'hidden-source-map'
+  } else if (mode === MODE_DEV) {
+    // 'eval-source-map' would be a good fit for staging (slow but generates original code)
+    // from documentation: quick build time, very quick rebuild, transformed code (lines only)
+    return 'cheap-eval-source-map' //callstacks show links to TS code
+  } else {
+    throw new Error(
+      'Invalid mode argument (' + mode + '). See package.json scripts'
+    )
+  }
+}
+
 const resolveConfig = {
   extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
   alias: {
@@ -84,170 +114,184 @@ const imageminPlugin = new ImageminPlugin({
   },
 })
 
-const botonicDevConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  devServer: {
-    contentBase: [
-      path.join(__dirname, 'dist'),
-      path.join(__dirname, 'src', 'nlu', 'models'),
+function botonicDevConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    devServer: {
+      contentBase: [
+        path.join(__dirname, 'dist'),
+        path.join(__dirname, 'src', 'nlu', 'models'),
+      ],
+      watchContentBase: true,
+      historyApiFallback: true,
+      publicPath: '/',
+      hot: true,
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      new webpack.HotModuleReplacementPlugin(),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
+      }),
     ],
-    watchContentBase: true,
-    historyApiFallback: true,
-    publicPath: '/',
-    hot: true,
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    new webpack.HotModuleReplacementPlugin(),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'dev',
-    }),
-  ],
+  }
 }
 
-const botonicWebchatConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'webchat.botonic.js',
-    library: 'Botonic',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-    publicPath: './',
-  },
-  resolve: resolveConfig,
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      WEBCHAT_PUSHER_KEY: null,
-      BOTONIC_TARGET: 'webchat',
-    }),
-  ],
+function botonicWebchatConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, stylesLoaderConfig],
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'webchat.botonic.js',
+      library: 'Botonic',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+      publicPath: './',
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webchat.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        WEBCHAT_PUSHER_KEY: null,
+        BOTONIC_TARGET: 'webchat',
+      }),
+    ],
+  }
 }
 
-const botonicWebviewsConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    path: path.resolve(__dirname, 'dist/webviews'),
-    filename: 'webviews.js',
-    library: 'BotonicWebview',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [
-      babelLoaderConfig,
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              outputPath: '../assets',
+function botonicWebviewsConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'web',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      path: path.resolve(__dirname, 'dist/webviews'),
+      filename: 'webviews.js',
+      library: 'BotonicWebview',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [
+        babelLoaderConfig,
+        {
+          test: /\.(png|svg|jpg|gif)$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                outputPath: '../assets',
+              },
             },
-          },
-        ],
-      },
-      stylesLoaderConfig,
+          ],
+        },
+        stylesLoaderConfig,
+      ],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.resolve(botonicPath, 'src', 'webview.template.html'),
+        filename: 'index.html',
+      }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'webviews',
+      }),
     ],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.resolve(botonicPath, 'src', 'webview.template.html'),
-      filename: 'index.html',
-    }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'webviews',
-    }),
-  ],
+  }
 }
 
-const botonicServerConfig = {
-  optimization: {
-    minimizer: [terserPlugin],
-  },
-  context: root,
-  mode: 'development',
-  target: 'node',
-  entry: path.resolve(botonicPath, 'src', 'entry.js'),
-  output: {
-    filename: 'bot.js',
-    library: 'bot',
-    libraryTarget: 'umd',
-    libraryExport: 'app',
-  },
-  module: {
-    rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
-  },
-  resolve: resolveConfig,
-  devtool: 'source-map',
-  plugins: [
-    new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
-    imageminPlugin,
-    new webpack.EnvironmentPlugin({
-      HUBTYPE_API_URL: null,
-      BOTONIC_TARGET: 'node',
-    }),
-    new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-  ],
+function botonicServerConfig(mode) {
+  return {
+    optimization: {
+      minimizer: [terserPlugin],
+    },
+    context: root,
+    mode: mode,
+    devtool: sourceMap(mode),
+    target: 'node',
+    entry: path.resolve(botonicPath, 'src', 'entry.js'),
+    output: {
+      filename: 'bot.js',
+      library: 'bot',
+      libraryTarget: 'umd',
+      libraryExport: 'app',
+    },
+    module: {
+      rules: [babelLoaderConfig, fileLoaderConfig, nullLoaderConfig],
+    },
+    resolve: resolveConfig,
+    plugins: [
+      new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: ['dist'] }),
+      imageminPlugin,
+      new webpack.EnvironmentPlugin({
+        HUBTYPE_API_URL: null,
+        BOTONIC_TARGET: 'node',
+      }),
+      new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
+    ],
+  }
 }
 
-module.exports = function (env) {
+module.exports = function (env, argv) {
   if (env.target === 'all') {
-    return [botonicServerConfig, botonicWebviewsConfig, botonicWebchatConfig]
-  } else if (env.target === 'dev') {
-    return [botonicDevConfig]
-  } else if (env.target === 'node') {
-    return [botonicServerConfig]
-  } else if (env.target === 'webviews') {
-    return [botonicWebviewsConfig]
-  } else if (env.target === 'webchat') {
-    return [botonicWebchatConfig]
+    return [
+      botonicServerConfig(argv.mode),
+      botonicWebviewsConfig(argv.mode),
+      botonicWebchatConfig(argv.mode),
+    ]
+  } else if (env.target === BOTONIC_TARGETS.DEV) {
+    return [botonicDevConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.NODE) {
+    return [botonicServerConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBVIEWS) {
+    return [botonicWebviewsConfig(argv.mode)]
+  } else if (env.target === BOTONIC_TARGETS.WEBCHAT) {
+    return [botonicWebchatConfig(argv.mode)]
+  } else {
+    return null
   }
 }

--- a/packages/botonic-plugin-inbenta/package-lock.json
+++ b/packages/botonic-plugin-inbenta/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-inbenta",
-  "version": "0.13.0-rc.0",
+  "version": "0.13.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-inbenta/package.json
+++ b/packages/botonic-plugin-inbenta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-inbenta",
-  "version": "0.13.0-rc.0",
+  "version": "0.13.0-rc.1",
   "main": "src/index.js",
   "scripts": {
     "prepare": "node ../../preinstall.js",

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -34,6 +34,7 @@ export const WEBCHAT = {
     LOGO: BotonicLogo,
     PLACEHOLDER: 'Ask me something...',
     FONT_FAMILY: "'Noto Sans JP', sans-serif",
+    BORDER_RADIUS_TOP_CORNERS: '6px 6px 0px 0px',
   },
   CUSTOM_PROPERTIES: {
     webviewStyle: 'webview.style',

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -226,11 +226,10 @@ export class WebchatApp {
   async resolveWebchatVisibility(optionsAtRuntime) {
     let { appId, visibility } = optionsAtRuntime
     visibility = visibility || this.visibility
-    if (visibility === undefined) {
-      if (await this.isWebchatVisible({ appId })) return true
-    }
-    if (visibility === true) return true
+    if (visibility === undefined || visibility === true) return true
     if (typeof visibility === 'function' && visibility()) return true
+    if (visibility === 'dynamic' && (await this.isWebchatVisible({ appId })))
+      return true
     return false
   }
 

--- a/packages/botonic-react/src/webchat/components/styled-scrollbar.scss
+++ b/packages/botonic-react/src/webchat/components/styled-scrollbar.scss
@@ -1,8 +1,10 @@
-#botonic-scrollable-content {
-  .simplebar-mask .simplebar-offset .simplebar-content-wrapper {
-    overscroll-behavior: contain; // https://css-tricks.com/almanac/properties/o/overscroll-behavior/
-    -webkit-overflow-scrolling: touch;
-  }
+#botonic-scrollable-content
+  > div.simplebar-wrapper
+  > div.simplebar-mask
+  > div
+  > div {
+  overscroll-behavior: contain; // https://css-tricks.com/almanac/properties/o/overscroll-behavior/
+  -webkit-overflow-scrolling: touch;
   ::-webkit-scrollbar {
     // https://github.com/Grsmto/simplebar/issues/445#issuecomment-586902814
     display: none;

--- a/packages/botonic-react/src/webchat/header.jsx
+++ b/packages/botonic-react/src/webchat/header.jsx
@@ -13,7 +13,7 @@ const Header = styled(Flex)`
     ${props => props.color} 100%
   );
   height: 55px;
-  border-radius: 6px 6px 0px 0px;
+  border-radius: ${WEBCHAT.DEFAULTS.BORDER_RADIUS_TOP_CORNERS};
   z-index: 2;
 `
 

--- a/packages/botonic-react/src/webchat/webview.jsx
+++ b/packages/botonic-react/src/webchat/webview.jsx
@@ -3,7 +3,7 @@ import Frame from 'react-frame-component'
 import { RequestContext, WebchatContext } from '../contexts'
 
 import styled from 'styled-components'
-import { COLORS } from '../constants'
+import { WEBCHAT, COLORS } from '../constants'
 
 const StyledWebview = styled.div`
   position: absolute;
@@ -11,9 +11,10 @@ const StyledWebview = styled.div`
   flex-direction: column;
   bottom: 0;
   width: 100%;
-  height: 80%;
+  height: 100%;
   background-color: ${COLORS.SOLID_WHITE};
   z-index: 2;
+  border-radius: ${WEBCHAT.DEFAULTS.BORDER_RADIUS_TOP_CORNERS};
 `
 
 const StyledWebviewHeader = styled.div`
@@ -21,6 +22,7 @@ const StyledWebviewHeader = styled.div`
   background-color: ${COLORS.WILD_SAND_WHITE};
   border-top: 1px solid ${COLORS.SOLID_BLACK_ALPHA_0_2};
   border-bottom: 1px solid ${COLORS.SOLID_BLACK_ALPHA_0_2};
+  border-radius: ${WEBCHAT.DEFAULTS.BORDER_RADIUS_TOP_CORNERS};
 `
 const StyledCloseHeader = styled.div`
   display: inline-block;


### PR DESCRIPTION
## Description
Added a session token to Inbenta search queries to track user actions.

## Context
Inbenta noticed us that we were not using session tracking and told us that it's preferred to do so to track user actions by the final client.
Adding this features, the final client will be able to track all the questions and answers made by the user through the bot.

## Approach taken / Explain the design
We obtain the session token on the first search query done by the user and it's saved in the bot's session (`inbentaSessionToken` parameter) for future uses.
The session token is been added to the queries headers in order to track them correctly.

## To documentate / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
