### PR TITLE
Add key prop to WrappedComponent for customMessages

### DIFF
--- a/packages/botonic-react/src/components/custom-message.jsx
+++ b/packages/botonic-react/src/components/custom-message.jsx
@@ -23,7 +23,7 @@ export const customMessage = ({
   WrappedComponent.customTypeName = name
   // eslint-disable-next-line react/display-name
   WrappedComponent.deserialize = msg => (
-    <WrappedComponent id={msg.id} json={msg.data} {...msg.data} />
+    <WrappedComponent id={msg.id} key={msg.key} json={msg.data} {...msg.data} />
   )
   return WrappedComponent
 }


### PR DESCRIPTION
## Description
Add `key` prop to `WrappedComponent` for `customMessages` in order to avoid getting the warning of:

> Warning: Each child in a list should have a unique "key" prop

## Context
When calling `msgsToBotonic()` to render multiple messages using a customMessage no key was set in the wrapping element for the customMessage and a warning was appearing in console.
 
## Approach taken / Explain the design
Added the `key` prop with the `msg.key` value to `WrappedComponent`.

## To documentate / Usage example

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [x] doesn't need tests because it's only a basic prop addition
