### PR TITLE
fix(react): refactor and remove moment dep

### DIFF
--- a/packages/botonic-cli/templates/blank/package.json
+++ b/packages/botonic-cli/templates/blank/package.json
@@ -39,7 +39,6 @@
     "imagemin-svgo": "^7.0.0",
     "imagemin-webpack": "^5.1.0",
     "jest": "^25.2.0",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.13.0",
     "null-loader": "^3.0.0",
     "react-hot-loader": "^4.12.18",

--- a/packages/botonic-cli/templates/blank/webpack.config.js
+++ b/packages/botonic-cli/templates/blank/webpack.config.js
@@ -4,10 +4,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
-// Optimizing locales bundle:
-// - npm: https://www.npmjs.com/package/moment-locales-webpack-plugin
-// - webpack config: https://medium.com/@Memija/less-is-more-with-moment-and-moment-timezone-d7afbab34df3
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
 
 const webpack = require('webpack')
 
@@ -159,7 +155,6 @@ function botonicDevConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -196,7 +191,6 @@ function botonicWebchatConfig(mode) {
         WEBCHAT_PUSHER_KEY: null,
         BOTONIC_TARGET: 'webchat',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -245,7 +239,6 @@ function botonicWebviewsConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: 'webviews',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -278,7 +271,6 @@ function botonicServerConfig(mode) {
         BOTONIC_TARGET: 'node',
       }),
       new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-      new MomentLocalesPlugin(),
     ],
   }
 }

--- a/packages/botonic-cli/templates/childs/package.json
+++ b/packages/botonic-cli/templates/childs/package.json
@@ -39,7 +39,6 @@
     "imagemin-svgo": "^7.0.0",
     "imagemin-webpack": "^5.1.0",
     "jest": "^25.2.0",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.13.0",
     "null-loader": "^3.0.0",
     "react-hot-loader": "^4.12.18",

--- a/packages/botonic-cli/templates/childs/webpack.config.js
+++ b/packages/botonic-cli/templates/childs/webpack.config.js
@@ -4,10 +4,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
-// Optimizing locales bundle:
-// - npm: https://www.npmjs.com/package/moment-locales-webpack-plugin
-// - webpack config: https://medium.com/@Memija/less-is-more-with-moment-and-moment-timezone-d7afbab34df3
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
 
 const webpack = require('webpack')
 
@@ -159,7 +155,6 @@ function botonicDevConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -196,7 +191,6 @@ function botonicWebchatConfig(mode) {
         WEBCHAT_PUSHER_KEY: null,
         BOTONIC_TARGET: 'webchat',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -245,7 +239,6 @@ function botonicWebviewsConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: 'webviews',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -278,7 +271,6 @@ function botonicServerConfig(mode) {
         BOTONIC_TARGET: 'node',
       }),
       new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-      new MomentLocalesPlugin(),
     ],
   }
 }

--- a/packages/botonic-cli/templates/custom-webchat/package.json
+++ b/packages/botonic-cli/templates/custom-webchat/package.json
@@ -40,7 +40,6 @@
     "imagemin-svgo": "^7.0.0",
     "imagemin-webpack": "^5.1.0",
     "jest": "^25.2.0",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.13.0",
     "null-loader": "^3.0.0",
     "react-hot-loader": "^4.12.18",

--- a/packages/botonic-cli/templates/custom-webchat/webpack.config.js
+++ b/packages/botonic-cli/templates/custom-webchat/webpack.config.js
@@ -4,10 +4,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
-// Optimizing locales bundle:
-// - npm: https://www.npmjs.com/package/moment-locales-webpack-plugin
-// - webpack config: https://medium.com/@Memija/less-is-more-with-moment-and-moment-timezone-d7afbab34df3
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
 
 const webpack = require('webpack')
 
@@ -159,7 +155,6 @@ function botonicDevConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -196,7 +191,6 @@ function botonicWebchatConfig(mode) {
         WEBCHAT_PUSHER_KEY: null,
         BOTONIC_TARGET: 'webchat',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -245,7 +239,6 @@ function botonicWebviewsConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: 'webviews',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -278,7 +271,6 @@ function botonicServerConfig(mode) {
         BOTONIC_TARGET: 'node',
       }),
       new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-      new MomentLocalesPlugin(),
     ],
   }
 }

--- a/packages/botonic-cli/templates/dynamic-carousel/package.json
+++ b/packages/botonic-cli/templates/dynamic-carousel/package.json
@@ -40,7 +40,6 @@
     "imagemin-svgo": "^7.0.0",
     "imagemin-webpack": "^5.1.0",
     "jest": "^25.2.0",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.13.0",
     "null-loader": "^3.0.0",
     "react-hot-loader": "^4.12.18",

--- a/packages/botonic-cli/templates/dynamic-carousel/webpack.config.js
+++ b/packages/botonic-cli/templates/dynamic-carousel/webpack.config.js
@@ -4,10 +4,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
-// Optimizing locales bundle:
-// - npm: https://www.npmjs.com/package/moment-locales-webpack-plugin
-// - webpack config: https://medium.com/@Memija/less-is-more-with-moment-and-moment-timezone-d7afbab34df3
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
 
 const webpack = require('webpack')
 
@@ -159,7 +155,6 @@ function botonicDevConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -196,7 +191,6 @@ function botonicWebchatConfig(mode) {
         WEBCHAT_PUSHER_KEY: null,
         BOTONIC_TARGET: 'webchat',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -245,7 +239,6 @@ function botonicWebviewsConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: 'webviews',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -278,7 +271,6 @@ function botonicServerConfig(mode) {
         BOTONIC_TARGET: 'node',
       }),
       new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-      new MomentLocalesPlugin(),
     ],
   }
 }

--- a/packages/botonic-cli/templates/handoff/package.json
+++ b/packages/botonic-cli/templates/handoff/package.json
@@ -39,7 +39,6 @@
     "imagemin-svgo": "^7.0.0",
     "imagemin-webpack": "^5.1.0",
     "jest": "^25.2.0",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.13.0",
     "null-loader": "^3.0.0",
     "react-hot-loader": "^4.12.18",

--- a/packages/botonic-cli/templates/handoff/webpack.config.js
+++ b/packages/botonic-cli/templates/handoff/webpack.config.js
@@ -4,10 +4,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
-// Optimizing locales bundle:
-// - npm: https://www.npmjs.com/package/moment-locales-webpack-plugin
-// - webpack config: https://medium.com/@Memija/less-is-more-with-moment-and-moment-timezone-d7afbab34df3
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
 
 const webpack = require('webpack')
 
@@ -159,7 +155,6 @@ function botonicDevConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -196,7 +191,6 @@ function botonicWebchatConfig(mode) {
         WEBCHAT_PUSHER_KEY: null,
         BOTONIC_TARGET: 'webchat',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -245,7 +239,6 @@ function botonicWebviewsConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: 'webviews',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -278,7 +271,6 @@ function botonicServerConfig(mode) {
         BOTONIC_TARGET: 'node',
       }),
       new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-      new MomentLocalesPlugin(),
     ],
   }
 }

--- a/packages/botonic-cli/templates/intent/package.json
+++ b/packages/botonic-cli/templates/intent/package.json
@@ -40,7 +40,6 @@
     "imagemin-svgo": "^7.0.0",
     "imagemin-webpack": "^5.1.0",
     "jest": "^25.2.0",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.13.0",
     "null-loader": "^3.0.0",
     "react-hot-loader": "^4.12.18",

--- a/packages/botonic-cli/templates/intent/webpack.config.js
+++ b/packages/botonic-cli/templates/intent/webpack.config.js
@@ -4,10 +4,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
-// Optimizing locales bundle:
-// - npm: https://www.npmjs.com/package/moment-locales-webpack-plugin
-// - webpack config: https://medium.com/@Memija/less-is-more-with-moment-and-moment-timezone-d7afbab34df3
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
 
 const webpack = require('webpack')
 
@@ -159,7 +155,6 @@ function botonicDevConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -196,7 +191,6 @@ function botonicWebchatConfig(mode) {
         WEBCHAT_PUSHER_KEY: null,
         BOTONIC_TARGET: 'webchat',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -245,7 +239,6 @@ function botonicWebviewsConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: 'webviews',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -278,7 +271,6 @@ function botonicServerConfig(mode) {
         BOTONIC_TARGET: 'node',
       }),
       new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-      new MomentLocalesPlugin(),
     ],
   }
 }

--- a/packages/botonic-cli/templates/nlu/package.json
+++ b/packages/botonic-cli/templates/nlu/package.json
@@ -41,7 +41,6 @@
     "imagemin-svgo": "^7.0.0",
     "imagemin-webpack": "^5.1.0",
     "jest": "^25.2.0",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.13.0",
     "null-loader": "^3.0.0",
     "react-hot-loader": "^4.12.18",

--- a/packages/botonic-cli/templates/nlu/webpack.config.js
+++ b/packages/botonic-cli/templates/nlu/webpack.config.js
@@ -4,10 +4,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
-// Optimizing locales bundle:
-// - npm: https://www.npmjs.com/package/moment-locales-webpack-plugin
-// - webpack config: https://medium.com/@Memija/less-is-more-with-moment-and-moment-timezone-d7afbab34df3
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
 
 const webpack = require('webpack')
 
@@ -159,7 +155,6 @@ function botonicDevConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -196,7 +191,6 @@ function botonicWebchatConfig(mode) {
         WEBCHAT_PUSHER_KEY: null,
         BOTONIC_TARGET: 'webchat',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -245,7 +239,6 @@ function botonicWebviewsConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: 'webviews',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -278,7 +271,6 @@ function botonicServerConfig(mode) {
         BOTONIC_TARGET: 'node',
       }),
       new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-      new MomentLocalesPlugin(),
     ],
   }
 }

--- a/packages/botonic-cli/templates/tutorial/package.json
+++ b/packages/botonic-cli/templates/tutorial/package.json
@@ -39,7 +39,6 @@
     "imagemin-svgo": "^7.0.0",
     "imagemin-webpack": "^5.1.0",
     "jest": "^25.2.0",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.13.0",
     "null-loader": "^3.0.0",
     "react-hot-loader": "^4.12.18",

--- a/packages/botonic-cli/templates/tutorial/webpack.config.js
+++ b/packages/botonic-cli/templates/tutorial/webpack.config.js
@@ -4,10 +4,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
-// Optimizing locales bundle:
-// - npm: https://www.npmjs.com/package/moment-locales-webpack-plugin
-// - webpack config: https://medium.com/@Memija/less-is-more-with-moment-and-moment-timezone-d7afbab34df3
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
 
 const webpack = require('webpack')
 
@@ -159,7 +155,6 @@ function botonicDevConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: BOTONIC_TARGETS.DEV,
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -196,7 +191,6 @@ function botonicWebchatConfig(mode) {
         WEBCHAT_PUSHER_KEY: null,
         BOTONIC_TARGET: 'webchat',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -245,7 +239,6 @@ function botonicWebviewsConfig(mode) {
         HUBTYPE_API_URL: null,
         BOTONIC_TARGET: 'webviews',
       }),
-      new MomentLocalesPlugin(),
     ],
   }
 }
@@ -278,7 +271,6 @@ function botonicServerConfig(mode) {
         BOTONIC_TARGET: 'node',
       }),
       new CopyPlugin([{ from: 'nlu/models/', to: 'assets/models/' }]),
-      new MomentLocalesPlugin(),
     ],
   }
 }

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -30,7 +30,6 @@
     "framer-motion": "^1.8.4",
     "lodash.merge": "^4.6.2",
     "markdown-it": "^11.0.0",
-    "moment": "^2.24.0",
     "react": "^16.13.1",
     "react-children-utilities": "^2.1.0",
     "react-dom": "^16.13.1",

--- a/packages/botonic-react/src/components/timestamps.jsx
+++ b/packages/botonic-react/src/components/timestamps.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import styled from 'styled-components'
+import { COLORS } from '../constants'
+
+export const resolveMessageTimestamps = getThemeFn => {
+  const timestampsFormat = getThemeFn('message.timestamps.format')
+  const timestampStyle = getThemeFn('message.timestamps.style')
+  const timestampsEnabled = getThemeFn(
+    'message.timestamps.enable',
+    Boolean(timestampStyle) || Boolean(timestampsFormat) || false
+  )
+  const defaultTimestampFormat = {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+  }
+  const getFormattedTimestamp =
+    (timestampsFormat && timestampsFormat()) ||
+    new Date().toLocaleString(undefined, defaultTimestampFormat)
+  return { timestampsEnabled, getFormattedTimestamp, timestampStyle }
+}
+
+const TimestampContainer = styled.div`
+  display: flex;
+  position: relative;
+  align-items: flex-start;
+`
+
+const TimestampText = styled.div`
+  @import url('https://fonts.googleapis.com/css?family=Lato');
+  font-family: Lato;
+  font-size: 10px;
+  color: ${COLORS.SOLID_BLACK};
+  width: 100%;
+  text-align: ${props => (props.isfromuser ? 'right' : 'left')};
+  padding: ${props => (props.isfromuser ? '0px 15px' : '0px 50px')};
+  margin-bottom: 5px;
+`
+
+export const MessageTimestamp = ({ timestamp, style, isfromuser }) => {
+  return (
+    <TimestampContainer>
+      <TimestampText
+        isfromuser={isfromuser}
+        style={{
+          ...style,
+        }}
+      >
+        {timestamp}
+      </TimestampText>
+    </TimestampContainer>
+  )
+}

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -62,7 +62,7 @@ export const WEBCHAT = {
     userMessageBorderColor: 'message.user.style.borderColor',
     customMessageTypes: 'message.customTypes',
     messageStyle: 'message.style',
-    messageTimestampsLocale: 'message.timestamps.locale',
+    enableMessageTimestamps: 'message.timestamps.enable',
     messageTimestampsFormat: 'message.timestamps.format',
     messageTimestampsStyle: 'message.timestamps.style',
     introImage: 'intro.image',


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

**Note**
In render section (return) the only relevant changes are: https://github.com/hubtype/botonic/pull/841/files#diff-a05365ee2d7479e601dd64cc443ef010R276-R282. The rest of changes within this return are due to wrapping it all inside a fragment `<></>`.

## Description
* Removed `moment` dependency. Managed default `webchat.botonic.js` size by 170KB.
* Refactored timestamps.
* Modify and adapt api for defining timestamps.

## Context
A needed action in order to keep reducing webchat bundle sizes.

## Approach taken / Explain the design
<img width="341" alt="Screenshot 2020-06-29 at 12 43 02" src="https://user-images.githubusercontent.com/35448568/85996795-f91aa880-ba08-11ea-8481-afa9c24636b2.png">

## To documentate / Usage example
Timestamps are disabled by default.

You can enable them easily by:
* Setting `theme.message.timestamps.enable` to `true`. The format displayed by default for all locales will look like: `29 Jun, 12:40:07`. (formatted with [toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString))
```
theme: {
    message: {
      timestamps: {
        enable: true,
      },
    },
  },
```
* Defining whether `style`, `format` or both properties:
```
theme: {
    message: {
      timestamps: {
        format: () => {
          // A function returning an string formatted date
          return new Date().toLocaleString();
        },
        style: {
          color: "blue",
        },
      },
    },
  },
```
## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [X] doesn't need tests because... Removed dep and code reorganization
