### PR TITLE
feat(contentful): im/export URLS for translators

### DIFF
--- a/packages/botonic-plugin-contentful/bin/l10n/import-from-translators.sh
+++ b/packages/botonic-plugin-contentful/bin/l10n/import-from-translators.sh
@@ -1,5 +1,4 @@
 #!/bin/zsh
-set -x
 SPACE_ID=$1
 ENVIRONMENT=$2
 DELIVER_TOKEN=$3

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -145,7 +145,7 @@ export class ContentfulEntryUtils {
     const dateRange =
       fields.dateRange && DateRangeDelivery.fromEntry(fields.dateRange)
 
-    return new CommonFields(entry.sys.id, fields.name, {
+    return new CommonFields(entry.sys.id, fields.name || '', {
       keywords: fields.keywords,
       shortText: fields.shortText,
       partitions: fields.partitions,

--- a/packages/botonic-plugin-contentful/src/manage-cms/fields.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/fields.ts
@@ -60,7 +60,7 @@ export const CONTENT_FIELDS = new Map<ContentFieldType, ContentField>(
     new ContentField(ContentFieldType.SUBTITLE, 'subtitle', ContentFieldValueType.STRING),
     new ContentField(ContentFieldType.BUTTONS, 'buttons', ContentFieldValueType.REFERENCE_ARRAY),
     new ContentField(ContentFieldType.IMAGE, 'pic', ContentFieldValueType.ASSET),
-
+    new ContentField(ContentFieldType.URL, 'url', ContentFieldValueType.STRING),
   ]))
 /* eslint-enable prettier/prettier*/
 

--- a/packages/botonic-plugin-contentful/src/tools/l10n/csv-import.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/csv-import.ts
@@ -91,13 +91,17 @@ export class StringFieldImporter {
   constructor(readonly cms: ManageCms, readonly context: ManageContext) {}
 
   async consume(record: Record): Promise<void> {
-    if (!isOfType(record.Model, BotonicContentType)) {
-      console.error(`Bad model ${record.Model}`)
+    if (!isOfType(record.Model, ContentType)) {
+      console.error(
+        `Bad model '${String(record.Model)}'. Should be one of ${String(
+          Object.values(BotonicContentType)
+        )}`
+      )
       return
     }
     const field = CONTENT_FIELDS.get(record.Field)
     if (!field) {
-      console.error(`Bad field ${record.Field}`)
+      console.error(`Bad field '${record.Field}'`)
       return
     }
     const id = new cms.ContentId(record.Model, record.Id)
@@ -140,7 +144,7 @@ export class ReferenceFieldDuplicator {
       [ContentType.ELEMENT]: [ContentFieldType.IMAGE],
     }
     for (const contentType of Object.keys(fields)) {
-      console.log(`***Duplicating contents of type '${contentType}'`)
+      console.log(`***Duplicating reference field of type '${contentType}'`)
       for (const fieldType of (fields as any)[contentType]) {
         console.log(` **Duplicating '${contentType}' fields`)
         await this.duplicate(

--- a/packages/botonic-plugin-contentful/src/tools/l10n/export-csv-for-translators.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/export-csv-for-translators.ts
@@ -1,22 +1,60 @@
-import { CsvExport, skipEmptyStrings } from './csv-export'
+import { CsvExport, I18nField, skipEmptyStrings } from './csv-export'
 import { Locale } from '../../nlp'
 import { ContentfulOptions } from '../../plugin'
 import { Contentful } from '../../contentful/cms-contentful'
+import { ContentFieldType } from '../../manage-cms'
+
+export class PostProcessor {
+  constructor(readonly targetLocale: string) {}
+
+  urlAutoTrans(field: I18nField): I18nField {
+    if (!this.targetLocale || this.targetLocale.length < 5) {
+      return field
+    }
+    if (field.name != ContentFieldType.URL) {
+      return field
+    }
+    const convertCountry = (chunk: string) => {
+      if (chunk.length != 2) {
+        return chunk
+      }
+      const country = this.targetLocale.substr(3).toLowerCase()
+      console.log(
+        `Replacing part of URL '${field.value}': from '${chunk}' to '${country}'`
+      )
+      return country
+    }
+
+    return new I18nField(
+      field.name,
+      field.value.split('/').map(convertCountry).join('/')
+    )
+  }
+}
 
 async function writeCsvForTranslators(
   options: ContentfulOptions,
   locale: Locale,
-  fileName: string
+  fileName: string,
+  targetLocale: Locale | undefined
 ) {
   const cms = new Contentful(options)
-  const exporter = new CsvExport({
-    stringFilter: skipEmptyStrings,
-  })
+  const postProcess = targetLocale ? new PostProcessor(targetLocale) : undefined
+  const exporter = new CsvExport(
+    {
+      stringFilter: skipEmptyStrings,
+    },
+    postProcess
+      ? (field: I18nField) => postProcess!.urlAutoTrans(field)
+      : undefined
+  )
   return await exporter.write(fileName, cms, locale)
 }
 
 if (process.argv.length < 7 || process.argv[2] == '--help') {
-  console.error(`Usage: space_id environment access_token locale filename`)
+  console.error(
+    `Usage: space_id environment access_token locale filename [target_country]`
+  )
   // eslint-disable-next-line no-process-exit
   process.exit(1)
 }
@@ -26,6 +64,7 @@ const environment = process.argv[3]
 const accessToken = process.argv[4]
 const locale = process.argv[5]
 const fileName = process.argv[6]
+const targetLocale = process.argv[7]
 
 async function main() {
   try {
@@ -36,7 +75,8 @@ async function main() {
         environment,
       },
       locale,
-      fileName
+      fileName,
+      targetLocale
     )
     console.log('done')
   } catch (e) {

--- a/packages/botonic-plugin-contentful/src/tools/l10n/import-csv-from-translators.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/import-csv-from-translators.ts
@@ -29,7 +29,7 @@ export enum ImportType {
 
 if (process.argv.length < 10 || process.argv[2] == '--help') {
   console.error(
-    `Usage: space_id environment access_token locale filename [${Object.values(
+    `Usage: space_id environment delivery_token mgmnt_token locale filename [${Object.values(
       ImportType
     ).join('|')}] duplicate_references`
   )

--- a/packages/botonic-plugin-contentful/tests/tools/l10n/__fixtures__/contentful_es-pl.csv
+++ b/packages/botonic-plugin-contentful/tests/tools/l10n/__fixtures__/contentful_es-pl.csv
@@ -2,3 +2,5 @@
 "text";"POST_FAQ1";"id1";"Short text";"from";"válor1"
 "text";"POST_FAQ1";"id1";"Keywords";"from";"kw1;hola,amigo"
 "carousel";"POST_FAQ2";"id2";"Text";"from";"válor2"
+"url";"URL1";"id3";"Short text";"from";"st1"
+"url";"URL1";"id3";"URL";"http://url1";"http://url2"

--- a/packages/botonic-plugin-contentful/tests/tools/l10n/csv-export.test.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/l10n/csv-export.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../src/tools/l10n/csv-export'
 import { testContentful } from '../../../tests/contentful/contentful.helper'
 import { ENGLISH } from '../../../src/nlp'
+import { CommonFields, Url } from '../../../src/cms'
 import { TextBuilder } from '../../../src/cms/factories'
 import sync from 'csv-stringify/lib/sync'
 import { RndButtonsBuilder } from '../../../src/cms/test-helpers'
@@ -31,6 +32,21 @@ test('TEST: ContentToCsvLines.getCsvLines Text', () => {
     ['text', 'name1', 'id1', 'Short text', 'short1'],
     ['text', 'name1', 'id1', 'Keywords', 'kw1;kw2'],
     ['text', 'name1', 'id1', 'Text', 'long text'],
+  ])
+})
+
+test('TEST: ContentToCsvLines.getCsvLines URL', () => {
+  const exporter = new ContentToCsvLines({})
+  const fields = exporter.getCsvLines(
+    new Url(
+      new CommonFields('id1', 'url1name', { shortText: 'st1' }),
+      'http://url1'
+    )
+  )
+  expect(fields).toEqual([
+    ['url', 'url1name', 'id1', 'Short text', 'st1'],
+    ['url', 'url1name', 'id1', 'Keywords', ''],
+    ['url', 'url1name', 'id1', 'URL', 'http://url1'],
   ])
 })
 

--- a/packages/botonic-plugin-contentful/tests/tools/l10n/csv-import.test.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/l10n/csv-import.test.ts
@@ -22,18 +22,18 @@ function ctxt(ctx: Partial<ManageContext>): ManageContext {
   return { ...ctx, preview: false } as ManageContext
 }
 
-test('TEST: CsvImport read text & carousel', async () => {
+test('TEST: CsvImport read text, URL & carousel', async () => {
   const mockFieldImporter = mock<StringFieldImporter>()
   const readLines: Record[] = []
   when(mockFieldImporter.consume(anything())).thenCall((record: Record) => {
     readLines.push(record)
   })
-  const importer = new CsvImport(instance(mockFieldImporter))
+  const importer = new CsvImport(instance(mockFieldImporter), undefined)
   // running for ENGLISH to test contents with empty fields
   await importer.import(`${FIXTURES_BASE}/contentful_es-pl.csv`)
-  expect(readLines.length).toEqual(3)
+  expect(readLines.length).toEqual(5)
   expect(readLines[0]).toEqual({
-    Model: 'text',
+    Model: cms.ContentType.TEXT,
     Code: 'POST_FAQ1',
     Id: 'id1',
     Field: ContentFieldType.SHORT_TEXT,
@@ -41,7 +41,7 @@ test('TEST: CsvImport read text & carousel', async () => {
     to: 'válor1',
   } as Record)
   expect(readLines[1]).toEqual({
-    Model: 'text',
+    Model: cms.ContentType.TEXT,
     Code: 'POST_FAQ1',
     Id: 'id1',
     Field: ContentFieldType.KEYWORDS,
@@ -49,12 +49,28 @@ test('TEST: CsvImport read text & carousel', async () => {
     to: 'kw1;hola,amigo',
   } as Record)
   expect(readLines[2]).toEqual({
-    Model: 'carousel',
+    Model: cms.ContentType.CAROUSEL,
     Code: 'POST_FAQ2',
     Id: 'id2',
     Field: ContentFieldType.TEXT,
     from: 'from',
     to: 'válor2',
+  } as Record)
+  expect(readLines[3]).toEqual({
+    Model: cms.ContentType.URL,
+    Code: 'URL1',
+    Id: 'id3',
+    Field: ContentFieldType.SHORT_TEXT,
+    from: 'from',
+    to: 'st1',
+  } as Record)
+  expect(readLines[4]).toEqual({
+    Model: cms.ContentType.URL,
+    Code: 'URL1',
+    Id: 'id3',
+    Field: ContentFieldType.URL,
+    from: 'http://url1',
+    to: 'http://url2',
   } as Record)
 }, 10000)
 


### PR DESCRIPTION
## Description
* In tools for import/export content texts for translators, we had forgotten the URLs. Now added
* Also, now URLs are automatically converted to the target country. eg. when importing to fr_LU URLs such as https:/.../es/...html are transformed to https:/.../lu/...html

## Testing

The pull request...

- [has unit tests
