### PR TITLE
fix(react): fix change button text color on hover

### DIFF
--- a/packages/botonic-react/src/components/button.jsx
+++ b/packages/botonic-react/src/components/button.jsx
@@ -79,7 +79,7 @@ export const Button = props => {
       ? getThemeProperty('button.hoverBackground', COLORS.CONCRETE_WHITE)
       : getThemeProperty('button.style.background', COLORS.SOLID_WHITE)
     const buttonTextColor = hover
-      ? getThemeProperty('button.hoverText', COLORS.SOLID_BLACK)
+      ? getThemeProperty('button.hoverTextColor', COLORS.SOLID_BLACK)
       : getThemeProperty('button.style.color', COLORS.SOLID_BLACK)
 
     return (

--- a/packages/botonic-react/src/components/button.jsx
+++ b/packages/botonic-react/src/components/button.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { params2queryString, INPUT } from '@botonic/core'
 import { WebchatContext } from '../contexts'
-import { COLORS } from '../constants'
+import { COLORS, WEBCHAT } from '../constants'
 import { renderComponent } from '../utils'
 
 const StyledButton = styled.button`
@@ -40,7 +40,10 @@ export const Button = props => {
 
   const handleClick = event => {
     event.preventDefault()
-    const type = getThemeProperty('button.messageType', INPUT.TEXT)
+    const type = getThemeProperty(
+      WEBCHAT.CUSTOM_PROPERTIES.buttonMessageType,
+      INPUT.TEXT
+    )
     if (props.webview) openWebview(props.webview, props.params)
     else if (props.path) {
       type == INPUT.POSTBACK
@@ -65,8 +68,10 @@ export const Button = props => {
   }
 
   const renderBrowser = () => {
-    const buttonStyle = getThemeProperty('button.style')
-    const CustomButton = getThemeProperty('button.custom')
+    const buttonStyle = getThemeProperty(WEBCHAT.CUSTOM_PROPERTIES.buttonStyle)
+    const CustomButton = getThemeProperty(
+      WEBCHAT.CUSTOM_PROPERTIES.customButton
+    )
     if (CustomButton) {
       return (
         <div onClick={e => handleClick(e)}>
@@ -76,11 +81,23 @@ export const Button = props => {
     }
 
     const buttonBgColor = hover
-      ? getThemeProperty('button.hoverBackground', COLORS.CONCRETE_WHITE)
-      : getThemeProperty('button.style.background', COLORS.SOLID_WHITE)
+      ? getThemeProperty(
+          WEBCHAT.CUSTOM_PROPERTIES.buttonHoverBackground,
+          COLORS.CONCRETE_WHITE
+        )
+      : getThemeProperty(
+          WEBCHAT.CUSTOM_PROPERTIES.buttonStyleBackground,
+          COLORS.SOLID_WHITE
+        )
     const buttonTextColor = hover
-      ? getThemeProperty('button.hoverTextColor', COLORS.SOLID_BLACK)
-      : getThemeProperty('button.style.color', COLORS.SOLID_BLACK)
+      ? getThemeProperty(
+          WEBCHAT.CUSTOM_PROPERTIES.buttonHoverTextColor,
+          COLORS.SOLID_BLACK
+        )
+      : getThemeProperty(
+          WEBCHAT.CUSTOM_PROPERTIES.buttonStyleColor,
+          COLORS.SOLID_BLACK
+        )
 
     return (
       <StyledButton
@@ -90,7 +107,10 @@ export const Button = props => {
         onClick={e => handleClick(e)}
         style={{
           // TODO remove?
-          color: getThemeProperty('brand.color', COLORS.SOLID_BLACK),
+          color: getThemeProperty(
+            WEBCHAT.CUSTOM_PROPERTIES.brandColor,
+            COLORS.SOLID_BLACK
+          ),
           ...buttonStyle,
           // eslint-disable-next-line no-dupe-keys
           color: buttonTextColor,


### PR DESCRIPTION
## Description
Rename theme property `hoverText` to `hoverTextColor` in `button.jsx` so changing button's text color on hover could work

## Context
Changing the text color of a button when the mouse was over it (`:hover`) wasn't working.

## Approach taken / Explain the design
There are 2 different variable names that match the same theme property, `hoverTextColor` in [`constants.js`](https://github.com/hubtype/botonic/blob/master/packages/botonic-react/src/constants.js#L80) and `hoverText` in [`button.jsx`](https://github.com/hubtype/botonic/blob/master/packages/botonic-react/src/components/button.jsx#L82). 
I decided to use `hoverTextColor` because it's more representative of the usage of the property and also because that's the one that appears in the [documentation](https://docs.botonic.io/templates/template-custom-webchat/#webchat-styles)

## To documentate / Usage example

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
