### PR TITLE
fix(react): useComponentVisible with CustomPersistentMenu

### DIFF
--- a/packages/botonic-react/src/webchat/components/persistent-menu.jsx
+++ b/packages/botonic-react/src/webchat/components/persistent-menu.jsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
 import { Button } from '../../components/button'
 import LogoMenu from '../../assets/menuButton.svg'
 import { Icon } from './common'
 import { useComponentVisible } from '../hooks'
+import { WebchatContext } from '../../contexts'
 
 const ButtonsContainer = styled.div`
   position: absolute;
@@ -15,6 +16,11 @@ const ButtonsContainer = styled.div`
 
 export const OpenedPersistentMenu = ({ onClick, options, borderRadius }) => {
   const { ref, isComponentVisible } = useComponentVisible(true, onClick)
+  const { getThemeProperty } = useContext(WebchatContext)
+  const CustomPersistentMenu = getThemeProperty(
+    'userInput.menu.custom',
+    undefined
+  )
   let closeLabel = 'Cancel'
   try {
     closeLabel = options.filter(opt => opt.closeLabel !== undefined)[0]
@@ -22,7 +28,9 @@ export const OpenedPersistentMenu = ({ onClick, options, borderRadius }) => {
   } catch (e) {}
   return (
     <div ref={ref}>
-      {isComponentVisible && (
+      {isComponentVisible && CustomPersistentMenu ? (
+        <CustomPersistentMenu onClick={onClick} options={options} />
+      ) : (
         <ButtonsContainer>
           {Object.values(options).map((e, i) => {
             return (

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -313,10 +313,6 @@ export const Webchat = forwardRef((props, ref) => {
     props.persistentMenu
   )
 
-  const CustomPersistentMenu = getThemeProperty(
-    'userInput.menu.custom',
-    undefined
-  )
   const darkBackgroundMenu = getThemeProperty(
     'userInput.menu.darkBackground',
     false
@@ -363,13 +359,6 @@ export const Webchat = forwardRef((props, ref) => {
   }
 
   const persistentMenu = () => {
-    if (CustomPersistentMenu)
-      return (
-        <CustomPersistentMenu
-          onClick={closeMenu}
-          options={persistentMenuOptions}
-        />
-      )
     return (
       <OpenedPersistentMenu
         onClick={closeMenu}


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description

`CustomPersistenMenu` uses `isComponentVisible` to close when it detects a click outside the PersistenMenu

<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context

`CustomPersistenMenu` does not close when user clicks outside the PersistenMenu

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

Move `CustomPersistenMenu` form `webchat.jsx` to `persistent-menu.jsx`

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To documentate / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [X] doesn't need tests because... **[provide a description]**
