### PR TITLE
feat(react): add 'storageKey' webchat setting #BOT-133

### DIFF
--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -40,6 +40,7 @@ export const WEBCHAT = {
     BORDER_RADIUS_TOP_CORNERS: '6px 6px 0px 0px',
     ELEMENT_WIDTH: 222,
     ELEMENT_MARGIN_RIGHT: 6,
+    STORAGE_KEY: 'botonicState',
   },
   CUSTOM_PROPERTIES: {
     webviewStyle: 'webview.style',
@@ -109,7 +110,6 @@ export const WEBCHAT = {
     enableCarouselArrows: 'carousel.enableArrows',
     customCarouselLeftArrow: 'carousel.arrow.left',
     customCarouselRightArrow: 'carousel.arrow.right',
-    storage: 'storage',
   },
 }
 

--- a/packages/botonic-react/src/dev-app.jsx
+++ b/packages/botonic-react/src/dev-app.jsx
@@ -17,6 +17,7 @@ export class DevApp extends WebchatApp {
     enableUserInput,
     enableAnimations,
     storage,
+    storageKey,
     onInit,
     onOpen,
     onClose,
@@ -33,6 +34,7 @@ export class DevApp extends WebchatApp {
       enableUserInput,
       enableAnimations,
       storage,
+      storageKey,
       onInit,
       onOpen,
       onClose,
@@ -54,6 +56,7 @@ export class DevApp extends WebchatApp {
       enableUserInput,
       enableAnimations,
       storage,
+      storageKey,
       onInit,
       onOpen,
       onClose,
@@ -69,6 +72,7 @@ export class DevApp extends WebchatApp {
     enableUserInput = enableUserInput || this.enableUserInput
     enableAnimations = enableAnimations || this.enableAnimations
     storage = storage || this.storage
+    storageKey = storageKey || this.storageKey
     this.onInit = onInit || this.onInit
     this.onOpen = onOpen || this.onOpen
     this.onClose = onClose || this.onClose
@@ -86,6 +90,7 @@ export class DevApp extends WebchatApp {
         enableUserInput={enableUserInput}
         enableAnimations={enableAnimations}
         storage={storage}
+        storageKey={storageKey}
         getString={(stringId, session) => this.bot.getString(stringId, session)}
         setLocale={(locale, session) => this.bot.setLocale(locale, session)}
         onInit={(...args) => this.onInitWebchat(...args)}

--- a/packages/botonic-react/src/index.d.ts
+++ b/packages/botonic-react/src/index.d.ts
@@ -110,6 +110,7 @@ export interface WebchatAppArgs {
   onOpen?: (app: WebchatApp, args: any) => void
   persistentMenu?: PersistentMenuProps
   storage?: Storage
+  storageKey?: any
   theme?: ThemeProps
   visibility?: () => boolean
 }

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -192,6 +192,7 @@ export class WebchatApp {
       defaultDelay,
       defaultTyping,
       storage,
+      storageKey,
       onInit,
       onOpen,
       onClose,
@@ -211,6 +212,7 @@ export class WebchatApp {
     defaultDelay = defaultDelay || this.defaultDelay
     defaultTyping = defaultTyping || this.defaultTyping
     storage = storage || this.storage
+    storageKey = storageKey || this.storageKey
     this.onInit = onInit || this.onInit
     this.onOpen = onOpen || this.onOpen
     this.onClose = onClose || this.onClose
@@ -230,6 +232,7 @@ export class WebchatApp {
         enableUserInput={enableUserInput}
         enableAnimations={enableAnimations}
         storage={storage}
+        storageKey={storageKey}
         defaultDelay={defaultDelay}
         defaultTyping={defaultTyping}
         onInit={(...args) => this.onInitWebchat(...args)}

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -159,6 +159,7 @@ const createUser = () => {
   }
 }
 
+// eslint-disable-next-line complexity
 export const Webchat = forwardRef((props, ref) => {
   const {
     webchatState,
@@ -191,22 +192,18 @@ export const Webchat = forwardRef((props, ref) => {
   const isOnline = useNetwork()
   const getThemeProperty = _getThemeProperty(theme)
 
-  const getStorage = () => {
-    const storage = getThemeProperty(
-      WEBCHAT.CUSTOM_PROPERTIES.storage,
-      props.storage
-    )
-    if (storage === undefined) return localStorage
-    return storage
-  }
-
+  const storage = props.storage === undefined ? localStorage : props.storage
+  const storageKey =
+    typeof props.storageKey === 'function'
+      ? props.storageKey()
+      : props.storageKey
   const [botonicState, saveState, writeError] = useStorageState(
-    getStorage(),
-    'botonicState'
+    storage,
+    storageKey || WEBCHAT.DEFAULTS.STORAGE_KEY
   )
 
   const saveWebchatState = webchatState => {
-    getStorage() &&
+    storage &&
       saveState({
         messages: webchatState.messagesJSON,
         session: webchatState.session,

--- a/packages/botonic-react/tests/webchat/storage.test.jsx
+++ b/packages/botonic-react/tests/webchat/storage.test.jsx
@@ -45,3 +45,34 @@ describe('TEST: storage', () => {
     expect(sessionStorage.getItem('botonicState')).toBeNull()
   })
 })
+
+describe('TEST: storageKey', () => {
+  afterEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('Stores botonicState in the localStorage key defined in the settings', async () => {
+    await act(async () => {
+      TestRenderer.create(<Webchat storageKey='myCustomKey' />)
+    })
+    expect(localStorage.getItem('botonicState')).toBeNull()
+    expect(localStorage.getItem('myCustomKey')).not.toBeNull()
+  })
+
+  it('Stores botonicState in the localStorage key returned if storageKey is a function', async () => {
+    await act(async () => {
+      TestRenderer.create(<Webchat storageKey={() => 'myCustomKey'} />)
+    })
+    expect(localStorage.getItem('botonicState')).toBeNull()
+    expect(localStorage.getItem('myCustomKey')).not.toBeNull()
+  })
+
+  it('Stores botonicState in the default localStorage key if storageKey is null', async () => {
+    await act(async () => {
+      TestRenderer.create(<Webchat storageKey={null} />)
+    })
+    expect(localStorage.getItem('botonicState')).not.toBeNull()
+    expect(localStorage.getItem('myCustomKey')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Description

Add a new webchat setting `storageKey` that indicates what key name to use in order to store the webchat state in localStorage (or sessionStorage).
It can be any "stringable" object, or a function, in that case the return value of the function will be used. If a falsy object is passed then the default value "botonicState" will be used.

Note: I also took the chance to refactor a little bit the "storage" functionality by removing some unnecessary code.

## Context

Some clients need to have different webchat SDKs under the same domain. For example:
* customer.com/help --> Bot about FAQs
* customer.com/product --> Live agent chat for pre-sales

The problem is that localStorage is defined at domain level, so different instances of the webchat SDK would end up sharing the state (history of messages, etc), which is not desirable.
By adding a configurable localstorage key we can now have multiple SDKs without this conflicts.

## Approach taken / Explain the design


## To document / Usage example

Just define a 'storageKey' param in wechat settings:
```
const webchat = {
  storageKey: 'myCustomBotonicStateKey'
}
```

or using a function:
```
const webchat = {
  storageKey: () => 'myCustomBotonicStateKey'
}
```

## Testing

The pull request...

- has unit tests
