### PR TITLE
fix(react): missing theme props in first theme merge

### DIFF
--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -187,7 +187,7 @@ export const Webchat = forwardRef((props, ref) => {
     setCurrentAttachment,
     // eslint-disable-next-line react-hooks/rules-of-hooks
   } = props.webchatHooks || useWebchat()
-  const { theme } = webchatState
+  const theme = merge(webchatState.theme, props.theme)
   const { initialSession, initialDevSettings, onStateChange } = props
   const isOnline = useNetwork()
   const [botonicState, saveState, deleteState] = useLocalStorage('botonicState')


### PR DESCRIPTION
_Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.  

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
Fixed a bug reported that cause some styles not showing up as the upper level Webchat props were not deep merged initially in `webchat.jsx`.