### PR TITLE
feat(contentful): content validator only if reachable

### DIFF
--- a/packages/botonic-plugin-contentful/src/cms/context.ts
+++ b/packages/botonic-plugin-contentful/src/cms/context.ts
@@ -20,6 +20,12 @@ export interface Context {
    * If not specified, the contents will use as much parallelism as possible.
    */
   concurrency?: number
+
+  /**
+   * Eg. If a button cannot show any text because the content has no shortText, show its name
+   * True by default
+   */
+  fixMissingData?: boolean
 }
 
 export interface ContextWithLocale extends Context {

--- a/packages/botonic-plugin-contentful/src/cms/visitors/message-visitors.ts
+++ b/packages/botonic-plugin-contentful/src/cms/visitors/message-visitors.ts
@@ -1,0 +1,61 @@
+import { Carousel, MessageContent, Text, StartUp, Button } from '../contents'
+import { CMS, CmsException, Context } from '../'
+
+export function getButtons(content: MessageContent): Button[] {
+  if (content instanceof Carousel) {
+    return Array.prototype.concat(...content.elements.map(e => e.buttons))
+  }
+  if (content instanceof Text || content instanceof StartUp) {
+    return content.buttons
+  }
+  return []
+}
+
+/**
+ * TODO add cache
+ */
+export class MessageContentTraverser {
+  /**
+   * It does not take care of circular loops
+   * @param depth
+   */
+  constructor(
+    readonly cms: CMS,
+    readonly visitor: (content: MessageContent) => void,
+    readonly depth = 1
+  ) {
+    if (depth > 1) {
+      throw new CmsException('Not supported yet')
+    }
+  }
+
+  async traverse(content: MessageContent, context: Context) {
+    const buttons = getButtons(content)
+    for (const button of buttons) {
+      const contentId = button.callback.asContentId()
+      if (contentId) {
+        const reference = (await contentId.deliver(
+          this.cms,
+          context
+        )) as MessageContent
+        this.visitor(reference)
+      }
+    }
+  }
+}
+
+export async function reachableFrom(
+  cms: CMS,
+  fromContents: MessageContent[],
+  context: Context
+): Promise<Set<MessageContent>> {
+  const reachable = new Set<MessageContent>()
+  const visitor = (content: MessageContent) => {
+    reachable.add(content)
+  }
+  const traverser = new MessageContentTraverser(cms, visitor)
+  for (const fromContent of fromContents) {
+    await traverser.traverse(fromContent, context)
+  }
+  return reachable
+}

--- a/packages/botonic-plugin-contentful/src/contentful/contents/button.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/button.ts
@@ -67,8 +67,9 @@ export class ButtonDelivery extends ContentDelivery {
     const entry = await this.delivery.getEntry(id, context)
     const entryType = ContentfulEntryUtils.getContentModel(entry)
     if (isOfType(entryType, TopContentType)) {
-      return ButtonDelivery.fromContentReference(
-        entry as contentful.Entry<CommonEntryFields>
+      return this.fromContentReference(
+        entry as contentful.Entry<CommonEntryFields>,
+        context
       )
     }
     if (entryType === ButtonDelivery.BUTTON_CONTENT_TYPE) {
@@ -95,12 +96,14 @@ export class ButtonDelivery extends ContentDelivery {
   }
 
   // TODO move to a new CmsUtils.buttonToCallback(cms.ContentCallback)?
-  private static fromContentReference(
-    entry: contentful.Entry<CommonEntryFields>
+  private fromContentReference(
+    entry: contentful.Entry<CommonEntryFields>,
+    context: cms.Context
   ): cms.Button {
     const fields = entry.fields
     let text = fields.shortText
-    if (!text) {
+    const fixMissingData = context.fixMissingData ?? true
+    if (!text && fixMissingData) {
       text = fields.name
       console.error(`Text ${text} without short text`)
     }

--- a/packages/botonic-plugin-contentful/src/manage-cms/fields.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/fields.ts
@@ -8,6 +8,7 @@ export enum ContentFieldType {
   SUBTITLE = 'Subtitle',
   BUTTONS = 'Buttons',
   IMAGE = 'Image',
+  URL = 'URL',
 }
 
 export enum ContentFieldValueType {

--- a/packages/botonic-plugin-contentful/src/tools/validate-all-contents.ts
+++ b/packages/botonic-plugin-contentful/src/tools/validate-all-contents.ts
@@ -1,8 +1,25 @@
-import { CMS, ContextWithLocale, TOP_CONTENT_TYPES } from '../cms'
-import { asyncEach } from '../util/async'
+import {
+  CMS,
+  Context,
+  MessageContent,
+  TOP_CONTENT_TYPES,
+  TopContent,
+} from '../cms'
+import { reachableFrom } from '../cms/visitors/message-visitors'
+
+export function defaultValidationReport(id: string, error: string) {
+  console.log(`${id}: ${error}`)
+}
 
 export class ContentsValidator {
-  constructor(readonly cms: CMS) {}
+  constructor(
+    readonly cms: CMS,
+    readonly report: (
+      id: string,
+      error: string
+    ) => void = defaultValidationReport,
+    readonly onlyValidateReachable = true
+  ) {}
 
   /**
    * Deliver all TopContent's to validate that they won't fail in production.
@@ -10,14 +27,37 @@ export class ContentsValidator {
    * - It has a link to a deleted content
    * - There are infinite loops
    * - There's a bug on the CMS plugin
+   * - An URL has empty URL empty
    */
-  async validateAllTopContents(context: ContextWithLocale): Promise<void> {
-    await asyncEach(
-      context,
-      TOP_CONTENT_TYPES,
-      ct => this.cms.topContents(ct, context),
-      // topContents will internally manage concurrency
-      1
-    )
+  async validateAllTopContents(context: Context): Promise<void> {
+    context = { ...context, fixMissingData: false }
+    const contents: MessageContent[] = []
+    for (const model of TOP_CONTENT_TYPES) {
+      contents.push(
+        ...((await this.cms.topContents(model, context)) as MessageContent[])
+      )
+    }
+    const contentsToValidate = this.onlyValidateReachable
+      ? await this.reachableContents(contents, context)
+      : contents
+    for (const c of contentsToValidate) {
+      this.validate(c)
+    }
+  }
+
+  protected async reachableContents(
+    allContents: MessageContent[],
+    context: Context
+  ): Promise<Iterable<MessageContent>> {
+    const reachable = await reachableFrom(this.cms, allContents, context)
+    allContents.filter(c => c.isSearchable()).forEach(c => reachable.add(c))
+    return reachable
+  }
+
+  protected validate(content: TopContent) {
+    const res = content.validate()
+    if (res) {
+      this.report(content.id, res)
+    }
   }
 }

--- a/packages/botonic-plugin-contentful/tests/tools/validate-all-contents.test.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/validate-all-contents.test.ts
@@ -2,7 +2,7 @@ import { ContentsValidator } from '../../src/tools/validate-all-contents'
 import { testContentful } from '../contentful/contentful.helper'
 
 test('ContentsValidator', async () => {
-  const contentful = testContentful()
+  const contentful = testContentful({})
   const sut = new ContentsValidator(contentful)
   await sut.validateAllTopContents({ locale: 'es' })
 })


### PR DESCRIPTION
## Description

Flag so that  ContentValidator only validates contents which are reachable.
Check empty text in Text contents
 
## Context

Some contents are not available for some locales. We don't want ContentValidator to complain when they have empty fields.

## Approach taken / Explain the design

Added a flag in Context to to automatically fix the buttons when no shortText is available. Setting this flag is now possible to detect these cases.

## To documentate / Usage example

ContentsValidator is a useful class because contentful dashboard allow leaving contents in an inconsistent state.
See how to use in unit test https://github.com/hubtype/botonic/blob/master/packages/botonic-plugin-contentful/tests/tools/validate-all-contents.test.ts

## Testing

- has integration tests
