### PR TITLE
fix(contentful): schedule was miscalculating around midnight

### DIFF
--- a/packages/botonic-plugin-contentful/jest.setup.js
+++ b/packages/botonic-plugin-contentful/jest.setup.js
@@ -4,4 +4,4 @@
 // In the future we should run independently integration and unit tests
 jest.setTimeout(15000)
 // uncomment to extend jest test timeout while debugging from IDE
-jest.setTimeout(3000000)
+// jest.setTimeout(3000000)

--- a/packages/botonic-plugin-contentful/src/time/timezones.ts
+++ b/packages/botonic-plugin-contentful/src/time/timezones.ts
@@ -1,0 +1,15 @@
+import momentTz from 'moment-timezone'
+
+/**
+ * @return the offset of specified timezone with respect to offset of local timezone
+ * at specified date
+ */
+export function offsetWithTimeZone(
+  timeZone: momentTz.MomentZone,
+  date: Date
+): number {
+  const offset =
+    new Date(date.getTime()).getTimezoneOffset() -
+    timeZone.utcOffset(date.getTime())
+  return offset * 60 * 1000
+}

--- a/packages/botonic-plugin-contentful/tests/contentful/contents/date-range.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/contents/date-range.test.ts
@@ -1,26 +1,7 @@
 import { testContentful } from '../contentful.helper'
+import { cetDate } from '../../time/time.helper'
 
 const TEST_DATE_RANGE_HUBTYPE_ID = '46taK0TceR2OZ8issCMhB7'
-
-export function cetDate(
-  year: number,
-  month: number,
-  day: number,
-  hour = 0,
-  minute = 0
-): Date {
-  const date = new Date(Date.UTC(year, month, day, hour, minute, 0))
-
-  const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }))
-  const tzDate = new Date(
-    date.toLocaleString('en-US', { timeZone: 'Europe/Madrid' })
-  )
-  const offset = utcDate.getTime() - tzDate.getTime()
-
-  date.setTime(date.getTime() + offset)
-
-  return date
-}
 
 test('TEST: contentful dateRange', async () => {
   const dateRange = await testContentful().dateRange(TEST_DATE_RANGE_HUBTYPE_ID)

--- a/packages/botonic-plugin-contentful/tests/contentful/contents/date-range.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/contents/date-range.test.ts
@@ -2,7 +2,7 @@ import { testContentful } from '../contentful.helper'
 
 const TEST_DATE_RANGE_HUBTYPE_ID = '46taK0TceR2OZ8issCMhB7'
 
-function europeDate(
+export function cetDate(
   year: number,
   month: number,
   day: number,
@@ -26,6 +26,6 @@ test('TEST: contentful dateRange', async () => {
   const dateRange = await testContentful().dateRange(TEST_DATE_RANGE_HUBTYPE_ID)
 
   expect(dateRange.common.name).toEqual('Test DateRange name')
-  expect(dateRange.dateRange.from).toEqual(europeDate(2019, 4, 26, 20, 30))
-  expect(dateRange.dateRange.to).toEqual(europeDate(2019, 8, 1))
+  expect(dateRange.dateRange.from).toEqual(cetDate(2019, 4, 26, 20, 30))
+  expect(dateRange.dateRange.to).toEqual(cetDate(2019, 8, 1))
 })

--- a/packages/botonic-plugin-contentful/tests/time/schedule.test.ts
+++ b/packages/botonic-plugin-contentful/tests/time/schedule.test.ts
@@ -6,6 +6,7 @@ import {
   TimeRange,
   WeekDay,
 } from '../../src/time/schedule'
+import { cetDate, nyDate } from './time.helper'
 
 const MARCH = 2
 const APRIL = 3
@@ -16,54 +17,24 @@ test('TEST ScheduleAlwaysOn', () => {
   expect(sut.contains(new Date())).toEqual(true)
 })
 
-function utcDate(
-  year: number,
-  month: number,
-  day: number,
-  hour = 0,
-  minute = 0
-): Date {
-  return new Date(Date.UTC(year, month, day, hour, minute, 0))
-}
-
-function europeDate(
-  year: number,
-  month: number,
-  day: number,
-  hour = 0,
-  minute = 0
-): Date {
-  const date = new Date(Date.UTC(year, month, day, hour, minute, 0))
-
-  const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }))
-  const tzDate = new Date(
-    date.toLocaleString('en-US', { timeZone: 'Europe/Madrid' })
-  )
-  const offset = utcDate.getTime() - tzDate.getTime()
-
-  date.setTime(date.getTime() + offset)
-
-  return date
-}
-
 test.each<any>([
   // Friday winter time
-  [europeDate(2019, MARCH, 29, 8, 59), false],
-  [europeDate(2019, MARCH, 29, 9, 0), true],
-  [europeDate(2019, MARCH, 29, 18, 59), true],
-  [europeDate(2019, MARCH, 29, 19, 0), false],
+  [cetDate(2019, MARCH, 29, 8, 59), false],
+  [cetDate(2019, MARCH, 29, 9, 0), true],
+  [cetDate(2019, MARCH, 29, 18, 59), true],
+  [cetDate(2019, MARCH, 29, 19, 0), false],
   // Saturday winter time
-  [europeDate(2019, MARCH, 30, 9, 59), false],
-  [europeDate(2019, MARCH, 30, 10, 0), true],
-  [europeDate(2019, MARCH, 30, 15, 59), true],
-  [europeDate(2019, MARCH, 30, 16, 0), false],
+  [cetDate(2019, MARCH, 30, 9, 59), false],
+  [cetDate(2019, MARCH, 30, 10, 0), true],
+  [cetDate(2019, MARCH, 30, 15, 59), true],
+  [cetDate(2019, MARCH, 30, 16, 0), false],
   // Sunday (directly discarded because there's no service on Sunday)
-  [europeDate(2019, MARCH, 31, rand(0, 23), rand(0, 59)), false],
+  [cetDate(2019, MARCH, 31, rand(0, 23), rand(0, 59)), false],
   // Monday summer time
-  [europeDate(2019, APRIL, 1, 8, 59), false],
-  [europeDate(2019, APRIL, 1, 9, 0), true],
-  [europeDate(2019, APRIL, 1, 18, 59), true],
-  [europeDate(2019, APRIL, 1, 19, 0), false],
+  [cetDate(2019, APRIL, 1, 8, 59), false],
+  [cetDate(2019, APRIL, 1, 9, 0), true],
+  [cetDate(2019, APRIL, 1, 18, 59), true],
+  [cetDate(2019, APRIL, 1, 19, 0), false],
 ])('TEST: Schedule.contains(%s)=>%s', (date: Date, expected: boolean) => {
   const sut = new Schedule(Schedule.TZ_CET)
 
@@ -88,7 +59,7 @@ test.each<any>([
 test('TEST: HourAndMinute.compareToDate', () => {
   const time = new HourAndMinute(13, 45)
 
-  const date = europeDate(2019, 5, 29, 13, 46)
+  const date = new Date(2019, 5, 29, 13, 46)
 
   expect(time.compareToDate(date)).toEqual(-1)
 
@@ -102,42 +73,42 @@ test('TEST: HourAndMinute.compareToDate', () => {
 test('TEST: timeInThisTimezone ', () => {
   const sut = new Schedule('Europe/London')
 
-  const date = europeDate(2019, 5, 29, 0, 51)
+  const date = cetDate(2019, 5, 29, 0, 51)
   expect(sut.timeInThisTimezone('es', date)).toEqual('23:51:00')
 })
 
 test('TEST: ends at midnight', () => {
-  const sut = new Schedule('Europe/Madrid')
+  const sut = new Schedule('America/New_York')
   sut.addDaySchedule(
     WeekDay.WEDNESDAY,
     new DaySchedule([
       new TimeRange(sut.createHourAndMinute(10), sut.createHourAndMinute(0)),
     ])
   )
-  const date9h = europeDate(2019, NOVEMBER, 27, 9)
+  const date9h = nyDate(2019, NOVEMBER, 27, 9)
   expect(sut.contains(date9h)).toBeFalsy()
-  const date23h = europeDate(2019, NOVEMBER, 27, 23, 59)
+  const date23h = nyDate(2019, NOVEMBER, 27, 23, 59)
   expect(sut.contains(date23h)).toBeTruthy()
 })
 
 test('TEST: ends at 1am', () => {
-  const sut = new Schedule('UTC')
+  const sut = new Schedule('America/New_York')
   sut.addDaySchedule(
     WeekDay.THURSDAY,
     new DaySchedule([
       new TimeRange(sut.createHourAndMinute(23), sut.createHourAndMinute(0)),
     ])
   )
-  const midnight = utcDate(2019, NOVEMBER, 28, 23, 0)
+  const midnight = nyDate(2019, NOVEMBER, 28, 23, 0)
   expect(sut.contains(midnight)).toBeTruthy()
-  const lastMinute = utcDate(2019, NOVEMBER, 28, 23, 59)
+  const lastMinute = nyDate(2019, NOVEMBER, 28, 23, 59)
   expect(sut.contains(lastMinute)).toBeTruthy()
-  const after = utcDate(2019, NOVEMBER, 29, 0, 0)
+  const after = nyDate(2019, NOVEMBER, 29, 0, 0)
   expect(sut.contains(after)).toBeFalsy()
 })
 
 test('TEST: addException', () => {
-  const sut = new Schedule('Europe/Madrid')
+  const sut = new Schedule('America/New_York')
   sut.addDaySchedule(
     WeekDay.FRIDAY,
     new DaySchedule([
@@ -145,9 +116,9 @@ test('TEST: addException', () => {
     ])
   )
 
-  const date10h = europeDate(2019, MARCH, 29, 10)
+  const date10h = nyDate(2019, MARCH, 29, 10)
   expect(sut.contains(date10h)).toBeTruthy()
-  const date12h = europeDate(2019, MARCH, 29, 12)
+  const date12h = nyDate(2019, MARCH, 29, 12)
   expect(sut.contains(date12h)).toBeFalsy()
 
   sut.addException(
@@ -161,7 +132,7 @@ test('TEST: addException', () => {
 })
 
 test('TEST: addException start day', () => {
-  const sut = new Schedule('Europe/Madrid')
+  const sut = new Schedule('America/New_York')
   sut.addDaySchedule(
     WeekDay.FRIDAY,
     new DaySchedule([
@@ -170,23 +141,23 @@ test('TEST: addException start day', () => {
   )
 
   sut.addException(
-    europeDate(2019, MARCH, 29),
+    nyDate(2019, MARCH, 29),
     new DaySchedule([
       new TimeRange(sut.createHourAndMinute(0), sut.createHourAndMinute(1)),
       new TimeRange(sut.createHourAndMinute(11), sut.createHourAndMinute(13)),
     ])
   )
-  expect(sut.contains(europeDate(2019, MARCH, 28, 23, 59))).toBeFalsy()
-  expect(sut.contains(europeDate(2019, MARCH, 29, 0, 0))).toBeTruthy()
-  expect(sut.contains(europeDate(2019, MARCH, 29, 0, 15))).toBeTruthy()
-  expect(sut.contains(europeDate(2019, MARCH, 29, 1, 0))).toBeFalsy()
-  expect(sut.contains(europeDate(2019, MARCH, 29, 1, 1))).toBeFalsy()
-  expect(sut.contains(europeDate(2019, MARCH, 29, 23, 59))).toBeFalsy()
-  expect(sut.contains(europeDate(2019, MARCH, 30, 0, 0))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 28, 23, 59))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 29, 0, 0))).toBeTruthy()
+  expect(sut.contains(nyDate(2019, MARCH, 29, 0, 15))).toBeTruthy()
+  expect(sut.contains(nyDate(2019, MARCH, 29, 1, 0))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 29, 1, 1))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 29, 23, 59))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 30, 0, 0))).toBeFalsy()
 })
 
 test('TEST: addException end day', () => {
-  const sut = new Schedule('Europe/Madrid')
+  const sut = new Schedule('America/New_York')
   sut.addDaySchedule(
     WeekDay.FRIDAY,
     new DaySchedule([
@@ -195,7 +166,7 @@ test('TEST: addException end day', () => {
   )
 
   sut.addException(
-    europeDate(2019, MARCH, 29, 1), //Friday //BUG this do not work when hour is 0 executed on github actions
+    nyDate(2019, MARCH, 29, 1), //Friday //BUG this do not work when hour is 0 executed on github actions
     new DaySchedule([
       new TimeRange(
         sut.createHourAndMinute(23),
@@ -204,13 +175,13 @@ test('TEST: addException end day', () => {
     ])
   )
 
-  expect(sut.contains(europeDate(2019, MARCH, 28, 23, 15))).toBeFalsy()
-  expect(sut.contains(europeDate(2019, MARCH, 29, 22, 59))).toBeFalsy()
-  expect(sut.contains(europeDate(2019, MARCH, 29, 23, 0))).toBeTruthy()
-  expect(sut.contains(europeDate(2019, MARCH, 29, 23, 29))).toBeTruthy()
-  expect(sut.contains(europeDate(2019, MARCH, 29, 23, 30))).toBeFalsy()
-  expect(sut.contains(europeDate(2019, MARCH, 30, 0, 0))).toBeFalsy()
-  expect(sut.contains(europeDate(2019, MARCH, 30, 23, 15))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 28, 23, 15))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 29, 22, 59))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 29, 23, 0))).toBeTruthy()
+  expect(sut.contains(nyDate(2019, MARCH, 29, 23, 29))).toBeTruthy()
+  expect(sut.contains(nyDate(2019, MARCH, 29, 23, 30))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 30, 0, 0))).toBeFalsy()
+  expect(sut.contains(nyDate(2019, MARCH, 30, 23, 15))).toBeFalsy()
 })
 
 test('TEST: time.toString ', () => {

--- a/packages/botonic-plugin-contentful/tests/time/time.helper.ts
+++ b/packages/botonic-plugin-contentful/tests/time/time.helper.ts
@@ -1,0 +1,38 @@
+export function cetDate(
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0
+): Date {
+  return timeFor('Europe/Madrid', year, month, day, hour, minute)
+}
+
+export function nyDate(
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0
+): Date {
+  return timeFor('America/New_York', year, month, day, hour, minute)
+}
+
+export function timeFor(
+  timeZone: string,
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0
+): Date {
+  const date = new Date(Date.UTC(year, month, day, hour, minute, 0))
+
+  const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }))
+  const tzDate = new Date(date.toLocaleString('en-US', { timeZone }))
+  const offset = utcDate.getTime() - tzDate.getTime()
+
+  date.setTime(date.getTime() + offset)
+
+  return date
+}

--- a/packages/botonic-plugin-contentful/tests/time/timezones.test.ts
+++ b/packages/botonic-plugin-contentful/tests/time/timezones.test.ts
@@ -1,0 +1,14 @@
+import momentTz from 'moment-timezone'
+import { cetDate } from '../contentful/contents/date-range.test'
+import { offsetWithTimeZone } from '../../src/time/timezones'
+
+test('TEST offsetWithTimeZone', () => {
+  const date = cetDate(2020, 1, 1, 0)
+
+  // act
+  const offset1 = offsetWithTimeZone(momentTz.tz.zone('Europe/London')!, date)
+  const offset2 = offsetWithTimeZone(momentTz.tz.zone('Europe/Madrid')!, date)
+
+  // assert
+  expect(offset2 - offset1).toEqual(60 * 60 * 1000)
+})

--- a/packages/botonic-plugin-contentful/tests/time/timezones.test.ts
+++ b/packages/botonic-plugin-contentful/tests/time/timezones.test.ts
@@ -1,6 +1,6 @@
 import momentTz from 'moment-timezone'
-import { cetDate } from '../contentful/contents/date-range.test'
 import { offsetWithTimeZone } from '../../src/time/timezones'
+import { cetDate } from './time.helper'
 
 test('TEST offsetWithTimeZone', () => {
   const date = cetDate(2020, 1, 1, 0)


### PR DESCRIPTION
## Description
Fix bug in Contentful Schedule, where schedule was miscalculating around midnight. It was not taking the timezone offset into account to calculate the weekday.


## Context

Bug only afftected for schedules which are open after midnight.

## Approach taken / Explain the design

Since JS does not allow setting the TZ of a date, I had to apply the offset to a date and check weekday on it.

## Testing

-  has unit tests
