### PR TITLE
fix(react): custom message types to support Reply

### DIFF
--- a/packages/botonic-react/src/components/custom-message.jsx
+++ b/packages/botonic-react/src/components/custom-message.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Message } from './message'
+import { Reply } from './reply'
 import { INPUT } from '@botonic/core'
 
 export const customMessage = ({
@@ -11,12 +12,27 @@ export const customMessage = ({
     <Message {...defaultProps} {...props} type={INPUT.CUSTOM} />
   )
   const WrappedComponent = props => {
-    const { id, ...customMessageProps } = props
+    const { id, children, ...customMessageProps } = props
+    const replies = React.Children.toArray(children).filter(
+      e => e.type === Reply
+    )
+    const childrenWithoutReplies = React.Children.toArray(children).filter(
+      e => ![Reply].includes(e.type)
+    )
     return (
-      <CustomMessage id={id} json={{ ...props, customTypeName: name }}>
+      <CustomMessage
+        id={id}
+        json={{
+          ...customMessageProps,
+          id,
+          children: childrenWithoutReplies,
+          customTypeName: name,
+        }}
+      >
         <CustomMessageComponent {...customMessageProps}>
-          {props.children}
+          {childrenWithoutReplies}
         </CustomMessageComponent>
+        {replies}
       </CustomMessage>
     )
   }


### PR DESCRIPTION
## Description

This PR fixes a crash that happened when using Custom Message Types together with Reply component.

Imagine you have this custom message:

```javascript
import React from 'react'
import { WebchatContext } from '@botonic/react'
import { customMessage } from './custom-message'

class MyMessage extends React.Component {
  static contextType = WebchatContext

  render() {
    return (
      <>
        <button
          onClick={() =>
            this.context.sendText(`Bye!`)
          }
        >Click me!</button>
        <p>{this.props.children}</p>
      </>
    )
  }
}

export default customMessage({
  name: 'my-message',
  component: MyMessage,
})
```

Now you can use it in your actions like this:

```javascript
import React from 'react'
import { Reply } from '@botonic/react'
import MyMessage from '../webchat/MyMessage'

export const CalendarAction = props => (
	<MyMessage>
		Hi
		<Reply payload='p'>Peperoni</Reply>
		<Reply payload='v'>Veggie</Reply>
	</MyMessage>
)
```

## Context

This problem was reported by some of our partners and users in our Slack channel

## Approach taken / Explain the design

I used the same approach that `@botonic/react/src/components/services message.jsx`

## To documentate / Usage example

See above

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
