### PR TITLE
feat(react): config storage

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1258,11 +1258,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
-    "@rehooks/local-storage": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@rehooks/local-storage/-/local-storage-2.4.0.tgz",
-      "integrity": "sha512-LoXDbEHsuIckVgBsFAv8SuU/M7memjyfWut9Zf36TQXqqCHBRFv8bweg9PymQCa1aWIMjNrZQflFdo55FDlXYg=="
-    },
     "@styled-system/background": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.1.2.tgz",
@@ -3178,6 +3173,11 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
+    },
+    "react-storage-hooks": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-storage-hooks/-/react-storage-hooks-4.0.1.tgz",
+      "integrity": "sha512-fetDkT5RDHGruc2NrdD1iqqoLuXgbx6AUpQSQLLkrCiJf8i97EtwJNXNTy3+GRfsATLG8TZgNc9lGRZOaU5yQA=="
     },
     "react-test-renderer": {
       "version": "16.13.1",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -24,7 +24,6 @@
   ],
   "dependencies": {
     "@botonic/core": "0.14.0-alpha.0",
-    "@rehooks/local-storage": "^2.2.3",
     "axios": "^0.20.0",
     "emoji-picker-react": "^3.2.3",
     "framer-motion": "^2.6.6",
@@ -38,6 +37,7 @@
     "react-reveal": "^1.2.2",
     "react-router-dom": "^5.2.0",
     "react-textarea-autosize": "^8.2.0",
+    "react-storage-hooks": "^4.0.1",
     "rebass": "^4.0.7",
     "simplebar-react": "^2.2.1",
     "styled-components": "^5.1.1",

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -108,6 +108,7 @@ export const WEBCHAT = {
     enableCarouselArrows: 'carousel.enableArrows',
     customCarouselLeftArrow: 'carousel.arrow.left',
     customCarouselRightArrow: 'carousel.arrow.right',
+    storage: 'storage',
   },
 }
 

--- a/packages/botonic-react/src/dev-app.jsx
+++ b/packages/botonic-react/src/dev-app.jsx
@@ -16,6 +16,7 @@ export class DevApp extends WebchatApp {
     enableAttachments,
     enableUserInput,
     enableAnimations,
+    storage,
     onInit,
     onOpen,
     onClose,
@@ -31,6 +32,7 @@ export class DevApp extends WebchatApp {
       enableAttachments,
       enableUserInput,
       enableAnimations,
+      storage,
       onInit,
       onOpen,
       onClose,
@@ -51,6 +53,7 @@ export class DevApp extends WebchatApp {
       enableAttachments,
       enableUserInput,
       enableAnimations,
+      storage,
       onInit,
       onOpen,
       onClose,
@@ -65,6 +68,7 @@ export class DevApp extends WebchatApp {
     enableAttachments = enableAttachments || this.enableAttachments
     enableUserInput = enableUserInput || this.enableUserInput
     enableAnimations = enableAnimations || this.enableAnimations
+    storage = storage || this.storage
     this.onInit = onInit || this.onInit
     this.onOpen = onOpen || this.onOpen
     this.onClose = onClose || this.onClose
@@ -81,6 +85,7 @@ export class DevApp extends WebchatApp {
         enableAttachments={enableAttachments}
         enableUserInput={enableUserInput}
         enableAnimations={enableAnimations}
+        storage={storage}
         getString={(stringId, session) => this.bot.getString(stringId, session)}
         setLocale={(locale, session) => this.bot.setLocale(locale, session)}
         onInit={(...args) => this.onInitWebchat(...args)}

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -18,6 +18,7 @@ export class WebchatApp {
     enableAnimations,
     defaultDelay,
     defaultTyping,
+    storage,
     onInit,
     onOpen,
     onClose,
@@ -35,6 +36,7 @@ export class WebchatApp {
     this.enableAnimations = enableAnimations
     this.defaultDelay = defaultDelay
     this.defaultTyping = defaultTyping
+    this.storage = storage
     this.onInit = onInit
     this.onOpen = onOpen
     this.onClose = onClose
@@ -189,6 +191,7 @@ export class WebchatApp {
       enableEmojiPicker,
       defaultDelay,
       defaultTyping,
+      storage,
       onInit,
       onOpen,
       onClose,
@@ -207,6 +210,7 @@ export class WebchatApp {
     enableAnimations = enableAnimations || this.enableAnimations
     defaultDelay = defaultDelay || this.defaultDelay
     defaultTyping = defaultTyping || this.defaultTyping
+    storage = storage || this.storage
     this.onInit = onInit || this.onInit
     this.onOpen = onOpen || this.onOpen
     this.onClose = onClose || this.onClose
@@ -225,6 +229,7 @@ export class WebchatApp {
         enableAttachments={enableAttachments}
         enableUserInput={enableUserInput}
         enableAnimations={enableAnimations}
+        storage={storage}
         defaultDelay={defaultDelay}
         defaultTyping={defaultTyping}
         onInit={(...args) => this.onInitWebchat(...args)}

--- a/packages/botonic-react/tests/webchat/storage.test.jsx
+++ b/packages/botonic-react/tests/webchat/storage.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import { Webchat } from '../../src/webchat/webchat'
+
+describe('TEST: storage', () => {
+  afterEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('Stores botonicState in the localStorage by default with its default values', async () => {
+    await act(async () => {
+      TestRenderer.create(<Webchat />)
+    })
+    const botonicState = JSON.parse(localStorage.getItem('botonicState'))
+    expect(botonicState.user).toHaveProperty('id' && 'name')
+    expect(botonicState).toHaveProperty('messages', [])
+    expect(botonicState).toHaveProperty('session', {})
+    expect(botonicState).toHaveProperty('lastRoutePath', null)
+    expect(botonicState).toHaveProperty('devSettings', {})
+    expect(sessionStorage.getItem('botonicState')).toBeNull()
+  })
+
+  it('Stores botonicState in the localStorage', async () => {
+    await act(async () => {
+      TestRenderer.create(<Webchat storage={localStorage} />)
+    })
+    expect(localStorage.getItem('botonicState')).not.toBeNull()
+    expect(sessionStorage.getItem('botonicState')).toBeNull()
+  })
+
+  it('Stores botonicState in the sessionStorage', async () => {
+    await act(async () => {
+      TestRenderer.create(<Webchat storage={sessionStorage} />)
+    })
+    expect(localStorage.getItem('botonicState')).toBeNull()
+    expect(sessionStorage.getItem('botonicState')).not.toBeNull()
+  })
+
+  it('Does not store botonicState', async () => {
+    await act(async () => {
+      TestRenderer.create(<Webchat storage={null} />)
+    })
+    expect(localStorage.getItem('botonicState')).toBeNull()
+    expect(sessionStorage.getItem('botonicState')).toBeNull()
+  })
+})


### PR DESCRIPTION
_Remember to tag the PR with **WIP** tag if it's not ready to be merged_.  
[Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description

Define where to store the `botonicState` using the variable `storage`

<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
In some cases it may be better to store the `botonicState` in the `sessionStrorage` or not storing it
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

Change [@rehooks/local-storage](https://www.npmjs.com/package/@rehooks/local-storage)  for [react-storage-hooks](https://www.npmjs.com/package/react-storage-hooks) since it allows to store the application state in the `sessionStorage` or in the `localStorage`

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To documentate / Usage example

By default the `botonicState` will be stored in the `localStorage`. 

Code to change the `storage`:
```
export const webchat = {
  storage: {localStorage|sessionStorage|null} 
}
```
difference between `localStorage` and `sessionStorage`: https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- [X] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
