### PR TITLE
Contentful/multiple delivery

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.14.0-alpha.4",
+  "version": "0.14.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -15,7 +15,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.14.0-alpha.4",
+  "version": "0.14.0-beta.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-empty-pattern */
 import { SearchCandidate } from '../search/search-result'
 import { Callback, ContentCallback } from './callback'
-import { CMS, ContentType, TopContentType } from './cms'
+import { CMS, ContentType, PagingOptions, TopContentType } from './cms'
 import {
   Asset,
   Button,
@@ -108,7 +108,8 @@ export class DummyCMS implements CMS {
   topContents(
     model: TopContentType,
     context?: Context,
-    filter?: (cf: CommonFields) => boolean
+    filter?: (cf: CommonFields) => boolean,
+    paging?: PagingOptions
   ): Promise<TopContent[]> {
     return Promise.resolve([])
   }
@@ -153,7 +154,11 @@ export class DummyCMS implements CMS {
     return this.buttonCallbacks.map(DummyCMS.buttonFromCallback)
   }
 
-  contents(contentType: ContentType, context?: Context): Promise<Content[]> {
+  contents(
+    contentType: ContentType,
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<Content[]> {
     return Promise.resolve([])
   }
 

--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -1,4 +1,4 @@
-import { CMS, ContentType, TopContentType } from './cms'
+import { CMS, ContentType, PagingOptions, TopContentType } from './cms'
 import {
   Asset,
   Button,
@@ -107,16 +107,21 @@ export class ErrorReportingCMS implements CMS {
   topContents(
     model: TopContentType,
     context?: Context,
-    filter?: (cf: CommonFields) => boolean
+    filter?: (cf: CommonFields) => boolean,
+    paging?: PagingOptions
   ): Promise<TopContent[]> {
     return this.cms
-      .topContents(model, context, filter)
+      .topContents(model, context, filter, paging)
       .catch(this.handleError('topContents'))
   }
 
-  contents(contentType: ContentType, context?: Context): Promise<Content[]> {
+  contents(
+    contentType: ContentType,
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<Content[]> {
     return this.cms
-      .contents(contentType, context)
+      .contents(contentType, context, paging)
       .catch(this.handleError('contents'))
   }
 

--- a/packages/botonic-plugin-contentful/src/cms/cms-log.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-log.ts
@@ -1,4 +1,4 @@
-import { CMS, ContentType, TopContentType } from './cms'
+import { CMS, ContentType, PagingOptions, TopContentType } from './cms'
 import {
   Asset,
   Button,
@@ -82,15 +82,20 @@ export class LogCMS implements CMS {
   topContents(
     model: TopContentType,
     context?: Context,
-    filter?: (cf: CommonFields) => boolean
+    filter?: (cf: CommonFields) => boolean,
+    paging?: PagingOptions
   ): Promise<TopContent[]> {
     this.logger(`topContents of model ${model}`)
-    return this.cms.topContents(model, context, filter)
+    return this.cms.topContents(model, context, filter, paging)
   }
 
-  contents(contentType: ContentType, context?: Context): Promise<Content[]> {
+  contents(
+    contentType: ContentType,
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<Content[]> {
     this.logger(`contents of model ${contentType}`)
-    return this.cms.contents(contentType, context)
+    return this.cms.contents(contentType, context, paging)
   }
 
   assets(context?: Context): Promise<Asset[]> {

--- a/packages/botonic-plugin-contentful/src/cms/cms-multilocale.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-multilocale.ts
@@ -1,4 +1,4 @@
-import { CMS, ContentType, TopContentType } from './cms'
+import { CMS, ContentType, PagingOptions, TopContentType } from './cms'
 import {
   Asset,
   Button,
@@ -42,8 +42,12 @@ export class MultiContextCms implements CMS {
     return this.cmsFromContext(context).chitchat(id, context)
   }
 
-  contents(contentType: ContentType, context?: Context): Promise<Content[]> {
-    return this.cmsFromContext(context).contents(contentType, context)
+  contents(
+    contentType: ContentType,
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<Content[]> {
+    return this.cmsFromContext(context).contents(contentType, context, paging)
   }
 
   assets(context?: Context): Promise<Asset[]> {
@@ -85,9 +89,15 @@ export class MultiContextCms implements CMS {
   topContents(
     model: TopContentType,
     context?: Context,
-    filter?: (cf: CommonFields) => boolean
+    filter?: (cf: CommonFields) => boolean,
+    paging?: PagingOptions
   ): Promise<TopContent[]> {
-    return this.cmsFromContext(context).topContents(model, context, filter)
+    return this.cmsFromContext(context).topContents(
+      model,
+      context,
+      filter,
+      paging
+    )
   }
 
   url(id: string, context?: Context): Promise<Url> {

--- a/packages/botonic-plugin-contentful/src/cms/cms.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms.ts
@@ -76,6 +76,10 @@ export function isSameModel(model1: ContentType, model2: ContentType): boolean {
   }
 }
 
+export class PagingOptions {
+  constructor(readonly limit = 1000, readonly skip = 0) {}
+}
+
 /**
  * Except for {@link topContents} and {@link contentsWithKeywords}, when {@link Context.locale} is specified it will default
  * to the fallback locale for those fields not available in the specified locale.
@@ -97,14 +101,19 @@ export interface CMS {
   topContents(
     model: TopContentType,
     context?: Context,
-    filter?: (cf: CommonFields) => boolean
+    filter?: (cf: CommonFields) => boolean,
+    paging?: PagingOptions
   ): Promise<TopContent[]>
 
   /**
    * TODO add filter by id or name
    */
-  contents(contentType: ContentType, context?: Context): Promise<Content[]>
-  assets(context?: Context): Promise<Asset[]>
+  contents(
+    contentType: ContentType,
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<Content[]>
+  assets(context?: Context, paging?: PagingOptions): Promise<Asset[]>
 
   /**
    * For contents with 'Searchable by' field (eg. {@link Queue}), it returns one result per each 'Seachable by' entry

--- a/packages/botonic-plugin-contentful/src/cms/cms.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms.ts
@@ -87,16 +87,28 @@ export class PagingOptions {
  */
 export interface CMS {
   button(id: string, context?: Context): Promise<Button>
+
+  /**
+   * If any image cannot be retrieved, it will be left undefined
+   */
   carousel(id: string, context?: Context): Promise<Carousel>
+
   chitchat(id: string, context?: Context): Promise<Chitchat>
   element(id: string, context?: Context): Promise<Element>
   image(id: string, context?: Context): Promise<Image>
   queue(id: string, context?: Context): Promise<Queue>
+
+  /**
+   * If the image cannot be retrieved, it will be left undefined
+   */
   startUp(id: string, context?: Context): Promise<StartUp>
   text(id: string, context?: Context): Promise<Text>
   url(id: string, context?: Context): Promise<Url>
+
   /**
    * If locale specified in context, it does not return contents without values for the locale (even if it has value for the fallback locale)
+   * If ContentfulOptions.resumeErrors is set, if some contents fail to be devilered,
+   * an error will be displayed but the result will be returned.
    */
   topContents(
     model: TopContentType,
@@ -106,13 +118,15 @@ export interface CMS {
   ): Promise<TopContent[]>
 
   /**
-   * TODO add filter by id or name
+   * If ContentfulOptions.resumeErrors is set, if some contents fail to be devilered,
+   * an error will be displayed but the result will be returned.
    */
   contents(
     contentType: ContentType,
     context?: Context,
     paging?: PagingOptions
   ): Promise<Content[]>
+
   assets(context?: Context, paging?: PagingOptions): Promise<Asset[]>
 
   /**

--- a/packages/botonic-plugin-contentful/src/cms/cms.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms.ts
@@ -89,17 +89,23 @@ export interface CMS {
   button(id: string, context?: Context): Promise<Button>
 
   /**
-   * If any image cannot be retrieved, it will be left undefined
+   * If ContentfulOptions.resumeErrors is set:
+   * - If any image cannot be retrieved, it will be left undefined
+   * - If any element cannot be retrieved, only the rest will be returned
    */
   carousel(id: string, context?: Context): Promise<Carousel>
 
   chitchat(id: string, context?: Context): Promise<Chitchat>
   element(id: string, context?: Context): Promise<Element>
+
+  /** Even if ContentfulOptions.resumeErrors is set, if the asset is not available
+   * the method will fail. */
   image(id: string, context?: Context): Promise<Image>
   queue(id: string, context?: Context): Promise<Queue>
 
   /**
-   * If the image cannot be retrieved, it will be left undefined
+   * If ContentfulOptions.resumeErrors is set: If the image cannot be retrieved,
+   * it will be left undefined
    */
   startUp(id: string, context?: Context): Promise<StartUp>
   text(id: string, context?: Context): Promise<Text>
@@ -107,7 +113,8 @@ export interface CMS {
 
   /**
    * If locale specified in context, it does not return contents without values for the locale (even if it has value for the fallback locale)
-   * If ContentfulOptions.resumeErrors is set, if some contents fail to be devilered,
+   *
+   * If ContentfulOptions.resumeErrors is set: if some contents fail to be devilered,
    * an error will be displayed but the result will be returned.
    */
   topContents(
@@ -118,7 +125,7 @@ export interface CMS {
   ): Promise<TopContent[]>
 
   /**
-   * If ContentfulOptions.resumeErrors is set, if some contents fail to be devilered,
+   * If ContentfulOptions.resumeErrors is set: if some contents fail to be delivered,
    * an error will be displayed but the result will be returned.
    */
   contents(

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -137,7 +137,7 @@ export abstract class MessageContent extends TopContent {
  * to confirm their interest on this content
  * TODO move contentId o ContentType here?
  */
-export class CommonFields {
+export class CommonFields implements Stringable {
   readonly shortText: string
   readonly keywords: string[]
   readonly searchableBy?: SearchableBy
@@ -171,6 +171,10 @@ export class CommonFields {
       this.keywords = []
       this.partitions = []
     }
+  }
+
+  toString(): string {
+    return `'${this.id}/${this.name}'`
   }
 }
 

--- a/packages/botonic-plugin-contentful/src/cms/transform/cms-filter.ts
+++ b/packages/botonic-plugin-contentful/src/cms/transform/cms-filter.ts
@@ -13,6 +13,7 @@ import {
   Element,
   Image,
   MessageContent,
+  PagingOptions,
   Queue,
   ScheduleContent,
   StartUp,
@@ -110,17 +111,19 @@ export class FilteredCMS implements CMS {
   async topContents(
     model: TopContentType,
     context?: Context,
-    filter?: (cf: CommonFields) => boolean
+    filter?: (cf: CommonFields) => boolean,
+    paging?: PagingOptions
   ): Promise<TopContent[]> {
-    const contents = await this.cms.topContents(model, context, filter)
+    const contents = await this.cms.topContents(model, context, filter, paging)
     return this.filterContents(contents, context)
   }
 
   async contents(
     contentType: ContentType,
-    context?: Context | undefined
+    context?: Context | undefined,
+    paging?: PagingOptions
   ): Promise<Content[]> {
-    const contents = await this.cms.contents(contentType, context)
+    const contents = await this.cms.contents(contentType, context, paging)
     return this.filterContents(contents, context)
   }
 

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -142,7 +142,7 @@ export class Contentful implements cms.CMS {
     model: TopContentType,
     context = DEFAULT_CONTEXT,
     filter?: (cf: CommonFields) => boolean,
-    paging?: PagingOptions
+    paging = new PagingOptions()
   ): Promise<TopContent[]> {
     return this._contents.topContents(
       model,
@@ -156,10 +156,13 @@ export class Contentful implements cms.CMS {
   contents(
     contentType: ContentType,
     context = DEFAULT_CONTEXT,
-    paging?: PagingOptions
+    paging = new PagingOptions()
   ): Promise<Content[]> {
-    return this._contents.contents(contentType, context, (entry, ctxt) =>
-      this.contentFromEntry(entry, ctxt)
+    return this._contents.contents(
+      contentType,
+      context,
+      (entry, ctxt) => this.contentFromEntry(entry, ctxt),
+      paging
     )
   }
 

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -78,7 +78,7 @@ export class Contentful implements cms.CMS {
     this._startUp = new StartUpDelivery(delivery, this._button, resumeErrors)
     this._url = new UrlDelivery(delivery, resumeErrors)
     this._image = new ImageDelivery(delivery, resumeErrors)
-    this._asset = new AssetDelivery(delivery)
+    this._asset = new AssetDelivery(delivery, resumeErrors)
     this._schedule = new ScheduleDelivery(delivery, resumeErrors)
     this._queue = new QueueDelivery(delivery, this._schedule, resumeErrors)
     const followUp = new FollowUpDelivery(

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -7,6 +7,7 @@ import {
   Context,
   DateRangeContent,
   DEFAULT_CONTEXT,
+  PagingOptions,
   ScheduleContent,
   TopContent,
   TopContentType,
@@ -140,20 +141,22 @@ export class Contentful implements cms.CMS {
   topContents(
     model: TopContentType,
     context = DEFAULT_CONTEXT,
-    filter?: (cf: CommonFields) => boolean
+    filter?: (cf: CommonFields) => boolean,
+    paging?: PagingOptions
   ): Promise<TopContent[]> {
     return this._contents.topContents(
       model,
       context,
-      (entry: contentful.Entry<any>, ctxt: Context) =>
-        this.topContentFromEntry(entry, ctxt),
-      filter
+      (entry, ctxt) => this.topContentFromEntry(entry, ctxt),
+      filter,
+      paging
     )
   }
 
   contents(
     contentType: ContentType,
-    context = DEFAULT_CONTEXT
+    context = DEFAULT_CONTEXT,
+    paging?: PagingOptions
   ): Promise<Content[]> {
     return this._contents.contents(
       contentType,

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -69,7 +69,7 @@ export class Contentful implements cms.CMS {
     )
     const resumeErrors = options.resumeErrors || false
     const delivery = new IgnoreFallbackDecorator(deliveryApi)
-    this._contents = new ContentsDelivery(delivery)
+    this._contents = new ContentsDelivery(delivery, resumeErrors)
 
     this._delivery = delivery
     this._button = new ButtonDelivery(delivery, resumeErrors)
@@ -158,11 +158,8 @@ export class Contentful implements cms.CMS {
     context = DEFAULT_CONTEXT,
     paging?: PagingOptions
   ): Promise<Content[]> {
-    return this._contents.contents(
-      contentType,
-      context,
-      (entry: contentful.Entry<any>, ctxt: Context) =>
-        this.contentFromEntry(entry, ctxt)
+    return this._contents.contents(contentType, context, (entry, ctxt) =>
+      this.contentFromEntry(entry, ctxt)
     )
   }
 

--- a/packages/botonic-plugin-contentful/src/contentful/content-delivery.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/content-delivery.ts
@@ -1,6 +1,14 @@
-import { CmsException, ContentType, Context, isSameModel } from '../cms'
+import {
+  CmsException,
+  Content,
+  ContentType,
+  Context,
+  isSameModel,
+} from '../cms'
 import * as contentful from 'contentful'
+import { Entry } from 'contentful'
 import { ContentfulEntryUtils, DeliveryApi } from './delivery-api'
+import { asyncMap } from '../util/async'
 
 export abstract class ResourceDelivery {
   constructor(
@@ -35,6 +43,17 @@ export abstract class ResourceDelivery {
       return
     }
     throw new CmsException(doing, reason)
+  }
+
+  protected asyncMap<T extends Content>(
+    context: Context,
+    entries: Entry<any>[],
+    factory: (entry: Entry<any>) => Promise<T>
+  ): Promise<T[]> {
+    return asyncMap(context, entries, factory, undefined, (entry, e) => {
+      this.logOrThrow(`Loading ${entry.sys.type} '${entry.sys.id}'`, e)
+      return undefined
+    })
   }
 }
 

--- a/packages/botonic-plugin-contentful/src/contentful/contents/asset.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/asset.ts
@@ -1,20 +1,19 @@
 import * as cms from '../../cms'
-import { ContentfulEntryUtils, DeliveryApi } from '../delivery-api'
 import { Asset } from 'contentful'
+import { ResourceDelivery } from '../content-delivery'
 
-export class AssetDelivery {
-  constructor(protected delivery: DeliveryApi) {}
-
+export class AssetDelivery extends ResourceDelivery {
   async asset(id: string, context: cms.Context): Promise<cms.Asset> {
     const asset = await this.delivery.getAsset(id, context)
     return this.fromEntry(asset)
   }
 
   private fromEntry(asset: Asset) {
+    const url = this.urlFromAssetRequired(asset)
     return new cms.Asset(
       asset.sys.id,
       asset.fields.title,
-      ContentfulEntryUtils.urlFromAsset(asset),
+      url,
       asset.fields.file.contentType,
       asset.fields.file.details
     )

--- a/packages/botonic-plugin-contentful/src/contentful/contents/button.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/button.ts
@@ -15,7 +15,6 @@ import { QueueFields } from './queue'
 import { HourRangeFields, ScheduleFields } from './schedule'
 import { isOfType } from '../../util/enums'
 import { TopContentType } from '../../cms/cms'
-import { asyncMap } from '../../util/async'
 import { ContentDelivery } from '../content-delivery'
 
 export class ButtonDelivery extends ContentDelivery {
@@ -35,16 +34,9 @@ export class ButtonDelivery extends ContentDelivery {
     entries: contentful.Entry<any>[],
     context: cms.Context
   ): Promise<cms.Button[]> {
-    const buttons = await asyncMap(context, entries, async entry => {
-      try {
-        return await this.fromReference(entry, context)
-      } catch (e) {
-        // will fail if a draft content is referenced
-        this.logOrThrow(`Loading reference to content ${entry.sys.id}`, e)
-        return undefined
-      }
-    })
-    return buttons.filter(b => b !== undefined) as cms.Button[]
+    return await this.asyncMap(context, entries, entry =>
+      this.fromReference(entry, context)
+    )
   }
 
   public async fromReference(

--- a/packages/botonic-plugin-contentful/src/contentful/contents/carousel.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/carousel.ts
@@ -65,7 +65,7 @@ export class CarouselDelivery extends DeliveryWithFollowUp {
       buttons,
       fields.title ?? '',
       fields.subtitle ?? '',
-      fields.pic && ContentfulEntryUtils.urlFromAsset(fields.pic)
+      this.urlFromAssetOptional(fields.pic)
     )
   }
 }

--- a/packages/botonic-plugin-contentful/src/contentful/contents/carousel.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/carousel.ts
@@ -3,11 +3,10 @@ import { DeliveryWithFollowUp } from './follow-up'
 import { ButtonDelivery } from './button'
 import * as cms from '../../cms'
 import {
-  DeliveryApi,
   CommonEntryFields,
   ContentfulEntryUtils,
+  DeliveryApi,
 } from '../delivery-api'
-import { asyncMap } from '../../util/async'
 
 // TODO does not yet load the followU p
 export class CarouselDelivery extends DeliveryWithFollowUp {
@@ -31,7 +30,7 @@ export class CarouselDelivery extends DeliveryWithFollowUp {
     entry: contentful.Entry<CarouselFields>,
     context: cms.Context
   ) {
-    const elements = await asyncMap(
+    const elements = await this.asyncMap(
       context,
       entry.fields.elements,
       async entry => {

--- a/packages/botonic-plugin-contentful/src/contentful/contents/contents.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/contents.ts
@@ -22,7 +22,7 @@ export class ContentsDelivery extends ResourceDelivery {
     contentType: ContentType,
     context: Context,
     factory: (entry: contentful.Entry<any>, ctxt: Context) => Promise<Content>,
-    paging = new PagingOptions()
+    paging: PagingOptions
   ): Promise<Content[]> {
     const entryCollection: EntryCollection<CommonEntryFields> = await this.delivery.getEntries(
       context,
@@ -40,8 +40,8 @@ export class ContentsDelivery extends ResourceDelivery {
       entry: contentful.Entry<any>,
       ctxt: Context
     ) => Promise<TopContent>,
-    filter?: (cf: CommonFields) => boolean,
-    paging = new PagingOptions()
+    filter: ((cf: CommonFields) => boolean) | undefined,
+    paging: PagingOptions
   ): Promise<TopContent[]> {
     const entryCollection: EntryCollection<CommonEntryFields> = await this.delivery.getEntries(
       context,

--- a/packages/botonic-plugin-contentful/src/contentful/contents/image.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/image.ts
@@ -1,10 +1,6 @@
-import { Context } from '../../cms'
 import * as cms from '../../cms'
-import {
-  CommonEntryFields,
-  ContentfulEntryUtils,
-  DeliveryApi,
-} from '../delivery-api'
+import { Context } from '../../cms'
+import { CommonEntryFields, DeliveryApi } from '../delivery-api'
 import * as contentful from 'contentful'
 import { DeliveryWithFollowUp } from './follow-up'
 
@@ -27,7 +23,7 @@ export class ImageDelivery extends DeliveryWithFollowUp {
   ): Promise<cms.Image> {
     return new cms.Image(
       await this.getFollowUp().commonFields(entry, context),
-      ContentfulEntryUtils.urlFromAsset(entry.fields.image)
+      this.urlFromAssetRequired(entry.fields.image)
     )
   }
 }

--- a/packages/botonic-plugin-contentful/src/contentful/contents/startup.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/startup.ts
@@ -1,11 +1,7 @@
 import * as contentful from 'contentful'
 import * as cms from '../../cms'
 import { ButtonDelivery } from './button'
-import {
-  DeliveryApi,
-  CommonEntryFields,
-  ContentfulEntryUtils,
-} from '../delivery-api'
+import { CommonEntryFields, DeliveryApi } from '../delivery-api'
 import { DeliveryWithFollowUp } from './follow-up'
 
 export class StartUpDelivery extends DeliveryWithFollowUp {
@@ -36,12 +32,9 @@ export class StartUpDelivery extends DeliveryWithFollowUp {
       fields.buttons || [],
       context
     )
-    const img = fields.pic
-      ? ContentfulEntryUtils.urlFromAsset(fields.pic)
-      : undefined
     return new cms.StartUp(
       await this.getFollowUp().commonFields(entry, context),
-      img,
+      this.urlFromAssetOptional(fields.pic),
       fields.text ?? '',
       buttons
     )

--- a/packages/botonic-plugin-contentful/src/contentful/contents/url.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/url.ts
@@ -1,6 +1,6 @@
+import * as cms from '../../cms'
 import { Context } from '../../cms'
 import { DeliveryWithFollowUp } from './follow-up'
-import * as cms from '../../cms'
 import * as contentful from 'contentful'
 import { CommonEntryFields, DeliveryApi } from '../delivery-api'
 

--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -16,6 +16,9 @@ import { DateRangeDelivery, DateRangeFields } from './contents/date-range'
 import { ReducedClientApi } from './delivery/client-api'
 import { ContentfulOptions } from '../plugin'
 
+/**
+ * https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/
+ */
 export interface DeliveryApi {
   getAsset(id: string, context: Context, query?: any): Promise<contentful.Asset>
 
@@ -122,10 +125,6 @@ export class ContentfulEntryUtils {
     }
     const typ = entry.sys.contentType.sys.id
     return typ as T
-  }
-
-  static urlFromAsset(assetField: contentful.Asset): string {
-    return 'https:' + assetField.fields.file.url
   }
 
   static commonFieldsFromEntry(

--- a/packages/botonic-plugin-contentful/src/plugin.ts
+++ b/packages/botonic-plugin-contentful/src/plugin.ts
@@ -49,7 +49,7 @@ export interface ContentfulOptions extends OptionsBase, ContentfulCredentials {
   cmsLocale?: (locale?: Locale) => Locale | undefined
 
   /**
-   * If the delivery of a part of a content fails (eg. a referenced content),
+   * If the delivery of an optional part of a content fails (eg. a referenced content or assert),
    * the flag defines whether the content should be partially delivered
    * or an error should be raised.
    * False by default

--- a/packages/botonic-plugin-contentful/src/tools/l10n/export-csv-for-translators.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/export-csv-for-translators.ts
@@ -2,6 +2,7 @@ import { CsvExport, I18nField, skipEmptyStrings } from './csv-export'
 import { Locale } from '../../nlp'
 import { ContentfulOptions } from '../../plugin'
 import { Contentful } from '../../contentful/cms-contentful'
+import { ErrorReportingCMS } from '../../cms'
 import { ContentFieldType } from '../../manage-cms'
 
 export class PostProcessor {
@@ -38,7 +39,7 @@ async function writeCsvForTranslators(
   fileName: string,
   targetLocale: Locale | undefined
 ) {
-  const cms = new Contentful(options)
+  const cms = new ErrorReportingCMS(new Contentful(options))
   const postProcess = targetLocale ? new PostProcessor(targetLocale) : undefined
   const exporter = new CsvExport(
     {
@@ -73,6 +74,7 @@ async function main() {
         spaceId,
         accessToken,
         environment,
+        resumeErrors: true,
       },
       locale,
       fileName,

--- a/packages/botonic-plugin-contentful/tests/util/async.test.ts
+++ b/packages/botonic-plugin-contentful/tests/util/async.test.ts
@@ -1,0 +1,23 @@
+import { asyncMap } from '../../src/util/async'
+
+test('TEST: asyncMap errorTreatment', async () => {
+  const ctx = { locale: 'ru' }
+  const errors: number[] = []
+
+  const result = await asyncMap(
+    ctx,
+    [-2, -1, 0, 1],
+    item => {
+      if (item < 0) throw new Error()
+      return Promise.resolve(String(item))
+    },
+    undefined,
+    item => {
+      errors.push(item)
+      return undefined
+    }
+  )
+
+  expect(result).toIncludeSameMembers(['0', '1'])
+  expect(errors).toIncludeSameMembers([-2, -1])
+})


### PR DESCRIPTION
## Description

* paging for multiple delivery of contents (not yet for assets). By default contentful was limiting to 100. Now it can be specified as argument
* If ContentfulOptions.resumeErrors is set, when a  Carousels or Startup's image reference is broken, it will return the content with the image field undefined instead of failing. 
* If ContentfulOptions.resumeErrors is set when calling Contentful.contents or .topContents, if some contents fail to be delivered, an error will be displayed but the result will be returned.

## Context
When we want to export all the contents as csv or to validate all contents, we don't want that a single inconsistent content prevents from getting or validating the rest of contents

## Testing

The pull request...

- has unit tests for the inner functions. Pending to do it for ResourceDelivery.asyncMap
