### PR TITLE
Contentful/Locale improvements

### DIFF
--- a/packages/botonic-plugin-contentful/bin/l10n/import-from-translators.sh
+++ b/packages/botonic-plugin-contentful/bin/l10n/import-from-translators.sh
@@ -1,27 +1,32 @@
 #!/bin/zsh
-BIN_DIR=${0:a:h}
-cd "$BIN_DIR"/../.. || exit
-
-if [[ $# -lt 8 ]]; then
-	../../node_modules/.bin/ts-node --files	src/tools/l10n/import-csv-for-translators.ts --help
-	exit 1
-fi
-
-
+set -x
 SPACE_ID=$1
 ENVIRONMENT=$2
 DELIVER_TOKEN=$3
 CONTENTFUL_MANAGEMENT_TOKEN=$4
 LOCALE=$5
 CSV_FILENAME=$6
+CSV_FILENAME="$( cd "$( dirname "$CSV_FILENAME" )" && pwd )/$(basename $CSV_FILENAME)"
+
+
+BIN_DIR=${0:a:h}
+cd "$BIN_DIR"/../.. || exit
+
+if [[ $# -lt 8 ]]; then
+	../../node_modules/.bin/ts-node --files	src/tools/l10n/import-csv-from-translators.ts --help
+	exit 1
+fi
+
+
 
 WRITE_MODE=$7
 #  DRY: parse files but do write to CM
 #  NO_OVERWRITE: publishes the content, but fails if fields for this locale already have value
 #  OVERWRITE: modifies previous value, but leaves it in UNPUBLISHED state
+#  OVERWRITE_AND_PUBLISH: overwrites previous value and publishes it (only for new spaces!)
 
 DUPLICATE_REFERENCES=$8
 
-../../node_modules/.bin/ts-node --files	src/tools/l10n/import-csv-for-translators.ts \
+../../node_modules/.bin/ts-node --files	src/tools/l10n/import-csv-from-translators.ts \
 	"$SPACE_ID" "$ENVIRONMENT" "$DELIVER_TOKEN" "$CONTENTFUL_MANAGEMENT_TOKEN" "$LOCALE" "$CSV_FILENAME" \
 	"$WRITE_MODE" "$DUPLICATE_REFERENCES"

--- a/packages/botonic-plugin-contentful/bin/l10n/migrate-locales.sh
+++ b/packages/botonic-plugin-contentful/bin/l10n/migrate-locales.sh
@@ -1,7 +1,19 @@
 #!/bin/zsh
+set -e
 # Useful to clone the contents flow from a space when the target locales are different.
 # It clones the specifying exported json file with the requested changes
 # See LocaleMigrator class
+
+FROM_FILE=$1
+FROM_FILE="$( cd "$( dirname "$FROM_FILE" )" && pwd )/$(basename $FROM_FILE)"
+
+TO_FILE=$2
+TO_FILE="$( cd "$( dirname "$TO_FILE" )" && pwd )/$(basename $TO_FILE)"
+
+FROM_LOCALE=$3
+TO_LOCALE=$4
+REMOVE_LOCALES=$5
+
 
 BIN_DIR=${0:a:h}
 cd "$BIN_DIR"/../.. || exit
@@ -11,11 +23,7 @@ if [[ $# -lt 4 ]]; then
 	exit 1
 fi
 
-FROM_FILE=$1
-TO_FILE=$2
-FROM_LOCALE=$3
-TO_LOCALE=$4
-REMOVE_LOCALES=$5
 
 ../../node_modules/.bin/ts-node --files	src/tools/l10n/locale-migrate.ts \
 	"$FROM_FILE" "$TO_FILE" "$FROM_LOCALE" "$TO_LOCALE" "$REMOVE_LOCALES"
+echo "Change Element.image so that it does not have 1 version per locale"

--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -681,7 +681,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
       "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
-      "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
       }
@@ -801,8 +800,7 @@
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-regex": {
       "version": "4.1.0",
@@ -814,7 +812,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -828,8 +825,7 @@
     "any-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
-      "dev": true
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
     },
     "any-promise": {
       "version": "1.3.0",
@@ -858,8 +854,7 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-unique": {
       "version": "0.3.2",
@@ -1030,8 +1025,7 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "braces": {
       "version": "2.3.2",
@@ -1094,14 +1088,12 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
       "requires": {
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
@@ -1110,8 +1102,7 @@
         "camelcase": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         }
       }
     },
@@ -1155,7 +1146,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1165,8 +1155,7 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         }
       }
     },
@@ -1215,7 +1204,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
       }
@@ -1235,7 +1223,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-      "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
         "string-width": "^1.0.1"
@@ -1244,14 +1231,12 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1260,7 +1245,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1271,7 +1255,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1298,8 +1281,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codepage": {
       "version": "1.14.0",
@@ -1331,7 +1313,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1339,14 +1320,12 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
       "optional": true
     },
     "combined-stream": {
@@ -1414,7 +1393,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/contentful-batch-libs/-/contentful-batch-libs-9.0.1.tgz",
       "integrity": "sha512-4r8XVTKS0i1+3p6uuwY9xtlmsRtozmUMgz5usoyoQvEhxuSdyhutyiyNEWJG/sydfsmd/VWrcbxcWrRm/lEC1Q==",
-      "dev": true,
       "requires": {
         "bfj": "^5.2.1",
         "figures": "^2.0.0",
@@ -1427,7 +1405,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
           "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
@@ -1436,7 +1413,6 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/bfj/-/bfj-5.3.1.tgz",
           "integrity": "sha512-o2LY9aB+5m3c5zL6rke/Wz7pZmrwDq6vCYf/bl0H4qaEDG0ErVq3jSCvuxlbKp88qhy4vnQDqmkL/quI2Ryxvw==",
-          "dev": true,
           "requires": {
             "bluebird": "^3.5.1",
             "check-types": "^7.3.0",
@@ -1447,20 +1423,17 @@
         "check-types": {
           "version": "7.4.0",
           "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
-          "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==",
-          "dev": true
+          "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "figures": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
@@ -1469,7 +1442,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
           "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
-          "dev": true,
           "requires": {
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
@@ -1609,7 +1581,6 @@
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/contentful-import/-/contentful-import-7.9.1.tgz",
       "integrity": "sha512-JlbjCA3oDqOU52x1Shvo6lg6JTjiqcLHETcLzkIcmVg6F67rYW2vk2xJicVBpexSE/LJcU9yDuvKuF5gcQ2ahg==",
-      "dev": true,
       "requires": {
         "bluebird": "^3.5.1",
         "cli-table3": "^0.5.1",
@@ -1628,26 +1599,22 @@
         "ansi-escapes": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
         },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -1659,14 +1626,12 @@
             "ansi-regex": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             },
             "strip-ansi": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1677,7 +1642,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
           "requires": {
             "restore-cursor": "^1.0.1"
           }
@@ -1686,7 +1650,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
           "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
-          "dev": true,
           "requires": {
             "colors": "^1.1.2",
             "object-assign": "^4.1.0",
@@ -1697,7 +1660,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
           "requires": {
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0",
@@ -1708,7 +1670,6 @@
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-6.0.3.tgz",
           "integrity": "sha512-wlz7ou0jPGayJnNGM9Q6hJgw+cFFOcHWTSq8oTBak1bNPrd+W7ZZMrV/jp6XC7gn3ZJjIx7VNZcJNH+K/mtUkQ==",
-          "dev": true,
           "requires": {
             "axios": "^0.19.0",
             "contentful-sdk-core": "^6.4.0",
@@ -1719,14 +1680,12 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
           "requires": {
             "escape-string-regexp": "^1.0.5",
             "object-assign": "^4.1.0"
@@ -1736,7 +1695,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
           }
@@ -1744,26 +1702,22 @@
         "get-caller-file": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-          "dev": true
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
         },
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "listr-update-renderer": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
           "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
-          "dev": true,
           "requires": {
             "chalk": "^1.1.3",
             "cli-truncate": "^0.2.1",
@@ -1778,14 +1732,12 @@
             "ansi-regex": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             },
             "strip-ansi": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1796,7 +1748,6 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
           "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
-          "dev": true,
           "requires": {
             "chalk": "^1.1.3",
             "cli-cursor": "^1.0.2",
@@ -1808,7 +1759,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
@@ -1818,7 +1768,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
           "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-          "dev": true,
           "requires": {
             "ansi-escapes": "^1.0.0",
             "cli-cursor": "^1.0.2"
@@ -1827,14 +1776,12 @@
         "onetime": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "p-locate": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
           }
@@ -1842,20 +1789,17 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         },
         "require-main-filename": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-          "dev": true
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "restore-cursor": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
           "requires": {
             "exit-hook": "^1.0.0",
             "onetime": "^1.0.0"
@@ -1865,7 +1809,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -1875,7 +1818,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -1883,14 +1825,12 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "dev": true,
           "requires": {
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1"
@@ -1899,14 +1839,12 @@
             "ansi-regex": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1915,7 +1853,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1926,7 +1863,6 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1937,7 +1873,6 @@
           "version": "12.0.5",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
           "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-          "dev": true,
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.2.0",
@@ -1957,7 +1892,6 @@
           "version": "11.1.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
           "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -2168,7 +2102,6 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -2191,7 +2124,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
       }
@@ -2217,8 +2149,7 @@
     "date-fns": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "debug": {
       "version": "3.1.0",
@@ -2231,8 +2162,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2328,7 +2258,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/echo-cli/-/echo-cli-1.0.8.tgz",
       "integrity": "sha1-cKRbh/ltsItFQ8mJW/KuguaRCYg=",
-      "dev": true,
       "requires": {
         "meow": "^3.7.0",
         "unescape-js": "^1.0.3"
@@ -2337,8 +2266,7 @@
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
-      "dev": true
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -2368,7 +2296,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -2377,7 +2304,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -2412,14 +2338,12 @@
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -2587,8 +2511,7 @@
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-      "dev": true
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
     },
     "exit-on-epipe": {
       "version": "1.0.1",
@@ -2953,14 +2876,12 @@
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -2983,8 +2904,7 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-      "dev": true
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -3017,7 +2937,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -3025,16 +2944,14 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-value": {
       "version": "1.0.0",
@@ -3071,20 +2988,17 @@
     "hoek": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
-      "dev": true
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
     },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
-      "dev": true
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-      "dev": true
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -3149,7 +3063,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
       "requires": {
         "repeating": "^2.0.0"
       }
@@ -3484,8 +3397,7 @@
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-      "dev": true
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3510,8 +3422,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -3573,8 +3484,7 @@
     "is-finite": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "dev": true
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -3606,7 +3516,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-      "dev": true,
       "requires": {
         "symbol-observable": "^1.1.0"
       }
@@ -3628,8 +3537,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -3640,8 +3548,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -3668,7 +3575,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
       "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "dev": true,
       "requires": {
         "punycode": "2.x.x"
       }
@@ -3676,8 +3582,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -3795,7 +3700,6 @@
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
       "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
-      "dev": true,
       "requires": {
         "hoek": "5.x.x",
         "isemail": "3.x.x",
@@ -3873,7 +3777,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "dev": true,
       "requires": {
         "invert-kv": "^2.0.0"
       }
@@ -3897,7 +3800,6 @@
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
       "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
-      "dev": true,
       "requires": {
         "@samverschueren/stream-to-observable": "^0.3.0",
         "is-observable": "^1.1.0",
@@ -3913,14 +3815,12 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "figures": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
@@ -3929,7 +3829,6 @@
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
           "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-          "dev": true,
           "requires": {
             "chalk": "^2.4.1",
             "cli-cursor": "^2.1.0",
@@ -3942,14 +3841,12 @@
     "listr-silent-renderer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-      "dev": true
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
     },
     "listr-update-renderer": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
       "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "cli-truncate": "^0.2.1",
@@ -3964,20 +3861,17 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -3989,14 +3883,12 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
           "requires": {
             "escape-string-regexp": "^1.0.5",
             "object-assign": "^4.1.0"
@@ -4005,14 +3897,12 @@
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4020,8 +3910,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -4064,7 +3953,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -4132,7 +4020,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true,
       "requires": {
         "chalk": "^1.0.0"
       },
@@ -4140,20 +4027,17 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -4165,14 +4049,12 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4180,8 +4062,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -4189,7 +4070,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
-      "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
         "cli-cursor": "^2.0.0",
@@ -4199,20 +4079,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -4222,7 +4099,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -4231,7 +4107,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
           "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-          "dev": true,
           "requires": {
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0"
@@ -4243,7 +4118,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
@@ -4261,7 +4135,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
       "requires": {
         "p-defer": "^1.0.0"
       }
@@ -4275,8 +4148,7 @@
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -4296,7 +4168,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-      "dev": true,
       "requires": {
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
@@ -4306,8 +4177,7 @@
         "mimic-fn": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         }
       }
     },
@@ -4330,7 +4200,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true,
       "requires": {
         "camelcase-keys": "^2.0.0",
         "decamelize": "^1.1.2",
@@ -4389,14 +4258,12 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.3",
@@ -4506,8 +4373,7 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-nlp": {
       "version": "4.8.0",
@@ -4535,7 +4401,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -4547,7 +4412,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -4555,8 +4419,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -4567,8 +4430,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -4623,7 +4485,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4632,7 +4493,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
       }
@@ -4664,7 +4524,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
       "requires": {
         "execa": "^1.0.0",
         "lcid": "^2.0.0",
@@ -4675,7 +4534,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-          "dev": true,
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^4.0.0",
@@ -4703,26 +4561,22 @@
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-      "dev": true
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
     },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -4739,20 +4593,17 @@
     "p-map": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "dev": true
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -4777,7 +4628,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
       "requires": {
         "pinkie-promise": "^2.0.0"
       }
@@ -4785,20 +4635,17 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -4814,20 +4661,17 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -4894,7 +4738,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -4903,8 +4746,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.9.3",
@@ -4927,7 +4769,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -4938,7 +4779,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -4948,7 +4788,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -4995,7 +4834,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
       "requires": {
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
@@ -5047,7 +4885,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -5091,8 +4928,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -5104,7 +4940,6 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -5119,7 +4954,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -5153,7 +4987,6 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
       "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -5182,14 +5015,12 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -5218,7 +5049,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -5226,8 +5056,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shell-escape": {
       "version": "0.2.0",
@@ -5238,8 +5067,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "slash": {
       "version": "2.0.0",
@@ -5250,8 +5078,7 @@
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -5421,7 +5248,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -5430,14 +5256,12 @@
     "spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -5446,8 +5270,7 @@
     "spdx-license-ids": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-      "dev": true
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
     "split-string": {
       "version": "3.1.0",
@@ -5524,8 +5347,7 @@
     "string.fromcodepoint": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
-      "integrity": "sha1-jZeDM8C8klOPUPOD5IiPPlYZ1lM=",
-      "dev": true
+      "integrity": "sha1-jZeDM8C8klOPUPOD5IiPPlYZ1lM="
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -5565,7 +5387,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
       "requires": {
         "is-utf8": "^0.2.0"
       }
@@ -5573,8 +5394,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -5586,7 +5406,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
       "requires": {
         "get-stdin": "^4.0.1"
       }
@@ -5595,7 +5414,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -5603,8 +5421,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "tar": {
       "version": "6.0.2",
@@ -5731,7 +5548,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
       "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "dev": true,
       "requires": {
         "hoek": "6.x.x"
       },
@@ -5739,8 +5555,7 @@
         "hoek": {
           "version": "6.1.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
-          "dev": true
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
         }
       }
     },
@@ -5763,20 +5578,17 @@
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-      "dev": true
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
-      "dev": true
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -5809,8 +5621,7 @@
     "type-fest": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.15.1.tgz",
-      "integrity": "sha512-n+UXrN8i5ioo7kqT/nF8xsEzLaqFra7k32SEsSPwvXVGyAcRgV/FUQN/sgfptJTR1oRmmq7z4IXMFSM7im7C9A==",
-      "dev": true
+      "integrity": "sha512-n+UXrN8i5ioo7kqT/nF8xsEzLaqFra7k32SEsSPwvXVGyAcRgV/FUQN/sgfptJTR1oRmmq7z4IXMFSM7im7C9A=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -5837,7 +5648,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/unescape-js/-/unescape-js-1.1.4.tgz",
       "integrity": "sha512-42SD8NOQEhdYntEiUQdYq/1V/YHwr1HLwlHuTJB5InVVdOSbgI6xu8jK5q65yIzuFCfczzyDF/7hbGzVbyCw0g==",
-      "dev": true,
       "requires": {
         "string.fromcodepoint": "^0.2.1"
       }
@@ -5954,7 +5764,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -5975,7 +5784,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -5983,8 +5791,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wmf": {
       "version": "1.0.2",
@@ -6037,8 +5844,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xlsx": {
       "version": "0.15.6",
@@ -6058,8 +5864,7 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -138,7 +138,7 @@ export class DummyCMS implements CMS {
   }
 
   asset(id: string, context?: Context): Promise<Asset> {
-    return Promise.resolve(new Asset(`name for ${id}`, `http://url.${id}`))
+    return Promise.resolve(new Asset(id, `name for ${id}`, `http://url.${id}`))
   }
 
   dateRange(id: string, context?: Context): Promise<DateRangeContent> {
@@ -154,6 +154,10 @@ export class DummyCMS implements CMS {
   }
 
   contents(contentType: ContentType, context?: Context): Promise<Content[]> {
+    return Promise.resolve([])
+  }
+
+  assets(context?: Context): Promise<Asset[]> {
     return Promise.resolve([])
   }
 }

--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -111,13 +111,14 @@ export class ErrorReportingCMS implements CMS {
       .catch(this.handleError('topContents'))
   }
 
-  contents(
-    contentType: ContentType,
-    context?: Context | undefined
-  ): Promise<Content[]> {
+  contents(contentType: ContentType, context?: Context): Promise<Content[]> {
     return this.cms
       .contents(contentType, context)
       .catch(this.handleError('contents'))
+  }
+
+  assets(context?: Context): Promise<Asset[]> {
+    return this.cms.assets(context).catch(this.handleError('assets'))
   }
 
   schedule(id: string, context?: Context): Promise<ScheduleContent> {

--- a/packages/botonic-plugin-contentful/src/cms/cms-multilocale.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-multilocale.ts
@@ -46,6 +46,10 @@ export class MultiContextCms implements CMS {
     return this.cmsFromContext(context).contents(contentType, context)
   }
 
+  assets(context?: Context): Promise<Asset[]> {
+    return this.cmsFromContext(context).assets(context)
+  }
+
   contentsWithKeywords(context?: Context): Promise<SearchCandidate[]> {
     return this.cmsFromContext(context).contentsWithKeywords(context)
   }

--- a/packages/botonic-plugin-contentful/src/cms/cms.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms.ts
@@ -104,6 +104,7 @@ export interface CMS {
    * TODO add filter by id or name
    */
   contents(contentType: ContentType, context?: Context): Promise<Content[]>
+  assets(context?: Context): Promise<Asset[]>
 
   /**
    * For contents with 'Searchable by' field (eg. {@link Queue}), it returns one result per each 'Seachable by' entry

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -16,6 +16,7 @@ export class Asset {
    * @param details depends on the type. eg the image size
    */
   constructor(
+    readonly id: string,
     readonly name: string,
     readonly url: string,
     readonly type?: string,

--- a/packages/botonic-plugin-contentful/src/cms/transform/cms-filter.ts
+++ b/packages/botonic-plugin-contentful/src/cms/transform/cms-filter.ts
@@ -124,6 +124,10 @@ export class FilteredCMS implements CMS {
     return this.filterContents(contents, context)
   }
 
+  assets(context?: Context): Promise<Asset[]> {
+    return this.cms.assets(context)
+  }
+
   schedule(id: string, context?: Context): Promise<ScheduleContent> {
     return this.cms.schedule(id, context)
   }

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -62,7 +62,8 @@ export class Contentful implements cms.CMS {
     const deliveryApi = new AdaptorDeliveryApi(
       options.disableCache
         ? client
-        : new CachedClientApi(client, options.cacheTtlMs)
+        : new CachedClientApi(client, options.cacheTtlMs),
+      options
     )
     const delivery = new IgnoreFallbackDecorator(deliveryApi)
     this._contents = new ContentsDelivery(delivery)

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -1,5 +1,6 @@
 import * as cms from '../cms'
 import {
+  Asset,
   CommonFields,
   Content,
   ContentType,
@@ -220,8 +221,12 @@ export class Contentful implements cms.CMS {
     return this._schedule.schedule(id)
   }
 
-  asset(id: string): Promise<cms.Asset> {
-    return this._asset.asset(id)
+  asset(id: string, context = DEFAULT_CONTEXT): Promise<cms.Asset> {
+    return this._asset.asset(id, context)
+  }
+
+  assets(context = DEFAULT_CONTEXT): Promise<Asset[]> {
+    return this._asset.assets(context)
   }
 
   dateRange(id: string): Promise<DateRangeContent> {

--- a/packages/botonic-plugin-contentful/src/contentful/contents/asset.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/asset.ts
@@ -1,16 +1,27 @@
 import * as cms from '../../cms'
 import { ContentfulEntryUtils, DeliveryApi } from '../delivery-api'
+import { Asset } from 'contentful'
 
 export class AssetDelivery {
   constructor(protected delivery: DeliveryApi) {}
 
-  async asset(id: string): Promise<cms.Asset> {
-    const asset = await this.delivery.getAsset(id)
+  async asset(id: string, context: cms.Context): Promise<cms.Asset> {
+    const asset = await this.delivery.getAsset(id, context)
+    return this.fromEntry(asset)
+  }
+
+  private fromEntry(asset: Asset) {
     return new cms.Asset(
+      asset.sys.id,
       asset.fields.title,
       ContentfulEntryUtils.urlFromAsset(asset),
       asset.fields.file.contentType,
       asset.fields.file.details
     )
+  }
+
+  async assets(context: cms.Context): Promise<cms.Asset[]> {
+    const assets = await this.delivery.getAssets(context)
+    return assets.items.map(a => this.fromEntry(a))
   }
 }

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -17,7 +17,9 @@ import { ReducedClientApi } from './delivery/client-api'
 import { ContentfulOptions } from '../plugin'
 
 export interface DeliveryApi {
-  getAsset(id: string, query?: any): Promise<contentful.Asset>
+  getAsset(id: string, context: Context, query?: any): Promise<contentful.Asset>
+
+  getAssets(context: Context, query?: any): Promise<contentful.AssetCollection>
 
   getEntry<T>(
     id: string,
@@ -42,8 +44,19 @@ export class AdaptorDeliveryApi implements DeliveryApi {
     readonly options: ContentfulOptions
   ) {}
 
-  async getAsset(id: string, query?: any): Promise<contentful.Asset> {
-    return this.client.getAsset(id, query)
+  async getAsset(
+    id: string,
+    context: Context,
+    query?: any
+  ): Promise<contentful.Asset> {
+    return this.client.getAsset(id, this.queryFromContext(context, query))
+  }
+
+  async getAssets(
+    context: Context,
+    query?: any
+  ): Promise<contentful.AssetCollection> {
+    return this.client.getAssets(this.queryFromContext(context, query))
   }
 
   async getEntry<T>(

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -37,7 +37,10 @@ export interface DeliveryApi {
  * Manages the {@link Context}, parses Content's Id and ContentType from the Contentful entries...
  */
 export class AdaptorDeliveryApi implements DeliveryApi {
-  constructor(readonly client: ReducedClientApi) {}
+  constructor(
+    readonly client: ReducedClientApi,
+    readonly options: ContentfulOptions
+  ) {}
 
   async getAsset(id: string, query?: any): Promise<contentful.Asset> {
     return this.client.getAsset(id, query)
@@ -48,19 +51,14 @@ export class AdaptorDeliveryApi implements DeliveryApi {
     context: Context,
     query: any = {}
   ): Promise<contentful.Entry<T>> {
-    return this.client.getEntry<T>(
-      id,
-      AdaptorDeliveryApi.queryFromContext(context, query)
-    )
+    return this.client.getEntry<T>(id, this.queryFromContext(context, query))
   }
 
   async getEntries<T>(
     context: Context,
     query: any = {}
   ): Promise<contentful.EntryCollection<T>> {
-    return this.client.getEntries<T>(
-      AdaptorDeliveryApi.queryFromContext(context, query)
-    )
+    return this.client.getEntries<T>(this.queryFromContext(context, query))
   }
 
   async getContentType(id: string): Promise<contentful.ContentType> {
@@ -72,9 +70,12 @@ export class AdaptorDeliveryApi implements DeliveryApi {
     }
   }
 
-  private static queryFromContext(context: Context, query: any = {}): any {
-    if (context.locale) {
-      query['locale'] = context.locale
+  private queryFromContext(context: Context, query: any = {}): any {
+    const locale = this.options.cmsLocale
+      ? this.options.cmsLocale(context.locale)
+      : context.locale
+    if (locale) {
+      query['locale'] = locale
     }
     return query
   }

--- a/packages/botonic-plugin-contentful/src/contentful/delivery/cache.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery/cache.ts
@@ -5,6 +5,7 @@ import { ReducedClientApi } from './client-api'
 
 export class CachedClientApi implements ReducedClientApi {
   readonly getAsset: (id: string, query?: any) => Promise<contentful.Asset>
+  readonly getAssets: (query?: any) => Promise<contentful.AssetCollection>
   readonly getEntries: <T>(query: any) => Promise<contentful.EntryCollection<T>>
   readonly getEntry: <T>(id: string, query?: any) => Promise<Entry<T>>
   readonly getContentType: (id: string) => Promise<ContentType>
@@ -23,6 +24,7 @@ export class CachedClientApi implements ReducedClientApi {
       } as memoize.Options<any>)
 
     this.getAsset = memoize(client.getAsset, options(2))
+    this.getAssets = memoize(client.getAssets, options(1))
     this.getEntries = memoize(client.getEntries, options(1))
     this.getEntry = memoize(client.getEntry, options(2))
     this.getContentType = memoize(client.getContentType, options(1))

--- a/packages/botonic-plugin-contentful/src/contentful/delivery/client-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery/client-api.ts
@@ -2,5 +2,5 @@ import { ContentfulClientApi } from 'contentful'
 
 export type ReducedClientApi = Pick<
   ContentfulClientApi,
-  'getAsset' | 'getEntries' | 'getEntry' | 'getContentType'
+  'getAsset' | 'getAssets' | 'getEntries' | 'getEntry' | 'getContentType'
 >

--- a/packages/botonic-plugin-contentful/src/contentful/ignore-fallback-decorator.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/ignore-fallback-decorator.ts
@@ -7,6 +7,7 @@ import {
   I18nValue,
   VisitedField,
 } from './traverser'
+import * as contentful from 'contentful'
 
 /**
  * It requests contentful to deliver all locales for each entry, and we discard all except the one in the context
@@ -61,8 +62,21 @@ export class IgnoreFallbackDecorator implements DeliveryApi {
     )
   }
 
-  getAsset(id: string, query?: any): Promise<Asset> {
-    return this.api.getAsset(id, query)
+  getAsset(id: string, context: Context, query?: any): Promise<Asset> {
+    console.warn(
+      'IgnoreFallbackDecorator does not any special treatment for getAsset'
+    )
+    return this.api.getAsset(id, context, query)
+  }
+
+  async getAssets(
+    context: Context,
+    query?: any
+  ): Promise<contentful.AssetCollection> {
+    console.warn(
+      'IgnoreFallbackDecorator does not any special treatment for getAssets'
+    )
+    return this.api.getAssets(context, query)
   }
 
   private i18nContext(context: Context) {

--- a/packages/botonic-plugin-contentful/src/index.ts
+++ b/packages/botonic-plugin-contentful/src/index.ts
@@ -8,4 +8,9 @@ export * from './time'
 export * from './tools'
 export * from './util'
 
-export { default, CmsOptions, ContentfulOptions } from './plugin'
+export {
+  default,
+  CmsOptions,
+  ContentfulOptions,
+  ContentfulCredentials,
+} from './plugin'

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
@@ -18,7 +18,7 @@ export class ErrorReportingManageCms implements ManageCms {
     value: any
   ): Promise<void> {
     return this.manageCms
-      .updateField<T>(context, contentId, fieldType, value)
+      .updateField(context, contentId, fieldType, value)
       .catch(this.handleError('updateField', contentId))
   }
 
@@ -30,7 +30,7 @@ export class ErrorReportingManageCms implements ManageCms {
     onlyIfTargetEmpty: boolean
   ): Promise<void> {
     return this.manageCms
-      .copyField<T>(context, contentId, field, fromLocale, onlyIfTargetEmpty)
+      .copyField(context, contentId, field, fromLocale, onlyIfTargetEmpty)
       .catch(this.handleError('copyField', contentId))
   }
 
@@ -52,5 +52,21 @@ export class ErrorReportingManageCms implements ManageCms {
     return this.manageCms
       .getDefaultLocale()
       .catch(this.handleError('defaultLocale'))
+  }
+
+  copyAssetFile(
+    context: ManageContext,
+    assetId: string,
+    fromLocale: Locale
+  ): Promise<void> {
+    return this.manageCms
+      .copyAssetFile(context, assetId, fromLocale)
+      .catch(this.handleError('copyAssetFile'))
+  }
+
+  removeAssetFile(context: ManageContext, assetId: string): Promise<void> {
+    return this.manageCms
+      .removeAssetFile(context, assetId)
+      .catch(this.handleError('removeAssetFile'))
   }
 }

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
@@ -1,9 +1,8 @@
-import * as cms from '../cms'
-import { ManageContext } from './manage-context'
 import { ContentId } from '../cms'
+import { ManageContext } from './manage-context'
 import * as nlp from '../nlp'
-import { ContentFieldType } from './fields'
 import { Locale } from '../nlp'
+import { ContentFieldType } from './fields'
 
 /**
  * Take into account that if you request a content immediately after updating it
@@ -15,7 +14,7 @@ export interface ManageCms {
    */
   getDefaultLocale(): Promise<Locale>
 
-  updateField<T extends cms.Content>(
+  updateField(
     context: ManageContext,
     contentId: ContentId,
     fieldType: ContentFieldType,
@@ -23,11 +22,19 @@ export interface ManageCms {
   ): Promise<void>
 
   /** Will not fail if source does not have this field */
-  copyField<T extends cms.Content>(
+  copyField(
     context: ManageContext,
     contentId: ContentId,
     field: ContentFieldType,
     fromLocale: nlp.Locale,
     onlyIfTargetEmpty: boolean
   ): Promise<void>
+
+  copyAssetFile(
+    context: ManageContext,
+    assetId: string,
+    fromLocale: nlp.Locale
+  ): Promise<void>
+
+  removeAssetFile(context: ManageContext, assetId: string): Promise<void>
 }

--- a/packages/botonic-plugin-contentful/src/nlp/locales.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/locales.ts
@@ -24,6 +24,10 @@ export function checkLocale(locale: Locale): Locale {
   return locale
 }
 
+export function rootLocale(locale: Locale): Locale {
+  return locale.substr(0, 2)
+}
+
 /**
  * Converts to lowercase, trims and removes accents
  */

--- a/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_STOP_WORDS,
   tokenizerPerLocale,
 } from './tokens'
-import { Locale } from './locales'
+import { Locale, rootLocale } from './locales'
 import { equalArrays } from '../util/arrays'
 
 /**
@@ -118,6 +118,7 @@ export class Normalizer {
    * @throws EmptyTextException if the text is empty or only contains separators
    */
   normalize(locale: Locale, raw: string): NormalizedUtterance {
+    locale = rootLocale(locale)
     let txt = raw.replace(this.separatorsRegex, ' ')
     txt = txt.trim().toLowerCase() // TODO use preprocess without normalization? move to NormalizedUtterance constructor?
     if (!txt) {

--- a/packages/botonic-plugin-contentful/src/nlp/stemmer.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/stemmer.ts
@@ -5,6 +5,7 @@ import StemmerEs from '@nlpjs/lang-es/src/stemmer-es'
 import StemmerPt from '@nlpjs/lang-pt/src/stemmer-pt'
 import StemmerRu from '@nlpjs/lang-ru/src/stemmer-ru'
 import { StemmerPl } from './stemmers/polish-stemmer'
+import { Locale, rootLocale } from './locales'
 
 // see https://github.com/axa-group/nlp.js/blob/HEAD/docs/language-support.md
 // and https://stackoverflow.com/a/11210358/145289
@@ -21,8 +22,8 @@ export const stemmers: { [key: string]: BaseStemmer } = {
   //node-nlp does not support polish
 }
 
-export function stemmerFor(locale: string): BaseStemmer {
-  const stem = stemmers[locale]
+export function stemmerFor(locale: Locale): BaseStemmer {
+  const stem = stemmers[rootLocale(locale)]
   if (!stem) {
     throw new Error(`No stemmer configured for locale '${locale}'`)
   }

--- a/packages/botonic-plugin-contentful/src/nlp/tokens.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/tokens.ts
@@ -6,7 +6,7 @@ import TokenizerRu from '@nlpjs/lang-ru/src/tokenizer-ru'
 import { esDefaultStopWords } from './stopwords/stopwords-es'
 import { caDefaultStopWords } from './stopwords/stopwords-ca'
 import { enDefaultStopWords } from './stopwords/stopwords-en'
-import { Locale } from './locales'
+import { Locale, rootLocale } from './locales'
 import { plDefaultStopWords } from './stopwords/stopwords-pl'
 import { ptDefaultStopWords } from './stopwords/stopwords-pt'
 import { ruDefaultStopWords } from './stopwords/stopwords-ru'
@@ -78,8 +78,9 @@ const tokenizers: { [locale: string]: Tokenizer } = {
 }
 
 export function tokenizerPerLocale(locale: Locale): Tokenizer {
-  return tokenizers[locale]
+  return tokenizers[rootLocale(locale)]
 }
+
 export const DEFAULT_SEPARATORS = ';,./()!?" '
 export const DEFAULT_SEPARATORS_REGEX = new RegExp(
   '[' + DEFAULT_SEPARATORS + ']',

--- a/packages/botonic-plugin-contentful/src/plugin.ts
+++ b/packages/botonic-plugin-contentful/src/plugin.ts
@@ -1,5 +1,5 @@
 import * as cms from './cms'
-import { KeywordsOptions, Normalizer, StemmingBlackList } from './nlp'
+import { KeywordsOptions, Locale, Normalizer, StemmingBlackList } from './nlp'
 import { Search } from './search'
 import { BotonicMsgConverter } from './render'
 import { Contentful } from './contentful/cms-contentful'
@@ -43,6 +43,9 @@ export interface ContentfulOptions extends OptionsBase, ContentfulCredentials {
   disableCache?: boolean
 
   contentfulFactory?: (opts: ContentfulOptions) => cms.CMS
+
+  /** For locales not supported by the CMS (eg. English on a non-English country) */
+  cmsLocale?: (locale?: Locale) => Locale | undefined
 
   /**
    * If the delivery of a part of a content fails (eg. a referenced content),

--- a/packages/botonic-plugin-contentful/src/search/search-by-keywords.ts
+++ b/packages/botonic-plugin-contentful/src/search/search-by-keywords.ts
@@ -7,6 +7,7 @@ import {
   Normalizer,
   NormalizedUtterance,
   Word,
+  rootLocale,
 } from '../nlp'
 import { SearchCandidate, SearchResult } from './search-result'
 
@@ -25,7 +26,7 @@ export class SearchByKeywords {
     matchType: MatchType,
     context: cms.ContextWithLocale
   ): Promise<SearchResult[]> {
-    const locale = checkLocale(context.locale)
+    const locale = rootLocale(checkLocale(context.locale))
     const contentsWithKeywords = await this.cms.contentsWithKeywords(context)
     const kws = new KeywordsParser<SearchCandidate>(
       locale,

--- a/packages/botonic-plugin-contentful/src/tools/l10n/csv-import.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/csv-import.ts
@@ -132,7 +132,7 @@ export class ReferenceFieldDuplicator {
     readonly manageContext: ManageContext
   ) {}
 
-  async duplicateReferenceFields() {
+  async duplicateReferenceFields(): Promise<void> {
     const defaultLocale = await this.manageCms.getDefaultLocale()
     const fields = {
       [ContentType.TEXT]: [ContentFieldType.BUTTONS],
@@ -140,15 +140,37 @@ export class ReferenceFieldDuplicator {
       [ContentType.ELEMENT]: [ContentFieldType.IMAGE],
     }
     for (const contentType of Object.keys(fields)) {
-      console.log(`***Duplicating contents of type ${contentType}`)
+      console.log(`***Duplicating contents of type '${contentType}'`)
       for (const fieldType of (fields as any)[contentType]) {
-        console.log(` **Duplicating field ${contentType}`)
+        console.log(` **Duplicating '${contentType}' fields`)
         await this.duplicate(
           defaultLocale,
           contentType as ContentType,
           fieldType as ContentFieldType
         )
       }
+    }
+    this.warning()
+  }
+
+  async duplicateAssetFiles() {
+    const defaultLocale = await this.manageCms.getDefaultLocale()
+    console.log(`***Duplicating assets`)
+    const assets = await this.cms.assets({ locale: defaultLocale })
+    console.log(` **Duplicating ${assets.length} assets`)
+    for (const a of assets) {
+      await this.manageCms.copyAssetFile(
+        this.manageContext,
+        a.id,
+        defaultLocale
+      )
+    }
+    this.warning()
+  }
+
+  private warning() {
+    if (this.manageContext.preview) {
+      console.warn('Remember to publish the entries from contentful.com')
     }
   }
 
@@ -162,7 +184,7 @@ export class ReferenceFieldDuplicator {
       locale: defaultLocale,
     })
     for (const content of contents) {
-      console.log(`  *Duplicating ${content.id} (${content.name})`)
+      //console.log(`  *Duplicating ${content.id} (${content.name})`)
       await this.manageCms.copyField(
         this.manageContext,
         new ContentId(contentType, content.id),

--- a/packages/botonic-plugin-contentful/src/tools/l10n/locale-migrate.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/locale-migrate.ts
@@ -6,6 +6,9 @@ import { SpaceExport } from '../../contentful/export/space-export'
 
 if (process.argv.length < 6 || process.argv[2] == '--help') {
   console.error(`Usage: fromFile toFile fromLocale toLocale [removeLocales]`)
+  console.error(
+    'removeLocales: locales to remove, separated with commas. Eg: en,es'
+  )
   // eslint-disable-next-line no-process-exit
   process.exit(1)
 }
@@ -17,20 +20,16 @@ const toLocale = process.argv[5]
 const removeLocales = process.argv.length > 6 ? process.argv[6] : ''
 
 function main() {
-  try {
-    const spaceExport = SpaceExport.fromJsonFile(fromFile)
-    const migrator = new LocaleMigrator(fromLocale, toLocale)
-    const remover = new LocaleRemover(removeLocales.split(','), toLocale)
-    console.log('Removing locales', remover.removeLocs)
+  const spaceExport = SpaceExport.fromJsonFile(fromFile)
+  const migrator = new LocaleMigrator(fromLocale, toLocale)
+  const remover = new LocaleRemover(removeLocales.split(','), toLocale)
+  console.log('Removing locales', remover.removeLocs)
 
-    migrator.migrate(spaceExport)
-    remover.remove(spaceExport)
+  migrator.migrate(spaceExport)
+  remover.remove(spaceExport)
 
-    spaceExport.write(toFile)
-    console.log('done')
-  } catch (e) {
-    console.error(e)
-  }
+  spaceExport.write(toFile)
+  console.log('done')
 }
 
 main()

--- a/packages/botonic-plugin-contentful/tests/contentful/contents/asset.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/contents/asset.test.ts
@@ -1,7 +1,7 @@
 import { testContentful } from '../contentful.helper'
 import { expectImgUrlIs } from './image.test'
 
-const TEST_ASSET_ID = '1T0ntgNJnDUSwz59zGMZO6'
+export const TEST_ASSET_ID = '1T0ntgNJnDUSwz59zGMZO6'
 
 test('TEST: contentful asset', async () => {
   const sut = testContentful()
@@ -10,5 +10,14 @@ test('TEST: contentful asset', async () => {
 
   expectImgUrlIs(asset.url, 'red.jpg')
   expect(asset.type).toEqual('image/jpeg')
+  expect(asset.id).toEqual(TEST_ASSET_ID)
   expect(asset.details.size).toEqual(2253)
+})
+
+test('TEST: contentful assets', async () => {
+  const sut = testContentful()
+
+  const assets = await sut.assets()
+  expect(assets.length).toBeGreaterThanOrEqual(3)
+  expect(assets.map(a => a.id)).toContain(TEST_ASSET_ID)
 })

--- a/packages/botonic-plugin-contentful/tests/contentful/delivery.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/delivery.test.ts
@@ -1,5 +1,7 @@
-import { TopContentId, ContentType, MESSAGE_CONTENT_TYPES } from '../../src/cms'
+import { ContentType, MESSAGE_CONTENT_TYPES, TopContentId } from '../../src/cms'
 import { testContentful } from './contentful.helper'
+import { ENGLISH, SPANISH } from '../../src/nlp'
+import { TEST_POST_FAQ1_ID } from './contents/text.test'
 
 const TEST_IMAGE = '3xjvpC7d7PYBmiptEeygfd'
 
@@ -16,3 +18,11 @@ test('TEST: contentful delivery checks that we get the requested message type', 
     }
   }
 }, 10000)
+
+test('TEST: contentful cmsLocale', async () => {
+  const sut = testContentful({ cmsLocale: locale => ENGLISH })
+
+  const text = await sut.text(TEST_POST_FAQ1_ID, { locale: SPANISH })
+
+  expect(text.text).toEqual('How to find your order')
+})

--- a/packages/botonic-plugin-contentful/tests/contentful/ignore-fallback-decorator.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/ignore-fallback-decorator.test.ts
@@ -22,8 +22,9 @@ import {
 export const TEST_BUTTON_BLANK_SPANISH = '40buQOqp9jbwoxmMZhFO16'
 
 function createIgnoreFallbackDecorator() {
+  const options = testContentfulOptions()
   return new IgnoreFallbackDecorator(
-    new AdaptorDeliveryApi(createContentfulClientApi(testContentfulOptions()))
+    new AdaptorDeliveryApi(createContentfulClientApi(options), options)
   )
 }
 

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-asset.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-asset.test.ts
@@ -1,0 +1,24 @@
+import { ENGLISH, SPANISH } from '../../../src/nlp'
+import { testManageContentful } from './manage-contentful.helper'
+import { ManageContext } from '../../../src/manage-cms'
+import { TEST_ASSET_ID } from '../contents/asset.test'
+
+// Since the tests modify contentful contents, they might fail if executed
+// more than once simultaneously (eg from 2 different branches from CI)
+describe('ManageContentful assets', () => {
+  function ctxt(ctx: Partial<ManageContext>): ManageContext {
+    return { ...ctx, preview: false } as ManageContext
+  }
+
+  test('TEST: copyAssetFile', async () => {
+    const sut = testManageContentful()
+
+    try {
+      // ACT
+      await sut.copyAssetFile(ctxt({ locale: SPANISH }), TEST_ASSET_ID, ENGLISH)
+    } finally {
+      // RESTORE
+      await sut.removeAssetFile(ctxt({ locale: SPANISH }), TEST_ASSET_ID)
+    }
+  })
+})

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
@@ -14,7 +14,7 @@ function ctxt(ctx: Partial<ManageContext>): ManageContext {
 
 // Since the tests modify contentful contents, they might fail if executed
 // more than once simultaneously (eg from 2 different branches from CI)
-describe('ManageContentful', () => {
+describe('ManageContentful fields', () => {
   const TEST_MANAGE_CMS_ID = '627QkyJrFo3grJryj0vu6L'
 
   test('TEST: updateField on an empty field', async () => {
@@ -34,7 +34,7 @@ describe('ManageContentful', () => {
         )
       }
       // ACT
-      await sut.updateField<cms.Text>(
+      await sut.updateField(
         ctxt({ locale: SPANISH }),
         old.contentId,
         ContentFieldType.TEXT,
@@ -48,7 +48,7 @@ describe('ManageContentful', () => {
       })
     } finally {
       // RESTORE
-      await sut.updateField<cms.Text>(
+      await sut.updateField(
         ctxt({ locale: SPANISH, allowOverwrites: true }),
         old.contentId,
         ContentFieldType.TEXT,
@@ -104,7 +104,7 @@ describe('ManageContentful', () => {
 
     try {
       // ACT
-      await sut.copyField<cms.Text>(
+      await sut.copyField(
         ctxt({ locale: TO_LOCALE }),
         oldContent.contentId,
         ContentFieldType.BUTTONS,
@@ -120,7 +120,7 @@ describe('ManageContentful', () => {
       })
     } finally {
       // RESTORE
-      await sut.updateField<cms.Text>(
+      await sut.updateField(
         ctxt({ locale: TO_LOCALE, allowOverwrites: true }),
         oldContent.contentId,
         ContentFieldType.BUTTONS,

--- a/packages/botonic-plugin-contentful/tests/nlp/locales.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/locales.test.ts
@@ -1,5 +1,10 @@
-import { preprocess } from '../../src/nlp/locales'
+import { preprocess, rootLocale } from '../../src/nlp/locales'
 
-test('TEST normalize', () => {
-  expect(preprocess('es', ' ÑÇáü òL·l ')).toEqual('ncau ol·l')
+test('TEST preprocess', () => {
+  expect(preprocess('es_ES', ' ÑÇáü òL·l ')).toEqual('ncau ol·l')
+})
+
+test('TEST rootLocale', () => {
+  expect(rootLocale('es_ES')).toEqual('es')
+  expect(rootLocale('en')).toEqual('en')
 })

--- a/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
@@ -10,7 +10,10 @@ import {
 
 test('TEST: sut.normalize stopWord', () => {
   const sut = new Normalizer(undefined, { es: ['stopWórd'] })
-  expect(sut.normalize('es', 'no digas STOPword').stems).toEqual(['no', 'dec'])
+  expect(sut.normalize('es_ES', 'no digas STOPword').stems).toEqual([
+    'no',
+    'dec',
+  ])
 })
 
 test.each<any>([

--- a/packages/botonic-plugin-contentful/tests/tools/l10n/csv-import.test.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/l10n/csv-import.test.ts
@@ -61,6 +61,16 @@ test('TEST: CsvImport read text & carousel', async () => {
 test('TEST: StringFieldImporter test', async () => {
   // using manual mock because mockito was not recognizing the call. maybe because method returns Promise to void?
   class MockCms implements ManageCms {
+    copyAssetFile(
+      context: ManageContext,
+      assetId: string,
+      fromLocale: string
+    ): Promise<void> {
+      fail("shouldn't be called")
+    }
+    removeAssetFile(context: ManageContext, assetId: string): Promise<void> {
+      fail("shouldn't be called")
+    }
     numCalls = 0
 
     getDefaultLocale(): Promise<Locale> {


### PR DESCRIPTION
## Description

1. Added support for locales which include the country (eg. es_ES). Now they are preprocessed as the root locale (without the country)

2. Added an option for Contentful plugin to be able to transform the name of the locale when sent to Contentful

## Context

* Sometimes we want to use locales which are not supported by the Contentful. Eg, English language for a non English speaking country. So what we do is using eg. en_DK, but converting to da_DK when calling Contentful APIs.


## Testing

Unit tests and integration tests added