### PR TITLE
Contentful/async error reporting

### DIFF
--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -37,63 +37,63 @@ export class ErrorReportingCMS implements CMS {
   carousel(id: string, context?: Context): Promise<Carousel> {
     return this.cms
       .carousel(id, context)
-      .catch(this.handleDeliveryError(ContentType.CAROUSEL, id))
+      .catch(this.handleDeliveryError(ContentType.CAROUSEL, context, id))
       .then(ErrorReportingCMS.validate)
   }
 
   text(id: string, context?: Context): Promise<Text> {
     return this.cms
       .text(id, context)
-      .catch(this.handleDeliveryError(ContentType.TEXT, id))
+      .catch(this.handleDeliveryError(ContentType.TEXT, context, id))
       .then(ErrorReportingCMS.validate)
   }
 
   chitchat(id: string, context?: Context): Promise<Chitchat> {
     return this.cms
       .text(id, context)
-      .catch(this.handleDeliveryError(ContentType.CHITCHAT, id))
+      .catch(this.handleDeliveryError(ContentType.CHITCHAT, context, id))
       .then(ErrorReportingCMS.validate)
   }
 
   startUp(id: string, context?: Context): Promise<StartUp> {
     return this.cms
       .startUp(id, context)
-      .catch(this.handleDeliveryError(ContentType.STARTUP, id))
+      .catch(this.handleDeliveryError(ContentType.STARTUP, context, id))
       .then(ErrorReportingCMS.validate)
   }
 
   url(id: string, context?: Context): Promise<Url> {
     return this.cms
       .url(id, context)
-      .catch(this.handleDeliveryError(ContentType.URL, id))
+      .catch(this.handleDeliveryError(ContentType.URL, context, id))
       .then(ErrorReportingCMS.validate)
   }
 
   image(id: string, context?: Context): Promise<Image> {
     return this.cms
       .image(id, context)
-      .catch(this.handleDeliveryError(ContentType.IMAGE, id))
+      .catch(this.handleDeliveryError(ContentType.IMAGE, context, id))
       .then(ErrorReportingCMS.validate)
   }
 
   queue(id: string, context?: Context): Promise<Queue> {
     return this.cms
       .queue(id, context)
-      .catch(this.handleDeliveryError(ContentType.QUEUE, id))
+      .catch(this.handleDeliveryError(ContentType.QUEUE, context, id))
       .then(ErrorReportingCMS.validate)
   }
 
   button(id: string, context?: Context): Promise<Button> {
     return this.cms
       .button(id, context)
-      .catch(this.handleDeliveryError(ContentType.BUTTON, id))
+      .catch(this.handleDeliveryError(ContentType.BUTTON, context, id))
       .then(ErrorReportingCMS.validate)
   }
 
   element(id: string, context?: Context): Promise<Element> {
     return this.cms
       .element(id, context)
-      .catch(this.handleDeliveryError(ContentType.ELEMENT, id))
+      .catch(this.handleDeliveryError(ContentType.ELEMENT, context, id))
       .then(ErrorReportingCMS.validate)
   }
 
@@ -126,31 +126,44 @@ export class ErrorReportingCMS implements CMS {
   schedule(id: string, context?: Context): Promise<ScheduleContent> {
     return this.cms
       .schedule(id, context)
-      .catch(this.handleDeliveryError(ContentType.SCHEDULE, id))
+      .catch(this.handleDeliveryError(ContentType.SCHEDULE, context, id))
   }
 
   dateRange(id: string, context?: Context): Promise<DateRangeContent> {
     return this.cms
       .dateRange(id, context)
-      .catch(this.handleDeliveryError(ContentType.DATE_RANGE, id))
+      .catch(this.handleDeliveryError(ContentType.DATE_RANGE, context, id))
   }
 
   asset(id: string, context?: Context): Promise<Asset> {
-    return this.cms.asset(id, context).catch(this.handleError('asset', id))
+    return this.cms
+      .asset(id, context)
+      .catch(this.handleError('asset', context, id))
   }
 
   private handleDeliveryError(
     contentType: ContentType,
+    context: Context | undefined,
     id: string
   ): (reason: any) => never {
     return (reason: any) => {
-      throw this.exceptionWrapper.wrap(reason, contentType, undefined, id)
+      throw this.exceptionWrapper.wrap(
+        reason,
+        contentType,
+        undefined,
+        context,
+        id
+      )
     }
   }
 
-  private handleError(method: string, id?: string): (reason: any) => never {
+  private handleError(
+    method: string,
+    context?: Context,
+    id?: string
+  ): (reason: any) => never {
     return (reason: any) => {
-      throw this.exceptionWrapper.wrap(reason, method, undefined, id)
+      throw this.exceptionWrapper.wrap(reason, method, undefined, context, id)
     }
   }
 }
@@ -167,11 +180,15 @@ export class ContentfulExceptionWrapper {
     contentfulError: any,
     method: string,
     contentType?: ContentType,
+    context?: Context,
     contentId?: string
   ): CmsException {
     let content = ''
     if (contentType) {
       content += ` on '${contentType}'`
+    }
+    if (context?.locale) {
+      content += ` with locale '${context.locale}'`
     }
     if (contentId) {
       content += ` with id '${contentId}'`

--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -19,6 +19,8 @@ import {
 import { Context } from './context'
 import { CmsException } from './exceptions'
 import { SearchCandidate } from '../search'
+import { MultiError } from 'async-parallel'
+import { reduceMultiError } from '../util/async'
 
 export class ErrorReportingCMS implements CMS {
   exceptionWrapper = new ContentfulExceptionWrapper('CMS')
@@ -179,7 +181,14 @@ export class ContentfulExceptionWrapper {
     if (this.logErrors) {
       console.error(exception.toString())
       if (this.logStack) {
-        console.error('due to', contentfulError)
+        if (contentfulError instanceof MultiError) {
+          console.error('due to:')
+          for (const e of reduceMultiError(contentfulError)) {
+            console.error(e.message)
+          }
+        } else {
+          console.error('due to', contentfulError)
+        }
       }
     }
     throw exception

--- a/packages/botonic-plugin-contentful/src/contentful/contents/button.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/button.ts
@@ -147,7 +147,7 @@ export class ButtonDelivery extends ContentDelivery {
       throw new Error('Unexpected type: ' + model)
     } catch (e) {
       throw new CmsException(
-        `Error delivering button with id ${target.sys.id}`,
+        `Error delivering button with id '${target.sys.id}'`,
         e
       )
     }

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
@@ -19,7 +19,7 @@ export class ErrorReportingManageCms implements ManageCms {
   ): Promise<void> {
     return this.manageCms
       .updateField(context, contentId, fieldType, value)
-      .catch(this.handleError('updateField', contentId))
+      .catch(this.handleError('updateField', context, contentId))
   }
 
   copyField<T extends cms.Content>(
@@ -31,11 +31,12 @@ export class ErrorReportingManageCms implements ManageCms {
   ): Promise<void> {
     return this.manageCms
       .copyField(context, contentId, field, fromLocale, onlyIfTargetEmpty)
-      .catch(this.handleError('copyField', contentId))
+      .catch(this.handleError('copyField', context, contentId))
   }
 
   private handleError(
     method: string,
+    context?: ManageContext,
     contentId?: ContentId
   ): (reason: any) => never {
     return (reason: any) => {
@@ -43,6 +44,7 @@ export class ErrorReportingManageCms implements ManageCms {
         reason,
         method,
         contentId?.model,
+        context,
         contentId?.id
       )
     }

--- a/packages/botonic-plugin-contentful/src/tools/validate-all-contents.ts
+++ b/packages/botonic-plugin-contentful/src/tools/validate-all-contents.ts
@@ -1,5 +1,5 @@
 import { CMS, ContextWithLocale, TOP_CONTENT_TYPES } from '../cms'
-import * as Parallel from 'async-parallel'
+import { asyncEach } from '../util/async'
 
 export class ContentsValidator {
   constructor(readonly cms: CMS) {}
@@ -12,12 +12,12 @@ export class ContentsValidator {
    * - There's a bug on the CMS plugin
    */
   async validateAllTopContents(context: ContextWithLocale): Promise<void> {
-    // topContents will internally limit concurrency
-    const concurrency = context.concurrency && 1
-    await Parallel.each(
+    await asyncEach(
+      context,
       TOP_CONTENT_TYPES,
       ct => this.cms.topContents(ct, context),
-      concurrency
+      // topContents will internally manage concurrency
+      1
     )
   }
 }

--- a/packages/botonic-plugin-contentful/tests/cms/cms-error.test.ts
+++ b/packages/botonic-plugin-contentful/tests/cms/cms-error.test.ts
@@ -1,5 +1,11 @@
-import { instance, mock, when } from 'ts-mockito'
-import { Carousel, CmsException, DummyCMS, ErrorReportingCMS } from '../../src'
+import { anything, instance, mock, when } from 'ts-mockito'
+import {
+  Carousel,
+  CmsException,
+  DummyCMS,
+  ErrorReportingCMS,
+  SPANISH,
+} from '../../src'
 import { testContentful } from '../contentful/contentful.helper'
 
 test('TEST: ErrorReportingCMS integration test', async () => {
@@ -11,7 +17,7 @@ test('TEST: ErrorReportingCMS integration test', async () => {
   })
 })
 
-test('TEST: ErrorReportingCMS carousel delivery failed', async () => {
+test('TEST: ErrorReportingCMS content delivery failed', async () => {
   const mockCms = mock(DummyCMS)
   const error = new Error('mock error')
   when(mockCms.carousel('id1', undefined)).thenReject(error)
@@ -25,6 +31,21 @@ test('TEST: ErrorReportingCMS carousel delivery failed', async () => {
     .catch((error2: any) => {
       expect(error2).toEqual(
         new CmsException("Error calling CMS.carousel with id 'id1'.", error)
+      )
+    })
+
+  when(mockCms.text('id1', anything())).thenReject(error)
+  await sut
+    .text('id1', { locale: SPANISH })
+    .then(text => {
+      throw Error('should have thrown')
+    })
+    .catch((error2: any) => {
+      expect(error2).toEqual(
+        new CmsException(
+          "Error calling CMS.text with locale 'es' with id 'id1'.",
+          error
+        )
       )
     })
 })

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
@@ -80,7 +80,7 @@ describe('ManageContentful fields', () => {
       if (e instanceof CmsException) {
         // eslint-disable-next-line jest/no-try-expect
         expect(e.message).toInclude(
-          "Error calling ManageCms.updateField on 'button' with id '627QkyJrFo3grJryj0vu6L'."
+          "Error calling ManageCms.updateField on 'button' with locale 'en' with id '627QkyJrFo3grJryj0vu6L'."
         )
         // eslint-disable-next-line jest/no-try-expect
         expect(e.reason.message).toInclude('Cannot overwrite')

--- a/packages/botonic-plugin-contentful/tests/tools/validate-all-contents.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/validate-all-contents.ts
@@ -1,0 +1,8 @@
+import { ContentsValidator } from '../../src/tools/validate-all-contents'
+import { testContentful } from '../contentful/contentful.helper'
+
+test('ContentsValidator', async () => {
+  const contentful = testContentful()
+  const sut = new ContentsValidator(contentful)
+  await sut.validateAllTopContents({ locale: 'es' })
+})


### PR DESCRIPTION

## Description

* When promises executed with async-parallel library, retrieve the list of error occurred for each item and included in the top thrown exception
* Show locale in Error Reporting decorator
* flag to optionally log CMS calls 

## Context

* Users typically leave inconsistent contents in contentful. This PR provide way to report with detail all discovered issues

## To documentate / Usage example

New logCalls flag in Contentful plugin config to log each call performed to contentful (useful during debugging)

## Testing

-  has unit tests
