### PR TITLE
fix(react): text area not working

### DIFF
--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -723,7 +723,7 @@ export const Webchat = forwardRef((props, ref) => {
                 WEBCHAT.DEFAULTS.PLACEHOLDER
               )}
               autoFocus={true}
-              inputRef={textArea}
+              ref={textArea}
               onKeyDown={e => onKeyDown(e)}
               style={{
                 display: 'flex',


### PR DESCRIPTION
_Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.  

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
It seems that we bumped automatically the dependency with dependabot for `react-textarea-autosize` and sending inputs in the text area where not working. I have seen that they have changed the api from `inputRef` to `ref`. You can see here how to pass the ref in the new version: https://www.npmjs.com/package/react-textarea-autosize#how-to-focus