### PR TITLE
refactor(contentful): CMS.(top)contents to use generics

### DIFF
--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -105,12 +105,12 @@ export class DummyCMS implements CMS {
     return Promise.resolve(new Queue(new CommonFields(id, id), id))
   }
 
-  topContents(
+  topContents<T extends TopContent>(
     model: TopContentType,
     context?: Context,
     filter?: (cf: CommonFields) => boolean,
     paging?: PagingOptions
-  ): Promise<TopContent[]> {
+  ): Promise<T[]> {
     return Promise.resolve([])
   }
 
@@ -158,11 +158,11 @@ export class DummyCMS implements CMS {
     return this.text(id, context)
   }
 
-  contents(
+  contents<T extends Content>(
     contentType: ContentType,
     context?: Context,
     paging?: PagingOptions
-  ): Promise<Content[]> {
+  ): Promise<T[]> {
     return Promise.resolve([])
   }
 

--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -111,14 +111,14 @@ export class ErrorReportingCMS implements CMS {
       .catch(this.handleError('contentsWithKeywords', context))
   }
 
-  topContents(
+  topContents<T extends TopContent>(
     model: TopContentType,
     context?: Context,
     filter?: (cf: CommonFields) => boolean,
     paging?: PagingOptions
-  ): Promise<TopContent[]> {
+  ): Promise<T[]> {
     return this.cms
-      .topContents(model, context, filter, paging)
+      .topContents<T>(model, context, filter, paging)
       .catch(this.handleError('topContents', context))
   }
 
@@ -128,13 +128,13 @@ export class ErrorReportingCMS implements CMS {
       .catch(this.handleContentError('content' as ContentType, id, context))
   }
 
-  contents(
+  contents<T extends Content>(
     contentType: ContentType,
     context?: Context,
     paging?: PagingOptions
-  ): Promise<Content[]> {
+  ): Promise<T[]> {
     return this.cms
-      .contents(contentType, context, paging)
+      .contents<T>(contentType, context, paging)
       .catch(this.handleError('contents', context))
   }
 

--- a/packages/botonic-plugin-contentful/src/cms/cms-log.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-log.ts
@@ -84,21 +84,21 @@ export class LogCMS implements CMS {
     return this.cms.contentsWithKeywords(context)
   }
 
-  topContents(
+  topContents<T extends TopContent>(
     model: TopContentType,
     context?: Context,
     filter?: (cf: CommonFields) => boolean,
     paging?: PagingOptions
-  ): Promise<TopContent[]> {
+  ): Promise<T[]> {
     this.logger(`topContents of model ${model}`)
     return this.cms.topContents(model, context, filter, paging)
   }
 
-  contents(
+  contents<T extends Content>(
     contentType: ContentType,
     context?: Context,
     paging?: PagingOptions
-  ): Promise<Content[]> {
+  ): Promise<T[]> {
     this.logger(`contents of model ${contentType}`)
     return this.cms.contents(contentType, context, paging)
   }

--- a/packages/botonic-plugin-contentful/src/cms/cms-multilocale.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-multilocale.ts
@@ -46,11 +46,11 @@ export class MultiContextCms implements CMS {
     return this.cmsFromContext(context).content(id, context)
   }
 
-  contents(
+  contents<T extends Content>(
     contentType: ContentType,
     context?: Context,
     paging?: PagingOptions
-  ): Promise<Content[]> {
+  ): Promise<T[]> {
     return this.cmsFromContext(context).contents(contentType, context, paging)
   }
 
@@ -90,12 +90,12 @@ export class MultiContextCms implements CMS {
     return this.cmsFromContext(context).text(id, context)
   }
 
-  topContents(
+  topContents<T extends TopContent>(
     model: TopContentType,
     context?: Context,
     filter?: (cf: CommonFields) => boolean,
     paging?: PagingOptions
-  ): Promise<TopContent[]> {
+  ): Promise<T[]> {
     return this.cmsFromContext(context).topContents(
       model,
       context,

--- a/packages/botonic-plugin-contentful/src/cms/cms.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms.ts
@@ -117,12 +117,12 @@ export interface CMS {
    * If ContentfulOptions.resumeErrors is set: if some contents fail to be devilered,
    * an error will be displayed but the result will be returned.
    */
-  topContents(
+  topContents<T extends TopContent>(
     model: TopContentType,
     context?: Context,
     filter?: (cf: CommonFields) => boolean,
     paging?: PagingOptions
-  ): Promise<TopContent[]>
+  ): Promise<T[]>
 
   content(id: string, context?: Context): Promise<Content>
 
@@ -130,11 +130,11 @@ export interface CMS {
    * If ContentfulOptions.resumeErrors is set: if some contents fail to be delivered,
    * an error will be displayed but the result will be returned.
    */
-  contents(
+  contents<T extends Content>(
     contentType: ContentType,
     context?: Context,
     paging?: PagingOptions
-  ): Promise<Content[]>
+  ): Promise<T[]>
 
   assets(context?: Context, paging?: PagingOptions): Promise<Asset[]>
 

--- a/packages/botonic-plugin-contentful/src/cms/transform/cms-filter.ts
+++ b/packages/botonic-plugin-contentful/src/cms/transform/cms-filter.ts
@@ -112,22 +112,27 @@ export class FilteredCMS implements CMS {
     return this.cms.contentsWithKeywords(context)
   }
 
-  async topContents(
+  async topContents<T extends TopContent>(
     model: TopContentType,
     context?: Context,
     filter?: (cf: CommonFields) => boolean,
     paging?: PagingOptions
-  ): Promise<TopContent[]> {
-    const contents = await this.cms.topContents(model, context, filter, paging)
+  ): Promise<T[]> {
+    const contents = await this.cms.topContents<T>(
+      model,
+      context,
+      filter,
+      paging
+    )
     return this.filterContents(contents, context)
   }
 
-  async contents(
+  async contents<T extends Content>(
     contentType: ContentType,
     context?: Context | undefined,
     paging?: PagingOptions
-  ): Promise<Content[]> {
-    const contents = await this.cms.contents(contentType, context, paging)
+  ): Promise<T[]> {
+    const contents = await this.cms.contents<T>(contentType, context, paging)
     return this.filterContents(contents, context)
   }
 

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -138,12 +138,12 @@ export class Contentful implements cms.CMS {
     return this._text.text(id, context)
   }
 
-  topContents(
+  topContents<T extends TopContent>(
     model: TopContentType,
     context = DEFAULT_CONTEXT,
     filter?: (cf: CommonFields) => boolean,
     paging = new PagingOptions()
-  ): Promise<TopContent[]> {
+  ): Promise<T[]> {
     return this._contents.topContents(
       model,
       context,
@@ -158,11 +158,11 @@ export class Contentful implements cms.CMS {
     return this.contentFromEntry(entry, context)
   }
 
-  contents(
+  contents<T extends Content>(
     contentType: ContentType,
     context = DEFAULT_CONTEXT,
     paging = new PagingOptions()
-  ): Promise<Content[]> {
+  ): Promise<T[]> {
     return this._contents.contents(
       contentType,
       context,
@@ -171,29 +171,30 @@ export class Contentful implements cms.CMS {
     )
   }
 
-  async topContentFromEntry(
+  async topContentFromEntry<T extends TopContent>(
     entry: contentful.Entry<any>,
     context: Context
-  ): Promise<TopContent> {
+  ): Promise<T> {
     const model = ContentfulEntryUtils.getContentModel(entry)
+    const retype = (c: TopContent) => c as T
     switch (model) {
       case ContentType.CAROUSEL:
-        return await this._carousel.fromEntry(entry, context)
+        return retype(await this._carousel.fromEntry(entry, context))
       case ContentType.QUEUE:
-        return this._queue.fromEntry(entry)
+        return retype(this._queue.fromEntry(entry))
       case ContentType.CHITCHAT:
       case ContentType.TEXT:
-        return await this._text.fromEntry(entry, context)
+        return retype(await this._text.fromEntry(entry, context))
       case ContentType.IMAGE:
-        return await this._image.fromEntry(entry, context)
+        return retype(await this._image.fromEntry(entry, context))
       case ContentType.URL:
-        return await this._url.fromEntry(entry, context)
+        return retype(await this._url.fromEntry(entry, context))
       case ContentType.STARTUP:
-        return await this._startUp.fromEntry(entry, context)
+        return retype(await this._startUp.fromEntry(entry, context))
       case ContentType.SCHEDULE:
-        return this._schedule.fromEntry(entry)
+        return retype(this._schedule.fromEntry(entry))
       case ContentType.DATE_RANGE:
-        return DateRangeDelivery.fromEntry(entry)
+        return retype(DateRangeDelivery.fromEntry(entry))
       default:
         throw new Error(`${model} is not a Content type`)
     }
@@ -202,18 +203,19 @@ export class Contentful implements cms.CMS {
   }
 
   // TODO move all delivery instances to a class
-  async contentFromEntry(
+  async contentFromEntry<T extends Content>(
     entry: contentful.Entry<any>,
     context: Context
-  ): Promise<Content> {
+  ): Promise<T> {
     const model = ContentfulEntryUtils.getContentModel(entry)
+    const retype = (c: Content) => c as T
     switch (model) {
       case ContentType.BUTTON:
-        return this._button.fromEntry(entry, context)
+        return retype(this._button.fromEntry(entry, context))
       case ContentType.ELEMENT:
-        return this._carousel.elementFromEntry(entry, context)
+        return retype(await this._carousel.elementFromEntry(entry, context))
       default:
-        return this.topContentFromEntry(entry, context)
+        return retype(await this.topContentFromEntry(entry, context))
     }
   }
 

--- a/packages/botonic-plugin-contentful/src/contentful/contents/contents.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/contents.ts
@@ -18,12 +18,12 @@ import { ResourceDelivery } from '../content-delivery'
  * Retrieve multiple contents in a single call
  */
 export class ContentsDelivery extends ResourceDelivery {
-  async contents(
+  async contents<T extends Content>(
     contentType: ContentType,
     context: Context,
-    factory: (entry: contentful.Entry<any>, ctxt: Context) => Promise<Content>,
+    factory: (entry: contentful.Entry<any>, ctxt: Context) => Promise<T>,
     paging: PagingOptions
-  ): Promise<Content[]> {
+  ): Promise<T[]> {
     const entryCollection: EntryCollection<CommonEntryFields> = await this.delivery.getEntries(
       context,
       this.query(contentType, paging)
@@ -33,16 +33,13 @@ export class ContentsDelivery extends ResourceDelivery {
     )
   }
 
-  async topContents(
+  async topContents<T extends TopContent>(
     model: TopContentType,
     context: Context,
-    factory: (
-      entry: contentful.Entry<any>,
-      ctxt: Context
-    ) => Promise<TopContent>,
+    factory: (entry: contentful.Entry<any>, ctxt: Context) => Promise<T>,
     filter: ((cf: CommonFields) => boolean) | undefined,
     paging: PagingOptions
-  ): Promise<TopContent[]> {
+  ): Promise<T[]> {
     const entryCollection: EntryCollection<CommonEntryFields> = await this.delivery.getEntries(
       context,
       this.query(model, paging)


### PR DESCRIPTION
CMS.contents & CMS.topContents now use generics so that now they can return the specific subtype of Content desired 