### PR TITLE
fix(react): trigger onMessage in deployed bot messages

### DIFF
--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -91,7 +91,10 @@ export class WebchatApp {
       this.updateWebchatSettings(event.message.data)
     else if (event.message.type === 'sender_action')
       this.setTyping(event.message.data === 'typing_on')
-    else this.addBotMessage(event.message)
+    else {
+      this.onMessage(this, { from: 'bot', message: event.message })
+      this.addBotMessage(event.message)
+    }
   }
 
   updateUser(user) {


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
Trigger `onMessage()` when a message is sent by the bot in deployed bots.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
The function `onMessage()` was not being triggered in the deployed bots when the messages where sent by the bot.
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
