### PR TITLE
Botonic Core - Export getAvailableAgentsByQueue

### DIFF
--- a/packages/botonic-core/src/handoff.js
+++ b/packages/botonic-core/src/handoff.js
@@ -152,7 +152,6 @@ export async function getAvailableAgentsByQueue(session, queueId) {
     },
     method: 'post',
     url: `${baseUrl}/v1/queues/${queueId}/get_available_agents/`,
-    data: { queue_id: queueId },
   })
   return resp.data
 }

--- a/packages/botonic-core/src/index.js
+++ b/packages/botonic-core/src/index.js
@@ -6,6 +6,7 @@ export {
   HandOffBuilder,
   storeCaseRating,
   getAvailableAgents,
+  getAvailableAgentsByQueue,
   getAgentVacationRanges,
   cancelHandoff,
   deleteUser,


### PR DESCRIPTION
## Description
Added the export of `getAvailableAgentsByQueue` and remove no needed body from request.

## Context
Couldn't use the method `getAvailableAgentsByQueue` because was not exported.

## Approach taken / Explain the design

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
