### PR TITLE
fix(react): customMessage not to crash if bad children

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.14.1-alpha.2",
+  "version": "0.14.1-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.14.1-alpha.2",
+  "version": "0.14.1-alpha.3",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
   "scripts": {

--- a/packages/botonic-react/src/components/custom-message.jsx
+++ b/packages/botonic-react/src/components/custom-message.jsx
@@ -23,7 +23,7 @@ export const customMessage = ({
       )
       return { replies, childrenWithoutReplies }
     } catch (e) {
-      return { replies: children, childrenWithoutReplies: [] }
+      return { replies: [], childrenWithoutReplies: children }
     }
   }
 

--- a/packages/botonic-react/src/components/custom-message.jsx
+++ b/packages/botonic-react/src/components/custom-message.jsx
@@ -11,14 +11,25 @@ export const customMessage = ({
   const CustomMessage = props => (
     <Message {...defaultProps} {...props} type={INPUT.CUSTOM} />
   )
+
+  const SplitChildren = props => {
+    const { children } = props
+    try {
+      const replies = React.Children.toArray(children).filter(
+        e => e.type === Reply
+      )
+      const childrenWithoutReplies = React.Children.toArray(children).filter(
+        e => ![Reply].includes(e.type)
+      )
+      return { replies, childrenWithoutReplies }
+    } catch (e) {
+      return { replies: children, childrenWithoutReplies: [] }
+    }
+  }
+
   const WrappedComponent = props => {
     const { id, children, ...customMessageProps } = props
-    const replies = React.Children.toArray(children).filter(
-      e => e.type === Reply
-    )
-    const childrenWithoutReplies = React.Children.toArray(children).filter(
-      e => ![Reply].includes(e.type)
-    )
+    const { replies, childrenWithoutReplies } = SplitChildren(props)
     return (
       <CustomMessage
         id={id}


### PR DESCRIPTION
Avoid customMessage to crash if they have bad children. Some bots may store no-react objects in children