### PR TITLE
fix(react): late update of user when using updateAllUserReferences

### DIFF
--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -784,11 +784,8 @@ export const Webchat = forwardRef((props, ref) => {
   }
 
   const updateAllUserReferences = user => {
-    updateUser({ ...webchatState.user, ...user })
-    updateSession({
-      ...webchatState.session,
-      user: { ...webchatState.session.user, ...user },
-    })
+    Object.assign(webchatState.user, user)
+    Object.assign(webchatState.session.user, user)
   }
 
   useEffect(() => {


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
Try to fix the late update of the session when using `updateAllUserReferences`

<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context

To save the user info when using the `coverComponent` we created a function called `updateAllUserReferences` that updates the session with the user information. The problem is that this function doesn’t update the session immediately so the user information is not available in the next action

It should look like:
<img width="311" alt="Captura de Pantalla 2020-07-20 a les 18 20 24" src="https://user-images.githubusercontent.com/59646082/87962135-04686d80-cab7-11ea-8258-91c389a22c7b.png">


But in the first action it looks like:
<img width="313" alt="Captura de Pantalla 2020-07-20 a les 18 21 22" src="https://user-images.githubusercontent.com/59646082/87962143-08948b00-cab7-11ea-9d05-3996caf7bf9c.png">

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

Try to use `Object.assign` instead of `updateUser` and `updateSession` but it doesn’t work in prod


<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To documentate / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
