### PR TITLE
feat(plugin-inbenta): add session token and source to Inbenta queries

### DIFF
--- a/packages/botonic-plugin-inbenta/package-lock.json
+++ b/packages/botonic-plugin-inbenta/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-inbenta",
-  "version": "0.13.0-rc.0",
+  "version": "0.13.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-inbenta/package.json
+++ b/packages/botonic-plugin-inbenta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-inbenta",
-  "version": "0.13.0-rc.0",
+  "version": "0.13.0-rc.1",
   "main": "src/index.js",
   "scripts": {
     "prepare": "node ../../preinstall.js",


### PR DESCRIPTION
## Description
Added a session token to Inbenta search queries to track user actions.

Added a source info (webchat, whatsapp...) to Inbenta search queries to know the origin source of the query.

## Context
Inbenta noticed us that we were not using session tracking and told us that it's preferred to do so to track user actions by the final client.
Adding this features, the final client will be able to track all the questions and answers made by the user through the bot.

They wanted to to add the source information in order to know from which integration each query comes from.

## Approach taken / Explain the design
We obtain the session token on the first search query done by the user and it's saved in the bot's session (`inbentaSessionToken` parameter) for future uses.
The session token is been added to the queries headers in order to track them correctly.

The source information is added as a parameter in the constructor.

## To documentate / Usage example

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
