### PR TITLE
Contentful - Update content's Code when importing CSV from translators

### DIFF
--- a/packages/botonic-plugin-contentful/bin/l10n/import-from-translators.sh
+++ b/packages/botonic-plugin-contentful/bin/l10n/import-from-translators.sh
@@ -25,7 +25,8 @@ WRITE_MODE=$7
 #  OVERWRITE_AND_PUBLISH: overwrites previous value and publishes it (only for new spaces!)
 
 DUPLICATE_REFERENCES=$8
+OVERWRITE_CODES=$9
 
 ../../node_modules/.bin/ts-node --files	src/tools/l10n/import-csv-from-translators.ts \
 	"$SPACE_ID" "$ENVIRONMENT" "$DELIVER_TOKEN" "$CONTENTFUL_MANAGEMENT_TOKEN" "$LOCALE" "$CSV_FILENAME" \
-	"$WRITE_MODE" "$DUPLICATE_REFERENCES"
+	"$WRITE_MODE" "$DUPLICATE_REFERENCES" "$OVERWRITE_CODES"

--- a/packages/botonic-plugin-contentful/src/contentful/manage/manage-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/manage/manage-contentful.ts
@@ -60,15 +60,25 @@ export class ManageContentful implements ManageCms {
     context: ManageContext,
     contentId: ContentId,
     fieldType: ContentFieldType,
-    value: any
+    value: any,
+    code?: string
   ): Promise<void> {
     const environment = await this.getEnvironment()
     const oldEntry = await environment.getEntry(contentId.id)
+
     const field = this.checkOverwrite(context, oldEntry, fieldType, true)
     oldEntry.fields[field.cmsName][context.locale] = value
+    if (code) this.replaceCode(code, oldEntry)
+
     // we could use this.deliver.contentFromEntry & IgnoreFallbackDecorator to convert
     // the multilocale fields returned by update()
     await this.writeEntry(context, oldEntry)
+  }
+
+  replaceCode(code: string, entry: Entry) {
+    for (const locale in entry.fields.name) {
+      entry.fields.name[locale] = code
+    }
   }
 
   async removeAssetFile(

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
@@ -15,10 +15,11 @@ export class ErrorReportingManageCms implements ManageCms {
     context: ManageContext,
     contentId: ContentId,
     fieldType: ContentFieldType,
-    value: any
+    value: any,
+    code?: string
   ): Promise<void> {
     return this.manageCms
-      .updateField(context, contentId, fieldType, value)
+      .updateField(context, contentId, fieldType, value, code)
       .catch(this.handleError('updateField', context, contentId))
   }
 

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
@@ -18,7 +18,8 @@ export interface ManageCms {
     context: ManageContext,
     contentId: ContentId,
     fieldType: ContentFieldType,
-    value: any
+    value: any,
+    code?: string
   ): Promise<void>
 
   /** Will not fail if source does not have this field */

--- a/packages/botonic-plugin-contentful/src/tools/l10n/csv-import.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/csv-import.ts
@@ -87,8 +87,16 @@ export class CsvImport {
   }
 }
 
+export interface ImporterOptions {
+  overwriteCodes: boolean
+}
+
 export class StringFieldImporter {
-  constructor(readonly cms: ManageCms, readonly context: ManageContext) {}
+  constructor(
+    readonly cms: ManageCms,
+    readonly context: ManageContext,
+    readonly options?: ImporterOptions
+  ) {}
 
   async consume(record: Record): Promise<void> {
     if (!isOfType(record.Model, ContentType)) {
@@ -105,12 +113,13 @@ export class StringFieldImporter {
       return
     }
     const id = new cms.ContentId(record.Model, record.Id)
-
+    const code = this.options?.overwriteCodes ? record.Code : undefined
     await this.cms.updateField(
       this.context,
       id,
       field.fieldType,
-      this.value(record)
+      this.value(record),
+      code
     )
   }
 


### PR DESCRIPTION
## Description
Add an extra parameter `overwriteCodes` to the script `import-from-translators.sh` in order to be able to update all the content's Codes in bulk during the CSV import.

## Context
There is no way to change the content's Codes (unique key forced by the user for each content) in bulk with this plugin.

## Approach taken / Explain the design
I've used the actual import script to add this new feature to be able to change the Codes in bulk while importing the translated contents.

## To document / Usage example
If you only want to update the Codes without changin the main contents you can just export the contents into a CSV with the script `export-for-translators.sh`, change all the Codes you want to update and then import this file with the script `import-from-translators.sh` with the options `writeMode` set to `OVERWRITE` or `OVERWRITE_AND_PUBLISH` and `overwriteCodes` to `true`.

## Testing

The pull request...

- has unit tests
- has integration tests
