### PR TITLE
React/ getBotonicApp

### DIFF
--- a/packages/botonic-react/src/dev-app.jsx
+++ b/packages/botonic-react/src/dev-app.jsx
@@ -3,7 +3,7 @@ import { render } from 'react-dom'
 
 import { ReactBot } from './react-bot'
 import { WebchatApp } from './webchat-app'
-import { WebchatDev } from './webchat'
+import { WebchatDev } from './webchat/webchat-dev'
 import merge from 'lodash.merge'
 
 export class DevApp extends WebchatApp {

--- a/packages/botonic-react/src/index.d.ts
+++ b/packages/botonic-react/src/index.d.ts
@@ -94,8 +94,7 @@ export function msgsToBotonic(
   customMessageTypes?: CustomMessageType[]
 ): React.ReactNode
 
-export interface WebchatAppArgs {
-  appId?: string
+export interface WebchatArgs {
   blockInputs?: BlockInputOption[]
   coverComponent?: CoverComponentOptions
   defaultDelay?: number
@@ -104,13 +103,19 @@ export interface WebchatAppArgs {
   enableAttachments?: boolean
   enableEmojiPicker?: boolean
   enableUserInput?: boolean
+  getString?: (stringId: string, session: core.Session) => string
   onClose?: (app: WebchatApp, args: any) => void
   onInit?: (app: WebchatApp, args: any) => void
   onMessage?: (app: WebchatApp, message: WebchatMessage) => void
   onOpen?: (app: WebchatApp, args: any) => void
   persistentMenu?: PersistentMenuProps
+  setLocale: (locale: string, session: core.Session) => string
   storage?: Storage
   theme?: ThemeProps
+}
+
+export interface WebchatAppArgs extends WebchatArgs {
+  appId?: string
   visibility?: () => boolean
 }
 
@@ -199,3 +204,4 @@ export class DevApp extends WebchatApp {
 }
 
 export * from './components'
+export * from './webchat'

--- a/packages/botonic-react/src/index.js
+++ b/packages/botonic-react/src/index.js
@@ -1,4 +1,4 @@
-export { Webchat } from './webchat'
+export { Webchat, getBotonicApp } from './webchat/index.js'
 export { RequestContext, WebchatContext } from './contexts'
 export { NodeApp } from './node-app'
 export { DevApp } from './dev-app'

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -1,7 +1,7 @@
 import React, { createRef } from 'react'
 import { render } from 'react-dom'
 
-import { Webchat } from './webchat'
+import { Webchat } from './webchat/webchat'
 import { HubtypeService, INPUT } from '@botonic/core'
 import { msgToBotonic } from './msg-to-botonic'
 import merge from 'lodash.merge'

--- a/packages/botonic-react/src/webchat/index.d.ts
+++ b/packages/botonic-react/src/webchat/index.d.ts
@@ -1,0 +1,17 @@
+import { WebchatArgs } from '../index'
+import * as React from 'react'
+import { RefObject } from 'react'
+
+export interface WebchatProps extends WebchatArgs {
+  ref: RefObject<any>
+  resendUnsentInputs?: () => Promise<void>
+}
+export const WebChat: React.ForwardRefExoticComponent<WebchatProps>
+
+export interface WebchatDevProps extends WebchatProps {
+  initialDevSettings?: {
+    keepSessionOnReload?: boolean
+    showSessionView?: boolean
+  }
+}
+export const WebChatDev: React.ForwardRefExoticComponent<WebchatDevProps>

--- a/packages/botonic-react/src/webchat/index.d.ts
+++ b/packages/botonic-react/src/webchat/index.d.ts
@@ -1,4 +1,4 @@
-import { WebchatArgs } from '../index'
+import { WebchatApp, WebchatArgs } from '../index'
 import * as React from 'react'
 import { RefObject } from 'react'
 
@@ -15,3 +15,5 @@ export interface WebchatDevProps extends WebchatProps {
   }
 }
 export const WebChatDev: React.ForwardRefExoticComponent<WebchatDevProps>
+
+export function getBotonicApp(): WebchatApp

--- a/packages/botonic-react/src/webchat/index.js
+++ b/packages/botonic-react/src/webchat/index.js
@@ -1,2 +1,11 @@
 export { Webchat } from './webchat'
 export { WebchatDev } from './webchat-dev'
+
+/**
+ * @returns {WebChatApp}
+ */
+export function getBotonicApp() {
+  // Botonic is exported from your bot
+  // eslint-disable-next-line no-undef
+  return Botonic
+}


### PR DESCRIPTION

## Description

* Types for botonic-react WebChat & WebChatDev
* New getBotonicApp() to access the instance of WebChat on the browser

## Context

Currently to access the webchat app from a bot webchat in typescript, you have to do:
```
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
      //@ts-ignore
      Botonic.getMessages()
```
and you don't get the type of Botonic. 

Now this is solved with getBotonicApp()

## To document / Usage example

Copy "COntext" section above in documentation.

## Testing

Cannot be tested without a browser