### PR TITLE
chore: improve bump versions script

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -6,11 +6,50 @@ cd "$BIN_DIR/.." || exit 1
 cd packages || exit 1
 
 VERSION=$1 
+PHASE=$2
 
-for package in botonic-*; do
-  cd "$package" || exit
-  echo "Bumping $package to $VERSION"
-  echo "===================================="
-  nice npm version $VERSION > /dev/null
-  cd ..
-done
+update_botonic_deps (){
+  # $template $1
+  # $VERSION $2
+  # $PHASE $3
+  echo " - Updating botonic deps for '$1'"
+  if [[ "$3" == "rc" ]]
+  then
+    sed -i.aux -E 's/("@botonic\/(.*)": )"(.*)"/\1"'${2}'"/' package.json
+  else
+    sed -i.aux -E 's/("@botonic\/(.*)": )"(.*)"/\1"~'${2}'"/' package.json
+  fi
+  rm package.json.aux
+}
+
+if [ -z "$PHASE" ]
+    for package in botonic-*; do
+      cd "$package" || exit
+      echo "Bumping $package to $VERSION"
+      echo "===================================="
+
+      # Update botonic dependencies for every template
+      if [[ "$package" == "botonic-cli" ]]
+      then
+        cd "templates" || exit
+        for project in *; do
+          cd "$project"
+          update_botonic_deps "$project" "$VERSION" "$PHASE"
+          cd ".."
+        done
+        cd ".."
+      fi
+
+      # Update botonic dependencies for packages pointing to other botonic projects
+      if [ "$package" == "botonic-react" ] || [ "$package" == "botonic-plugin-nlu" ];
+      then
+        update_botonic_deps "$package" "$VERSION" "$PHASE"
+      fi
+      
+      # Updates package.json and package-lock.json
+      nice npm version $VERSION > /dev/null
+      cd ..
+    done
+  then exit
+fi
+


### PR DESCRIPTION
_Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.  

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/)

## Description
Automate even more package dependency updates for templates and botonic packages with deps to other botonic packages to speed up the process and minimize potential errors.

## Usage
For example, for the next release we can do:
For preparing rc versions, we can run the bash script:
`$ ./bump-version.sh 0.15.0-rc.0 rc`
will leave the dependencies for templates, react and plugin-nlu in the following format:

**./botonic-react/package.json**
`"@botonic/core": "0.15.0-rc.0"`

For definitive versions, we can run the bash script:
`$ ./bump-version.sh 0.15.0`
will leave the dependencies for templates, react and plugin-nlu in the following format:

**./botonic-react/package.json**
`"@botonic/core": "~0.15.0"`

## Context
Right now we were calling `npm version $VERSION` which updated both package.json and package-lock.json for every dependency, but we still need to manually replace the versions for all templates and botonic packages which have another botonic package as a dependency (botonic-plugin-nlu and botonic-react). 

@dpinol maybe you have suggestions to improve this even more
