### PR TITLE
Fix/webchat carousels

### DIFF
--- a/packages/botonic-react/src/assets/leftArrow.svg
+++ b/packages/botonic-react/src/assets/leftArrow.svg
@@ -1,0 +1,3 @@
+<svg class="bi bi-chevron-left" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+</svg>

--- a/packages/botonic-react/src/assets/rightArrow.svg
+++ b/packages/botonic-react/src/assets/rightArrow.svg
@@ -1,0 +1,3 @@
+<svg class="bi bi-chevron-right" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
+</svg>

--- a/packages/botonic-react/src/components/carousel.jsx
+++ b/packages/botonic-react/src/components/carousel.jsx
@@ -1,20 +1,44 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState, useEffect, useRef } from 'react'
 import { Message } from './message'
 import { WebchatContext } from '../contexts'
 import { StyledScrollbar } from '../webchat/components/styled-scrollbar'
 import { isBrowser, INPUT } from '@botonic/core'
 import styled from 'styled-components'
-import { COLORS } from '../constants'
+import { COLORS, WEBCHAT } from '../constants'
+import LeftArrow from '../assets/leftArrow.svg'
+import RightArrow from '../assets/rightArrow.svg'
+import { resolveImage } from '../utils'
 
 const StyledCarousel = styled.div`
-  padding-top: 10px;
+  padding: 10px 0px;
   display: flex;
   flex-direction: row;
   max-width: 100%;
+  ${props => props.carouselArrowsEnabled && 'overflow-x: auto;'}
 `
 
 const StyledItems = styled.div`
   display: flex;
+`
+
+const StyledArrowContainer = styled.div`
+  position: absolute;
+  top: calc(50% - 20px);
+  height: 40px;
+  width: 25px;
+  background: ${COLORS.SILVER};
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  justify-content: ${props => props.justifyContent};
+  left: ${props => props.left}px;
+  right: ${props => props.right}px;
+  border-top-${props => props.arrow}-radius: 30px;
+  border-bottom-${props => props.arrow}-radius: 30px;
+`
+const StyledArrow = styled.img`
+  width: 20px;
+  height: 20px;
 `
 
 const serialize = carouselProps => {
@@ -35,14 +59,92 @@ export const Carousel = props => {
     ...{ enable: true, autoHide: true },
     ...getThemeProperty('scrollbar'),
   }
+  const [hasLeftArrow, setLeftArrow] = useState(false)
+  const [hasRightArrow, setRightArrow] = useState(true)
+  const carouselRef = useRef(null)
+  const CustomCarouselLeftArrow = getThemeProperty(
+    'carousel.arrow.left',
+    undefined
+  )
+  const CustomCarouselRightArrow = getThemeProperty(
+    'carousel.arrow.right',
+    undefined
+  )
+  const carouselArrowsEnabled = getThemeProperty('carousel.enableArrows', true)
+
+  const scrollCarouselBy = value => {
+    carouselRef.current.scrollBy({
+      left: value,
+      behavior: 'smooth',
+    })
+  }
+
+  const setArrowsVisibility = event => {
+    const carousel = event.currentTarget
+    const maxRightScroll =
+      carousel.scrollWidth -
+      carousel.offsetWidth -
+      WEBCHAT.DEFAULTS.ELEMENT_MARGIN_RIGHT
+    setLeftArrow(carousel.scrollLeft !== 0)
+    setRightArrow(carousel.scrollLeft < maxRightScroll)
+  }
+
+  const getArrows = () => {
+    const scrollBy =
+      WEBCHAT.DEFAULTS.ELEMENT_WIDTH + WEBCHAT.DEFAULTS.ELEMENT_MARGIN_RIGHT
+    return (
+      <>
+        {hasLeftArrow &&
+          (CustomCarouselLeftArrow ? (
+            <CustomCarouselLeftArrow scrollCarouselBy={scrollCarouselBy} />
+          ) : (
+            <StyledArrowContainer
+              left={0}
+              arrow={'right'}
+              justifyContent={'flex-start'}
+              onClick={() => scrollCarouselBy(-scrollBy)}
+            >
+              <StyledArrow src={resolveImage(LeftArrow)} />
+            </StyledArrowContainer>
+          ))}
+        {hasRightArrow &&
+          (CustomCarouselRightArrow ? (
+            <CustomCarouselRightArrow scrollCarouselBy={scrollCarouselBy} />
+          ) : (
+            <StyledArrowContainer
+              right={0}
+              arrow={'left'}
+              justifyContent={'flex-end'}
+              onClick={() => scrollCarouselBy(scrollBy)}
+            >
+              <StyledArrow src={resolveImage(RightArrow)} />
+            </StyledArrowContainer>
+          ))}
+      </>
+    )
+  }
+
+  useEffect(() => {
+    const carousel = carouselRef.current
+    if (carousel && carousel.addEventListener) {
+      carousel.addEventListener('scroll', setArrowsVisibility, false)
+    } else if (carousel && carousel.attachEvent) {
+      carousel.attachEvent('scroll', setArrowsVisibility)
+    }
+  }, [carouselRef.current])
+
   if (isBrowser()) {
     content = (
       <StyledScrollbar
         scrollbar={scrollbarOptions}
         autoHide={scrollbarOptions.autoHide}
       >
-        <StyledCarousel>
+        <StyledCarousel
+          ref={carouselRef}
+          carouselArrowsEnabled={carouselArrowsEnabled}
+        >
           <StyledItems>{props.children}</StyledItems>
+          {carouselArrowsEnabled && getArrows()}
         </StyledCarousel>
       </StyledScrollbar>
     )

--- a/packages/botonic-react/src/components/element.jsx
+++ b/packages/botonic-react/src/components/element.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import styled from 'styled-components'
-import { COLORS } from '../constants'
+import { COLORS, WEBCHAT } from '../constants'
 import { renderComponent } from '../utils'
 
 const ElementContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 222px;
-  margin-right: 6px;
+  width: ${WEBCHAT.DEFAULTS.ELEMENT_WIDTH}px;
+  margin-right: ${WEBCHAT.DEFAULTS.ELEMENT_MARGIN_RIGHT}px;
   border-radius: 6px;
   border: 1px solid ${COLORS.SEASHELL_WHITE};
   overflow: hidden;

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -22,7 +22,7 @@ const MessageContainer = styled.div`
   display: flex;
   justify-content: ${props => (props.isfromuser ? 'flex-end' : 'flex-start')};
   position: relative;
-  padding-left: 5px;
+  padding: 0px 6px;
 `
 
 const BotMessageImageContainer = styled.div`

--- a/packages/botonic-react/src/components/pic.jsx
+++ b/packages/botonic-react/src/components/pic.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
 
 import styled from 'styled-components'
-import { COLORS } from '../constants'
+import { COLORS, WEBCHAT } from '../constants'
 import { renderComponent } from '../utils'
 
 const PicStyled = styled.div`
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-  width: 222px;
+  width: ${WEBCHAT.DEFAULTS.ELEMENT_WIDTH}px;
   height: 140px;
   background: ${COLORS.SOLID_WHITE} url(${props => props.src}) no-repeat
     center/cover;

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -20,6 +20,7 @@ export const COLORS = {
   DAINTREE_BLUE: 'rgba(0, 43, 53, 1)',
   PIGEON_POST_BLUE_ALPHA_0_5: 'rgba(176, 196, 222, 0.5)',
   SEASHELL_WHITE: 'rgba(241, 240, 240, 1)',
+  SILVER: 'rgba(200, 200, 200, 1)',
   GRAY: 'rgba(129, 129, 129, 1)',
   SCORPION_GRAY: 'rgba(87, 87, 87, 1)',
   BLEACHED_CEDAR_PURPLE: 'rgba(46, 32, 59, 1)',
@@ -37,6 +38,8 @@ export const WEBCHAT = {
     PLACEHOLDER: 'Ask me something...',
     FONT_FAMILY: "'Noto Sans JP', sans-serif",
     BORDER_RADIUS_TOP_CORNERS: '6px 6px 0px 0px',
+    ELEMENT_WIDTH: 222,
+    ELEMENT_MARGIN_RIGHT: 6,
   },
   CUSTOM_PROPERTIES: {
     webviewStyle: 'webview.style',
@@ -102,6 +105,9 @@ export const WEBCHAT = {
     coverComponent: 'coverComponent',
     mobileBreakpoint: 'mobileBreakpoint',
     mobileStyle: 'mobileStyle',
+    enableCarouselArrows: 'carousel.enableArrows',
+    customCarouselLeftArrow: 'carousel.arrow.left',
+    customCarouselRightArrow: 'carousel.arrow.right',
   },
 }
 


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
Add arrows to the left and right side of the carousel, they can also be disabled or customized 

<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context

The fact that the carousel doesn’t have arrows may look confusing for people that are not used to carousels.

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

- Add a ref to the carousel and then scroll it by a number of pixels when there is a click on one of the arrows. 
- Hide the arrows when the carousel is at the limit 

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To documentate / Usage example

Default style:
<img width="334" alt="Captura de Pantalla 2020-07-08 a les 12 40 45" src="https://user-images.githubusercontent.com/59646082/86910783-81403280-c11a-11ea-8a9a-ed22a0d7ec8c.png">

Customized:
<img width="335" alt="Captura de Pantalla 2020-07-08 a les 12 39 40" src="https://user-images.githubusercontent.com/59646082/86910122-7afd8680-c119-11ea-826a-e49417413bc6.png">

Customize or disable the arrows:

In `src/webchat/index.js`:
```
import {
  CustomCarouselLeftArrow,
  CustomCarouselRightArrow,
} from './custom-carousel-arrows'

export const webchat = {
  theme: {
    enableCarouselArrows: {true|false},
    customCarouselLeftArrow: CustomCarouselLeftArrow,
    customCarouselRightArrow: CustomCarouselRightArrow,
  },
}
```

In `src/webchat/custom-carousel-arrows.js`:

```
import React from 'react'
import styled from 'styled-components'

const StyledArrowContainer = styled.div`
  position: absolute;
  box-sizing: border-box;
  top: 10px;
  height: calc(100% - 20px);
  width: 22px;
  background: white;
  display: flex;
  align-items: center;
  justify-content: center;
  cursor: pointer;
  left: ${(props) => props.left}px;
  right: ${(props) => props.right}px;
`

const StyledArrow = styled.img`
  width: 18px;
  height: 18px;
`

export const CustomCarouselLeftArrow = (props) => {
  return (
    <StyledArrowContainer left={0} onClick={() => props.scrollCarouselBy(-228)}>
      <StyledArrow
        src={'https://image.flaticon.com/icons/svg/860/860790.svg'}
      />
    </StyledArrowContainer>
  )
}

export const CustomCarouselRightArrow = (props) => {
  return (
    <StyledArrowContainer right={0} onClick={() => props.scrollCarouselBy(228)}>
      <StyledArrow
        src={'https://image.flaticon.com/icons/svg/860/860828.svg'}
      />
    </StyledArrowContainer>
  )
}
```

`scrollCarouselBy` allows the developer to define how many pixels will the carousel move when there is a click on the arrows
<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [X] doesn't need tests because... **[provide a description]**
