### PR TITLE
fix(react): disable text input on Cover Component shown

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.14.0-alpha.2",
+  "version": "0.14.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.14.0-alpha.2",
+  "version": "0.14.0-alpha.3",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-react/src/webchat/hooks.js
+++ b/packages/botonic-react/src/webchat/hooks.js
@@ -55,7 +55,7 @@ export const webchatInitialState = {
   isWebchatOpen: false,
   isEmojiPickerOpen: false,
   isPersistentMenuOpen: false,
-  isCoverComponent: false,
+  isCoverComponentOpen: false,
   lastMessageUpdate: undefined,
   currentAttachment: undefined,
 }

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -418,12 +418,12 @@ export const Webchat = forwardRef((props, ref) => {
   }
 
   useEffect(() => {
-    if (CoverComponent)
-      if (
-        !botonicState ||
-        (botonicState.messages && botonicState.messages.length == 0)
-      )
-        toggleCoverComponent(true)
+    if (!CoverComponent) return
+    if (
+      !botonicState ||
+      (botonicState.messages && botonicState.messages.length == 0)
+    )
+      toggleCoverComponent(true)
   }, [])
 
   const coverComponent = () => {
@@ -511,6 +511,7 @@ export const Webchat = forwardRef((props, ref) => {
     getMessages: () => webchatState.messagesJSON,
     clearMessages: () => {
       clearMessages()
+      updateReplies(false)
     },
     getLastMessageUpdate: () => webchatState.lastMessageUpdate,
     updateMessageInfo: (msgId, messageInfo) => {
@@ -638,13 +639,11 @@ export const Webchat = forwardRef((props, ref) => {
   const webchatReplies = () => <WebchatReplies replies={webchatState.replies} />
 
   const isUserInputEnabled = () => {
-    let isUserInputEnabled = getThemeProperty(
+    const isUserInputEnabled = getThemeProperty(
       'userInput.enable',
       props.enableUserInput !== undefined ? props.enableUserInput : true
     )
-    isUserInputEnabled =
-      isUserInputEnabled && !webchatState.isCoverComponentOpen
-    return isUserInputEnabled
+    return isUserInputEnabled && !webchatState.isCoverComponentOpen
   }
 
   const userInputEnabled = isUserInputEnabled()

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -637,11 +637,17 @@ export const Webchat = forwardRef((props, ref) => {
   )
   const webchatReplies = () => <WebchatReplies replies={webchatState.replies} />
 
-  let userInputEnabled = getThemeProperty(
-    'userInput.enable',
-    props.enableUserInput !== undefined ? props.enableUserInput : true
-  )
-  userInputEnabled = userInputEnabled && !webchatState.isCoverComponentOpen
+  const isUserInputEnabled = () => {
+    let isUserInputEnabled = getThemeProperty(
+      'userInput.enable',
+      props.enableUserInput !== undefined ? props.enableUserInput : true
+    )
+    isUserInputEnabled =
+      isUserInputEnabled && !webchatState.isCoverComponentOpen
+    return isUserInputEnabled
+  }
+
+  const userInputEnabled = isUserInputEnabled()
   const emojiPickerEnabled = getThemeProperty(
     'userInput.emojiPicker.enable',
     props.enableEmojiPicker
@@ -801,6 +807,21 @@ export const Webchat = forwardRef((props, ref) => {
     }, [webchatState.messagesJSON])
   }
 
+  const DarkenBackground = ({ component }) => {
+    return (
+      <div>
+        {darkBackgroundMenu && (
+          <DarkBackgroundMenu
+            style={{
+              borderRadius: webchatState.theme.style.borderRadius,
+            }}
+          />
+        )}
+        {component}
+      </div>
+    )
+  }
+
   return (
     <WebchatContext.Provider
       value={{
@@ -857,20 +878,13 @@ export const Webchat = forwardRef((props, ref) => {
             Object.keys(webchatState.replies).length > 0 &&
             webchatReplies()}
           {webchatState.isPersistentMenuOpen && (
-            <div>
-              {darkBackgroundMenu && (
-                <DarkBackgroundMenu
-                  style={{
-                    borderRadius: webchatState.theme.style.borderRadius,
-                  }}
-                />
-              )}
-              {persistentMenu()}
-            </div>
+            <DarkenBackground component={persistentMenu()} />
           )}
           {!webchatState.handoff && userInputArea()}
           {webchatState.webview && webchatWebview()}
-          {coverComponent()}
+          {webchatState.isCoverComponentOpen && (
+            <DarkenBackground component={coverComponent()} />
+          )}
         </StyledWebchat>
       )}
     </WebchatContext.Provider>

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -418,11 +418,12 @@ export const Webchat = forwardRef((props, ref) => {
   }
 
   useEffect(() => {
-    if (
-      !botonicState ||
-      (botonicState.messages && botonicState.messages.length == 0)
-    )
-      toggleCoverComponent(true)
+    if (CoverComponent)
+      if (
+        !botonicState ||
+        (botonicState.messages && botonicState.messages.length == 0)
+      )
+        toggleCoverComponent(true)
   }, [])
 
   const coverComponent = () => {
@@ -636,10 +637,11 @@ export const Webchat = forwardRef((props, ref) => {
   )
   const webchatReplies = () => <WebchatReplies replies={webchatState.replies} />
 
-  const userInputEnabled = getThemeProperty(
+  let userInputEnabled = getThemeProperty(
     'userInput.enable',
     props.enableUserInput !== undefined ? props.enableUserInput : true
   )
+  userInputEnabled = userInputEnabled && !webchatState.isCoverComponentOpen
   const emojiPickerEnabled = getThemeProperty(
     'userInput.emojiPicker.enable',
     props.enableEmojiPicker


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
* Fix name in default initial state.
* Fix cover component: if cover component is shown, disable user input.

## Context
When cover component is shown on first interaction, user input should be disabled. This should be the expected behavior, as the purpose of the component is to retrieve information before the user starts interacting with webchat.

**Before:**
<img width="335" alt="Screenshot 2020-07-06 at 16 12 06" src="https://user-images.githubusercontent.com/35448568/86603578-719edd80-bfa4-11ea-85a1-f6995c244f91.png">

**Now:**
<img width="343" alt="Screenshot 2020-07-06 at 17 53 44" src="https://user-images.githubusercontent.com/35448568/86613302-af563300-bfb1-11ea-91b5-d73070653d2b.png">

