### PR TITLE
chore: bump alphas for core and react with latest updates

### DIFF
--- a/packages/botonic-core/package-lock.json
+++ b/packages/botonic-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.13.0",
+  "version": "0.14.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.13.0",
+  "version": "0.14.0-alpha.0",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.14.0-alpha.1",
+  "version": "0.14.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1288,9 +1288,9 @@
       }
     },
     "@botonic/core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.13.0.tgz",
-      "integrity": "sha512-lxl0MeRw1XHOknQImIS5uXBvP448rtQuPPUSkS5htLov95oNUMozD/maLC74qk8teH6AHPNVp5oKK/gJxS38Fg==",
+      "version": "0.14.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.14.0-alpha.0.tgz",
+      "integrity": "sha512-0Q+GyMXwOouDHcI+ILQzeWsR177VgJgLgzqDp4kEbGWSIPsZmoJEMlp4WHW7i1sbZNGbUdqBoNfeo6EtTX5Hfw==",
       "requires": {
         "axios": "^0.19.2",
         "pusher-js": "^5.1.1"
@@ -3784,11 +3784,6 @@
           }
         }
       }
-    },
-    "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
     },
     "ms": {
       "version": "2.0.0",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.14.0-alpha.1",
+  "version": "0.14.0-alpha.2",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "MIGRATION_GUIDE.md"
   ],
   "dependencies": {
-    "@botonic/core": "~0.13.0",
+    "@botonic/core": "0.14.0-alpha.0",
     "@rehooks/local-storage": "^2.2.3",
     "axios": "^0.19.2",
     "emoji-picker-react": "^3.1.7",


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
Bumping core (0.14.0-alpha.0) and react (0.14.0-alpha.2) to alpha versions to use latest changes:

[Minor improvements](https://github.com/hubtype/botonic/pull/845)
* Deep merging of theme properties at top-level in order to have properly merged the properties coming from webchat/index.js and the ones defined in index.html.
* Refactor mobile webchat configs and allow mobileStyle
* Add message classNames to every message to be able to select them via css/scss.

[Improved offline support](https://github.com/hubtype/botonic/pull/838)
`resendUnsentInputs` will be triggered:
* after hubtype service has been initialized
* after webchat has been opened
* if an online connection has been detected with useNetwork hook.

[Refactor and removal of moment dependency](https://github.com/hubtype/botonic/pull/841)
* Removed moment dependency. Managed default webchat.botonic.js size by 170KB.
* Refactored timestamps.
* Modify and adapt api for defining timestamps.




