### PR TITLE
chore(react): entry for proper tree-shaking

### DIFF
--- a/packages/botonic-react/src/entry.js
+++ b/packages/botonic-react/src/entry.js
@@ -1,19 +1,18 @@
-import { DevApp } from './dev-app'
-import { NodeApp } from './index'
-import { WebchatApp } from './webchat-app'
-import { WebviewApp } from './webview'
-import {
-  routes,
-  plugins,
-  locales,
-  webchat,
-  webviews,
-  config,
-  // eslint-disable-next-line import/no-unresolved,node/no-missing-import
-} from 'BotonicProject'
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable node/no-missing-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
 
 export let app
+
 if (process.env.BOTONIC_TARGET === 'dev') {
+  const { DevApp } = require('./dev-app')
+  const {
+    routes,
+    locales,
+    plugins,
+    webchat,
+    config,
+  } = require('BotonicProject')
   app = new DevApp({
     routes,
     locales,
@@ -22,9 +21,16 @@ if (process.env.BOTONIC_TARGET === 'dev') {
     ...config,
   })
 } else if (process.env.BOTONIC_TARGET === 'node') {
+  const { NodeApp } = require('./node-app')
+  const { routes, locales, plugins, config } = require('BotonicProject')
   app = new NodeApp({ routes, locales, plugins, ...config })
 } else if (process.env.BOTONIC_TARGET === 'webchat') {
+  const { WebchatApp } = require('./webchat-app')
+  const { webchat } = require('BotonicProject/webchat')
   app = new WebchatApp(webchat)
 } else if (process.env.BOTONIC_TARGET === 'webviews') {
+  const { WebviewApp } = require('./webview')
+  const { webviews } = require('BotonicProject/webviews')
+  const { locales } = require('BotonicProject/locales')
   app = new WebviewApp({ webviews, locales })
 }


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

**NOTE: This is an enhancement suggestion that can be discussed and be tested in some projects before move on**

## Description
* Suggest modifying `entry.js` in order to require specific modules and do app builds only with necessary stuff for every config.

## Context
We have figured out that tree-shaking (removal of unused/not necessary code) has not been working properly, creating builds for `WebviewsApp` for example, that included additionally code which is not necessary to build the app.
This implies having extra bundle sizes for `webchat.botonic.js` and `webviews.js`, which we upload to our hosting provider and can affect performance and costs.

## Approach taken / Explain the design
After having done some research, I haven't been able to see tree-shaking working properly on current or previous projects.
It seems that having the top-level imports of every needed module (`webchat`, `plugins`, `routes`, ...) in combination of the target env variables doesn't "trigger" the tree shaking and when building for example a `WebviewApp`:

```
app = new WebviewApp({ webviews, locales })
```

webpack is also taking into account the rest of imports. These are:
```
import {	
  routes,	
  plugins,	
  locales,	
  webchat,	
  webviews,	
  config,	
} from 'BotonicProject'
```
Webpack's trace:
```
Entrypoint main [big] = webviews.js webviews.js.map
     [27] (webpack)/buildin/global.js 472 bytes {0} [built]
     [80] (webpack)/buildin/module.js 497 bytes {0} [built]
    [147] ./node_modules/merge-anything/dist/index.esm.js + 1 modules 12.3 KiB {0} [built]
          |    2 modules
    [237] ./node_modules/moment/locale sync \b\B 160 bytes {0} [optional] [built]
    [294] ./node_modules/@botonic/react/src/entry.js + 75 modules 280 KiB {0} [built]
          | ./src/index.js 247 bytes [built]
          | ./src/routes.js 4.29 KiB [built]
          | ./src/locales/index.js 90 bytes [built]
          | ./src/plugins.js 24 bytes [built]
          | ./src/webchat/index.js 24 bytes [built]
          | ./src/webviews/index.js 146 bytes [built]
          | ./src/actions/404.js 1.65 KiB [built]
          | ./src/actions/start.js 3.35 KiB [built]
          | ./src/actions/age.js 1.66 KiB [built]
          | ./src/actions/buttons.js 2.46 KiB [built]
          | ./src/actions/bye.js 1.63 KiB [built]
          | ./src/actions/carousel.js 3.51 KiB [built]
          | ./src/actions/closed_webview.js 2.01 KiB [built]
          | ./src/actions/end.js 1.85 KiB [built]
          | ./src/actions/funny.js 1.66 KiB [built]
          |     + 61 hidden modules
        + 575 hidden modules

webviews.js (681 KiB)
```
With the suggested changes, we only require the necessary modules for building the app in a retro-compatible way (this should not affect previous projects which have the expected project structure with directories named as `webviews`, `webchat`, `locales` in their projects). Check this particular example:

```
const { WebviewApp } = require('./webview')
const { webviews } = require('BotonicProject/webviews')
const { locales } = require('BotonicProject/locales')
app = new WebviewApp({ webviews, locales })
```

Webpack's trace:
```
Entrypoint main [big] = webviews.js webviews.js.map
     [15] ./node_modules/@botonic/core/src/index.js + 9 modules 43.1 KiB {0} [built]
          |    10 modules
     [20] (webpack)/buildin/global.js 472 bytes {0} [built]
     [45] ./node_modules/@botonic/react/src/contexts.jsx + 7 modules 27.2 KiB {0} [built]
          |    8 modules
     [73] (webpack)/buildin/module.js 497 bytes {0} [built]
     [88] ./node_modules/@botonic/react/src/webview.jsx + 8 modules 73.3 KiB {0} [built]
          |    9 modules
     [89] ./src/webviews/index.js + 2 modules 5.9 KiB {0} [built]
          | ./src/webviews/index.js 146 bytes [built]
          | ./src/webviews/myWebview.js 3.22 KiB [built]
          | ./src/webviews/interactionWithBot.js 2.49 KiB [built]
     [90] ./src/locales/index.js + 2 modules 434 bytes {0} [built]
          | ./src/locales/index.js 90 bytes [built]
          | ./src/locales/en.js 171 bytes [built]
          | ./src/locales/es.js 173 bytes [built]
    [412] ./node_modules/moment/locale sync \b\B 160 bytes [optional] [built]
        + 599 hidden modules

main (332 KiB)
          webviews.js
```

With all this we can:
* Reduce bundle sizes
* Reduce size of minifed code for `webchat` and `webviews` which is published to production
* Improve build performance.
* Improve runtime performance (as we do not include extra code)
* Download both `webchat` and `webviews` faster
* Reduce hosting costs


