### PR TITLE
fix(contentful): MultiEnvironmentFactory to clone functions in options

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.14.0-alpha.1",
+  "version": "0.14.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -15,7 +15,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.14.0-alpha.1",
+  "version": "0.14.0-alpha.2",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/botonic-plugin-contentful/src/contentful/multi-environment.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/multi-environment.ts
@@ -4,6 +4,7 @@ import { CMS } from '../cms'
 import { Locale } from '../nlp'
 import { ContentfulCredentials, ContentfulOptions } from '../plugin'
 import { Contentful } from './cms-contentful'
+import { shallowClone } from '../util'
 
 /**
  * Set it to ContentfulOptions.contentfulFactory to connect to
@@ -50,12 +51,11 @@ export class MultiEnvironmentFactory {
     const locale = ctx!.locale!
     let cms = this.cache.get(locale)
     if (!cms) {
-      const opts: ContentfulOptions = {
-        ...contOptions,
-        spaceId: credentials.spaceId,
-        environment: credentials.environment,
-        accessToken: credentials.accessToken,
-      }
+      const opts = shallowClone(contOptions)
+      opts.spaceId = credentials.spaceId
+      opts.environment = credentials.environment
+      opts.accessToken = credentials.accessToken
+
       cms = this.contentfulFactory(opts)
       this.cache.set(locale, cms)
     }

--- a/packages/botonic-plugin-contentful/tests/contentful/multi-environment.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/multi-environment.test.ts
@@ -1,7 +1,7 @@
-import { testContentfulOptions } from './contentful.helper'
+import { testContentful, testContentfulOptions } from './contentful.helper'
 import { CMS } from '../../src/cms'
 import { MultiEnvironmentFactory } from '../../src/contentful/multi-environment'
-import { ContentfulOptions } from '../../src'
+import { ContentfulOptions, Locale } from '../../src'
 import { instance, mock } from 'ts-mockito'
 
 test('TEST MultiEnvironmentFactory', () => {
@@ -40,4 +40,34 @@ test('TEST MultiEnvironmentFactory', () => {
 
   // Act/Assert no context returns default CMS
   expect(sut.get(opts, undefined)).toBe(defaultCMS)
+})
+
+test('TEST MultiEnvironmentFactory keeps functions in options', () => {
+  // Arrange
+  const cms = testContentful()
+  class MyContentfulOptions implements ContentfulOptions {
+    cmsLocale(locale?: Locale): Locale | undefined {
+      return locale
+    }
+
+    accessToken = 'token'
+    spaceId = 'spaceId'
+  }
+
+  const sut = new MultiEnvironmentFactory(
+    undefined,
+    (opts: ContentfulOptions) => {
+      // since MultiEnvironmentFactory clones the ContentfulOptions, we want to make
+      // sure that it keeps their functions
+      expect(opts.cmsLocale!('kk')).toEqual('kk')
+      return cms
+    }
+  )
+
+  // act
+  const created = sut.get(new MyContentfulOptions())
+
+  // assert
+  expect(created).toBe(cms)
+  expect.assertions(2)
 })


### PR DESCRIPTION
ContentfulOptions.cmsLocale was lost in MultiEnvironmentFactory because we were cloning
the options fields but not its functions

## Testing

The pull request...

-  has unit tests
