### PR TITLE
feat(react): Enable coverComponent toggle through Botonic

### DIFF
--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -138,6 +138,18 @@ export class WebchatApp {
     this.webchatRef.current.toggleWebchat()
   }
 
+  openCoverComponent() {
+    this.webchatRef.current.openCoverComponent()
+  }
+
+  closeCoverComponent() {
+    this.webchatRef.current.closeCoverComponent()
+  }
+
+  toggleCoverComponent() {
+    this.webchatRef.current.toggleCoverComponent()
+  }
+
   getMessages() {
     return this.webchatRef.current.getMessages()
   }

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -509,6 +509,10 @@ export const Webchat = forwardRef((props, ref) => {
     openWebchat: () => toggleWebchat(true),
     closeWebchat: () => toggleWebchat(false),
     toggleWebchat: () => toggleWebchat(!webchatState.isWebchatOpen),
+    openCoverComponent: () => toggleCoverComponent(true),
+    closeCoverComponent: () => toggleCoverComponent(false),
+    toggleCoverComponent: () =>
+      toggleCoverComponent(!webchatState.isCoverComponentOpen),
     openWebviewApi: component => openWebviewT(component),
     setError,
     getMessages: () => webchatState.messagesJSON,


### PR DESCRIPTION
## Description
Make the methods `openCoverComponent`, `closeCoverComponent` and `toggleCoverComponent` available through `Botonic` object in browser so the `coverComponent` can be shown/hide manually.

## Context
Once the user has gone through the `coverComponent`, there is no way to show it again without not removing the cookies.

## Approach taken / Explain the design
Make the methods `openCoverComponent`, `closeCoverComponent` and `toggleCoverComponent` available both in `webchatRef` and `WebchatApp`.

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- [ ] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**
