### PR TITLE
chore: pre-commit ignored lint errors

### DIFF
--- a/scripts/qa/lint-package.sh
+++ b/scripts/qa/lint-package.sh
@@ -4,7 +4,7 @@ npm run lint
 EXIT_CODE=$?
 # when lint can fix all errors, npm will return 0
 # In this case, we want to see which files were changed
-if [[ $? == 0 ]]; then
+if [[ $EXIT_CODE == 0 ]]; then
   git status
   echo "If lint fixed some files, run the following to verify the changes and commit again:"
   echo " git diff"


### PR DESCRIPTION
lint-package.sh (called by pre-commit) was returnnig failure code when npm run lint failed