### PR TITLE
Contentful/multiple field update

### DIFF
--- a/packages/botonic-plugin-contentful/src/manage-cms/fields.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/fields.ts
@@ -1,4 +1,4 @@
-import { CmsException } from '../cms'
+import { CmsException, ContentType } from '../cms'
 
 export enum ContentFieldType {
   TEXT = 'Text',
@@ -66,4 +66,16 @@ export const CONTENT_FIELDS = new Map<ContentFieldType, ContentField>(
 
 function pairs(cfs: ContentField[]): [ContentFieldType, ContentField][] {
   return cfs.map(cf => [cf.fieldType, cf])
+}
+
+export class I18nField {
+  constructor(readonly name: ContentFieldType, readonly value: string) {}
+}
+
+export const FIELDS_PER_CONTENT_TYPE: { [type: string]: ContentFieldType[] } = {
+  [ContentType.BUTTON]: [ContentFieldType.TEXT],
+  [ContentType.STARTUP]: [ContentFieldType.SHORT_TEXT, ContentFieldType.TEXT],
+  [ContentType.TEXT]: [ContentFieldType.SHORT_TEXT, ContentFieldType.TEXT],
+  [ContentType.ELEMENT]: [ContentFieldType.TITLE, ContentFieldType.SUBTITLE],
+  [ContentType.URL]: [ContentFieldType.SHORT_TEXT, ContentFieldType.URL],
 }

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
@@ -11,15 +11,14 @@ export class ErrorReportingManageCms implements ManageCms {
 
   constructor(readonly manageCms: ManageCms, readonly logErrors = true) {}
 
-  updateField<T extends cms.Content>(
+  updateFields<T extends cms.Content>(
     context: ManageContext,
     contentId: ContentId,
-    fieldType: ContentFieldType,
-    value: any
+    fields: { [contentFieldType: string]: any }
   ): Promise<void> {
     return this.manageCms
-      .updateField(context, contentId, fieldType, value)
-      .catch(this.handleError('updateField', context, contentId))
+      .updateFields(context, contentId, fields)
+      .catch(this.handleError('updateFields', context, contentId))
   }
 
   copyField<T extends cms.Content>(

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
@@ -14,11 +14,10 @@ export interface ManageCms {
    */
   getDefaultLocale(): Promise<Locale>
 
-  updateField(
+  updateFields(
     context: ManageContext,
     contentId: ContentId,
-    fieldType: ContentFieldType,
-    value: any
+    fields: { [contentFieldType: string]: any }
   ): Promise<void>
 
   /** Will not fail if source does not have this field */

--- a/packages/botonic-plugin-contentful/src/nlp/util/strings.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/util/strings.ts
@@ -1,0 +1,28 @@
+import escapeStringRegexp from 'escape-string-regexp'
+
+export function ltrim(str: string, chars: string): string {
+  while (str.length && chars.includes(str[0])) {
+    str = str.slice(1)
+  }
+  return str
+}
+
+export function rtrim(str: string, chars: string): string {
+  while (str.length && chars.includes(str[str.length - 1])) {
+    str = str.slice(0, str.length - 1)
+  }
+  return str
+}
+
+export function trim(str: string, chars: string): string {
+  str = rtrim(str, chars)
+  return ltrim(str, chars)
+}
+
+/**
+ * String.replaceAll only available in esnext
+ */
+export function replaceAll(haystack: string, oldStr: string, newStr: string) {
+  oldStr = escapeStringRegexp(oldStr)
+  return haystack.replace(new RegExp(oldStr, 'g'), newStr)
+}

--- a/packages/botonic-plugin-contentful/src/tools/l10n/csv-export.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/csv-export.ts
@@ -10,19 +10,19 @@ import {
   Url,
 } from '../../index'
 import { Locale } from '../../nlp'
-import { Text, ContentType } from '../../cms'
+import { ContentType, Text } from '../../cms'
 import * as stream from 'stream'
 import * as fs from 'fs'
 import { promisify } from 'util'
 import sort from 'sort-stream'
 import stringify from 'csv-stringify'
-import { ContentField, ContentFieldType } from '../../manage-cms/fields'
+import {
+  ContentField,
+  ContentFieldType,
+  I18nField,
+} from '../../manage-cms/fields'
 
 const finished = promisify(stream.finished)
-
-export class I18nField {
-  constructor(readonly name: ContentFieldType, readonly value: string) {}
-}
 
 type CsvLine = string[]
 

--- a/packages/botonic-plugin-contentful/src/tools/l10n/export-csv-for-translators.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/export-csv-for-translators.ts
@@ -1,9 +1,10 @@
-import { CsvExport, I18nField, skipEmptyStrings } from './csv-export'
+import { CsvExport, skipEmptyStrings } from './csv-export'
 import { Locale } from '../../nlp'
 import { ContentfulOptions } from '../../plugin'
 import { Contentful } from '../../contentful/cms-contentful'
 import { ErrorReportingCMS } from '../../cms'
 import { ContentFieldType } from '../../manage-cms'
+import { I18nField } from '../../manage-cms/fields'
 
 export class PostProcessor {
   constructor(readonly targetLocale: string) {}

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
@@ -17,7 +17,7 @@ function ctxt(ctx: Partial<ManageContext>): ManageContext {
 describe('ManageContentful fields', () => {
   const TEST_MANAGE_CMS_ID = '627QkyJrFo3grJryj0vu6L'
 
-  test('TEST: updateField on an empty field', async () => {
+  test('TEST: updateFields on an empty field', async () => {
     const contentful = testContentful({ disableCache: true })
     const old = await contentful.text(
       TEST_MANAGE_CMS_ID,
@@ -34,12 +34,9 @@ describe('ManageContentful fields', () => {
         )
       }
       // ACT
-      await sut.updateField(
-        ctxt({ locale: SPANISH }),
-        old.contentId,
-        ContentFieldType.TEXT,
-        newValue
-      )
+      await sut.updateFields(ctxt({ locale: SPANISH }), old.contentId, {
+        [ContentFieldType.TEXT]: newValue,
+      })
       await repeatWithBackoff(async () => {
         const newContent = await contentful.text(old.id, {
           locale: SPANISH,
@@ -48,11 +45,10 @@ describe('ManageContentful fields', () => {
       })
     } finally {
       // RESTORE
-      await sut.updateField(
+      await sut.updateFields(
         ctxt({ locale: SPANISH, allowOverwrites: true }),
         old.contentId,
-        ContentFieldType.TEXT,
-        ''
+        { [ContentFieldType.TEXT]: '' }
       )
       await repeatWithBackoff(async () => {
         const restored = await contentful.text(old.id, {
@@ -63,16 +59,15 @@ describe('ManageContentful fields', () => {
     }
   }, 40000)
 
-  test('TEST: updateField by default does not allow overwrites', async () => {
+  test('TEST: updateFields by default does not allow overwrites', async () => {
     const sut = testManageContentful()
 
     try {
       expect.assertions(4)
-      await sut.updateField(
+      await sut.updateFields(
         ctxt({ locale: TEST_DEFAULT_LOCALE }),
         new cms.ContentId(cms.ContentType.BUTTON, TEST_MANAGE_CMS_ID),
-        ContentFieldType.TEXT,
-        rndStr()
+        { [ContentFieldType.TEXT]: rndStr() }
       )
     } catch (e) {
       // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
@@ -80,7 +75,7 @@ describe('ManageContentful fields', () => {
       if (e instanceof CmsException) {
         // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
         expect(e.message).toInclude(
-          "Error calling ManageCms.updateField with locale 'en' on 'button' with id '627QkyJrFo3grJryj0vu6L'. " +
+          "Error calling ManageCms.updateFields with locale 'en' on 'button' with id '627QkyJrFo3grJryj0vu6L'. " +
             "Due to: Cannot overwrite field 'text' of entry '627QkyJrFo3grJryj0vu6L'"
         )
         // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
@@ -126,11 +121,10 @@ describe('ManageContentful fields', () => {
       })
     } finally {
       // RESTORE
-      await sut.updateField(
+      await sut.updateFields(
         ctxt({ locale: TO_LOCALE, allowOverwrites: true }),
         oldContent.contentId,
-        ContentFieldType.BUTTONS,
-        []
+        { [ContentFieldType.BUTTONS]: [] }
       )
       await repeatWithBackoff(async () => {
         const restored = await contentful.text(oldContent.id, {

--- a/packages/botonic-plugin-contentful/tests/nlp/util/strings.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/util/strings.test.ts
@@ -1,0 +1,17 @@
+import { ltrim, replaceAll, rtrim, trim } from '../../../src/nlp/util/strings'
+
+test('ltrim', () => {
+  expect(ltrim('. hola', ' .')).toEqual('hola')
+})
+
+test('rtrim', () => {
+  expect(rtrim('hola. ', ' .')).toEqual('hola')
+})
+
+test('trim', () => {
+  expect(trim(' hola..', ' .')).toEqual('hola')
+})
+
+test('replaceAll', () => {
+  expect(replaceAll('$me$at', '$', '')).toEqual('meat')
+})


### PR DESCRIPTION
## Description
Now the csv importer of texts coming from content translator groups all the fields from the same content. Advantages:
* It enables updating all the fields for the same content in a single API call to the CMS. In this PR we have modified the ManageCms interface to be able to update multiple fields in a single call.
* In the future it will be easier to implement the feature of renaming the content name/code field
* In a future PR we will detect when contents don't make sense for the imported locale. In this case, we'll remove the references (buttons) leading to this content for this particular locale.

## Context

We want to be able to implement the last of the 3 points above.


## To document / Usage example
We have modified the ManageCms interface to be able to update multiple content fields in a single call.

## Testing

- has unit tests
- has integration tests
