### PR TITLE
feat(react): handle missed enduser messages when connectivty is regained

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -5171,6 +5171,11 @@
       "dev": true,
       "optional": true
     },
+    "use-async-effect": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/use-async-effect/-/use-async-effect-2.2.2.tgz",
+      "integrity": "sha512-zFas5h1jm4FNCk+txUzfMUAQhIFJGdrhAmg2lSA+Q6BZKYFen/yZlHEx5RGWSUV1USjLFZ+yg989fFyzJHW3Zw=="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -43,6 +43,7 @@
     "styled-components": "^4.4.1",
     "ua-parser-js": "^0.7.20",
     "unescape": "^1.0.1",
+    "use-async-effect": "^2.2.2",
     "uuid": "^8.1.0"
   },
   "devDependencies": {

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -85,8 +85,8 @@ export const Message = props => {
     imageStyle,
     ...otherProps
   } = props
-  const isFromUser = () => from === 'user'
-  const isFromBot = () => from === 'bot'
+  const isFromUser = from === 'user'
+  const isFromBot = from === 'bot'
   const markdown = props.markdown
   const {
     webchatState,
@@ -105,7 +105,7 @@ export const Message = props => {
   let textChildren = React.Children.toArray(children).filter(
     e => ![Button, Reply].includes(e.type)
   )
-  if (isFromUser())
+  if (isFromUser)
     textChildren = textChildren.map(e =>
       typeof e === 'string' ? renderLinks(e) : e
     )
@@ -121,7 +121,7 @@ export const Message = props => {
     if (isDev()) ack = 1
     else {
       if (props.ack !== undefined) ack = props.ack
-      else ack = isFromUser() ? 0 : 1
+      else ack = isFromUser ? 0 : 1
     }
     return ack
   }
@@ -178,7 +178,7 @@ export const Message = props => {
 
   const getBgColor = () => {
     if (!blob) return COLORS.TRANSPARENT
-    if (isFromUser()) {
+    if (isFromUser) {
       return getThemeProperty('message.user.style.background', brandColor)
     }
     return getThemeProperty(
@@ -188,7 +188,7 @@ export const Message = props => {
   }
 
   const getMessageStyle = () =>
-    isFromBot()
+    isFromBot
       ? getThemeProperty('message.bot.style')
       : getThemeProperty('message.user.style')
 
@@ -213,7 +213,7 @@ export const Message = props => {
         ...getThemeProperty(`message.${from}.blobTickStyle`),
       }
       const blobTickStyle = {}
-      if (isFromUser()) {
+      if (isFromUser) {
         containerStyle.right = 0
         containerStyle.marginRight = -pointerSize
         blobTickStyle.borderRight = 0
@@ -238,7 +238,7 @@ export const Message = props => {
     const animationsEnabled = getThemeProperty('animations.enable', true)
 
     const resolveCustomTypeName = () =>
-      isFromBot() && type === INPUT.CUSTOM ? ` ${m.customTypeName}` : ''
+      isFromBot && type === INPUT.CUSTOM ? ` ${m.customTypeName}` : ''
 
     const className = `${type}-${from}${resolveCustomTypeName()}`
     return (
@@ -248,12 +248,12 @@ export const Message = props => {
       >
         <>
           <MessageContainer
-            isfromuser={isFromUser()}
+            isfromuser={isFromUser}
             style={{
               ...getThemeProperty('message.style'),
             }}
           >
-            {isFromBot() && BotMessageImage && (
+            {isFromBot && BotMessageImage && (
               <BotMessageImageContainer
                 style={{
                   ...getThemeProperty('message.bot.imageStyle'),
@@ -269,7 +269,7 @@ export const Message = props => {
             <Blob
               className={className}
               bgcolor={getBgColor()}
-              color={isFromUser() ? COLORS.SOLID_WHITE : COLORS.SOLID_BLACK}
+              color={isFromUser ? COLORS.SOLID_WHITE : COLORS.SOLID_BLACK}
               blobWidth={getThemeProperty('message.bot.blobWidth')}
               blob={blob}
               style={{
@@ -287,7 +287,7 @@ export const Message = props => {
                   }}
                   markdownstyle={getMarkdownStyle(
                     getThemeProperty,
-                    isFromUser() ? COLORS.SEASHELL_WHITE : brandColor
+                    isFromUser ? COLORS.SEASHELL_WHITE : brandColor
                   )}
                 />
               ) : (
@@ -302,7 +302,7 @@ export const Message = props => {
             <MessageTimestamp
               timestamp={m.timestamp}
               style={timestampStyle}
-              isfromuser={isFromUser()}
+              isfromuser={isFromUser}
             />
           )}
         </>

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -116,13 +116,17 @@ export const Message = props => {
     timestampStyle,
   } = resolveMessageTimestamps(getThemeProperty)
 
-  let ack = 0
-  if (isDev()) {
-    ack = 1
-  } else {
-    if (props.ack !== undefined) ack = props.ack
-    else ack = isFromUser() ? 0 : 1
+  const getEnvAck = () => {
+    let ack = 0
+    if (isDev()) ack = 1
+    else {
+      if (props.ack !== undefined) ack = props.ack
+      else ack = isFromUser() ? 0 : 1
+    }
+    return ack
   }
+
+  const ack = getEnvAck()
 
   if (isBrowser()) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -271,7 +275,7 @@ export const Message = props => {
               style={{
                 ...getMessageStyle(),
                 ...style,
-                ...{ opacity: ack === 0 ? 0.5 : 1 },
+                ...{ opacity: ack === 0 ? 0.6 : 1 },
               }}
               {...otherProps}
             >

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -11,6 +11,7 @@ export const COLORS = {
   SOLID_WHITE_ALPHA_0_8: 'rgba(255, 255, 255, 0.8)',
   SOLID_WHITE_ALPHA_0_2: 'rgba(255, 255, 255, 0.2)',
   CONCRETE_WHITE: 'rgba(243, 243, 243, 1)',
+  LIGHT_GRAY: 'rgba(209, 209, 209, 1)',
   MID_GRAY: 'rgba(105, 105, 115, 1)',
   FRINGY_FLOWER_GREEN: 'rgba(198, 231, 192, 1)',
   TASMAN_GRAY: 'rgba(209, 216, 207, 1)',

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -25,6 +25,7 @@ export const COLORS = {
   BLEACHED_CEDAR_PURPLE: 'rgba(46, 32, 59, 1)',
   WILD_SAND_WHITE: 'rgba(244, 244, 244, 1)',
   CURIOUS_BLUE: 'rgba(38, 139, 210, 1)',
+  ERROR_RED: 'rgba(255, 43, 94)',
 }
 
 export const WEBCHAT = {

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -59,6 +59,10 @@ export class WebchatApp {
     return this.hubtypeService.postMessage(user, input)
   }
 
+  async resendUnsentInputs() {
+    return this.hubtypeService.resendUnsentInputs()
+  }
+
   onStateChange({ user, messagesJSON }) {
     if (!this.hubtypeService && user) {
       const lastMessage = messagesJSON[messagesJSON.length - 1]
@@ -68,6 +72,8 @@ export class WebchatApp {
         lastMessageId: lastMessage && lastMessage.id,
         lastMessageUpdateDate: this.getLastMessageUpdate(),
         onEvent: event => this.onServiceEvent(event),
+        unsentInputs: () =>
+          this.webchatRef.current.getMessages().filter(msg => msg.ack === 0),
       })
     }
   }
@@ -209,6 +215,9 @@ export class WebchatApp {
         onClose={(...args) => this.onCloseWebchat(...args)}
         onUserInput={(...args) => this.onUserInput(...args)}
         onStateChange={webchatState => this.onStateChange(webchatState)}
+        resendUnsentInputs={() =>
+          this.hubtypeService && this.hubtypeService.resendUnsentInputs()
+        }
       />
     )
   }

--- a/packages/botonic-react/src/webchat/hooks.js
+++ b/packages/botonic-react/src/webchat/hooks.js
@@ -238,3 +238,19 @@ export function useComponentVisible(initialIsVisible, onClickOutside) {
   })
   return { ref, isComponentVisible, setIsComponentVisible }
 }
+
+export function useNetwork() {
+  const [isOnline, setNetwork] = useState(window.navigator.onLine)
+  const updateNetwork = () => {
+    setNetwork(window.navigator.onLine)
+  }
+  useEffect(() => {
+    window.addEventListener('offline', updateNetwork)
+    window.addEventListener('online', updateNetwork)
+    return () => {
+      window.removeEventListener('offline', updateNetwork)
+      window.removeEventListener('online', updateNetwork)
+    }
+  })
+  return isOnline
+}

--- a/packages/botonic-react/src/webchat/messages-reducer.js
+++ b/packages/botonic-react/src/webchat/messages-reducer.js
@@ -38,7 +38,24 @@ export const messagesReducer = (state, action) => {
 
 function updateMessageReducer(state, action) {
   const msgIndex = state.messagesJSON.map(m => m.id).indexOf(action.payload.id)
-  if (msgIndex > -1)
+  if (msgIndex > -1) {
+    const msgComponent = state.messagesComponents[msgIndex]
+    let updatedMessageComponents = {}
+    if (msgComponent) {
+      const updatedMsgComponent = {
+        ...msgComponent,
+        ...{
+          props: { ...msgComponent.props, ack: action.payload.ack },
+        },
+      }
+      updatedMessageComponents = {
+        messagesComponents: [
+          ...state.messagesComponents.slice(0, msgIndex),
+          { ...updatedMsgComponent },
+          ...state.messagesComponents.slice(msgIndex + 1),
+        ],
+      }
+    }
     return {
       ...state,
       messagesJSON: [
@@ -46,7 +63,10 @@ function updateMessageReducer(state, action) {
         { ...action.payload },
         ...state.messagesJSON.slice(msgIndex + 1),
       ],
+      ...updatedMessageComponents,
     }
+  }
+
   return state
 }
 

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -118,7 +118,7 @@ const ErrorMessageContainer = styled.div`
   position: relative;
   display: flex;
   z-index: 1;
-  margin-top: 5px;
+  margin-top: 10px;
   justify-content: center;
   width: 100%;
 `
@@ -126,15 +126,16 @@ const ErrorMessageContainer = styled.div`
 const ErrorMessage = styled.div`
   position: absolute;
   top: 0;
-  padding: 5px;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 4px 11px;
   display: flex;
-  background-color: ${COLORS.LIGHT_GRAY};
-  color: ${COLORS.SOLID_BLACK};
+  background-color: ${COLORS.ERROR_RED};
+  color: ${COLORS.CONCRETE_WHITE};
   border-radius: 5px;
-  border: 1px solid black;
   align-items: center;
   justify-content: center;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: ${WEBCHAT.DEFAULTS.FONT_FAMILY};
 `
 
 const DarkBackgroundMenu = styled.div`
@@ -320,7 +321,7 @@ export const Webchat = forwardRef((props, ref) => {
   useAsyncEffect(async () => {
     if (!isOnline)
       setError({
-        message: 'Connection issues.',
+        message: 'connection issues',
       })
     else {
       await resendUnsentMessages()

--- a/packages/botonic-react/tests/webchat/usewebchat.test.js
+++ b/packages/botonic-react/tests/webchat/usewebchat.test.js
@@ -21,10 +21,15 @@ describe('TEST: useWebchat ', () => {
     extra_data: {},
   }
 
+  const addMessageAndMessageComponent = (useWebchatHook, message) => {
+    useWebchatHook.current.addMessage(message)
+    useWebchatHook.current.addMessageComponent(message)
+  }
+
   it('addMessage: add testMessage to webchatState.messagesJSON', () => {
     const { result } = renderUseWebchatHook()
     act(() => {
-      result.current.addMessage(testMessage)
+      addMessageAndMessageComponent(result, testMessage)
     })
     expect(result.current.webchatState.messagesJSON).toStrictEqual([
       testMessage,
@@ -34,21 +39,11 @@ describe('TEST: useWebchat ', () => {
   it('updateMessage: updates a message with the given properties', () => {
     const { result } = renderUseWebchatHook()
     act(() => {
-      result.current.addMessage(testMessage)
+      addMessageAndMessageComponent(result, testMessage)
       result.current.updateMessage({ ...testMessage, display: true })
     })
     expect(result.current.webchatState.messagesJSON).toStrictEqual([
       { ...testMessage, display: true },
-    ])
-  })
-
-  it('addMessageComponent: add testMessage to webchatState.messagesComponents', () => {
-    const { result } = renderUseWebchatHook()
-    act(() => {
-      result.current.addMessageComponent(testMessage)
-    })
-    expect(result.current.webchatState.messagesComponents).toStrictEqual([
-      testMessage,
     ])
   })
 


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
* Added functionality to support missed ~messages~ user inputs from enduser.
* Enduser messages are displayed with less opacity until they are correctly delivered to the server.




## Context
When enduser ~messages~ inputs were not delivered correctly, we weren't trying to resend them from `Botonic`-> `Hubtype`. The purpose of this PR is to have a very first approach of this system that sets the basis for keep improving these functionalities.

`resendUnsentInputs` will be triggered:
* after hubtype service has been initialized
* after webchat has been opened
* if an online connection has been detected with `useNetwork` hook.

## Approach taken / Explain the design
* Make use of a `useNetwork` [hook](https://medium.com/the-non-traditional-developer/checking-the-network-connection-with-a-react-hook-ec3d8e4de4ec) to detect network connectivity. By default, the enduser messages (prod) will be initialized with `ack` set to `0` (not delivered), once we receive the response from the server, we update these corresponding messages.
* `resendUnsentUserInputs` will be called every time we regain connectivity or every time the webchat is opened, trying to resend all the `messagesJSON` with `ack:0`, updating them with `ack: 1`

## To documentate / Usage example
**Message to be delivered**
<img width="331" alt="Screenshot 2020-06-25 at 13 30 14" src="https://user-images.githubusercontent.com/35448568/85712035-30771580-b6e8-11ea-8008-62f46d4b8f67.png">

**Message delivered**
<img width="317" alt="Screenshot 2020-06-25 at 13 30 31" src="https://user-images.githubusercontent.com/35448568/85712093-3ff65e80-b6e8-11ea-8da0-10df0f514d1f.png">

**Connectivity issues** (messages wil be dequeued and processed in the same order once we regain connection)
<img width="353" alt="Screenshot 2020-06-25 at 15 38 44" src="https://user-images.githubusercontent.com/35448568/85730518-ff9fdc00-b6f9-11ea-9236-73fd2dec7385.png">



## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
