### PR TITLE
original url for pic in carousel example returns 404

### DIFF
--- a/doc-botonic/docs/components/components-carousel.md
+++ b/doc-botonic/docs/components/components-carousel.md
@@ -88,7 +88,7 @@ export default class extends React.Component {
         desc: 'Fuck it Dude',
         url: 'https://www.imdb.com/title/tt0118715',
         pic:
-          'https://www.thelinda.org/wp-content/uploads/2018/02/Big-L-2-1.jpg',
+          'https://upload.wikimedia.org/wikipedia/en/a/a7/Snatch_ver4.jpg',
       },
       {
         name: 'Snatch',

--- a/packages/botonic-cli/templates/tutorial/src/actions/carousel.js
+++ b/packages/botonic-cli/templates/tutorial/src/actions/carousel.js
@@ -23,7 +23,7 @@ export default class extends React.Component {
         name: 'The Big Lebowski',
         desc: 'Fuck it Dude',
         url: 'https://www.imdb.com/title/tt0118715',
-        pic: 'https://www.thelinda.org/wp-content/uploads/2018/02/Big-L-2-1.jpg'
+        pic: 'https://upload.wikimedia.org/wikipedia/en/a/a7/Snatch_ver4.jpg'
       },
       {
         name: 'Snatch',


### PR DESCRIPTION
## Description

The original url for the Snatch picture in carousel example returns a 404, I propose a new pic taken from wikimedia

## Context

The carousel example looks unfinished because the picture is not there.

## Approach taken / Explain the design

replace the old pic url by a working one

## To document / Usage example

N/A

## Testing

The pull request...
 doesn't need tests because it is a really simple change and I have checked it manually
