### PR TITLE
fix(react): fix missing storageKey in constructor

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.15.1",
+  "version": "0.15.2-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.15.2-alpha.0",
+  "version": "0.15.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.15.2-alpha.0",
+  "version": "0.15.2",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.15.1",
+  "version": "0.15.2-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -19,6 +19,7 @@ export class WebchatApp {
     defaultDelay,
     defaultTyping,
     storage,
+    storageKey,
     onInit,
     onOpen,
     onClose,
@@ -37,6 +38,7 @@ export class WebchatApp {
     this.defaultDelay = defaultDelay
     this.defaultTyping = defaultTyping
     this.storage = storage
+    this.storageKey = storageKey
     this.onInit = onInit
     this.onOpen = onOpen
     this.onClose = onClose


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

Add missing `storageKey` attribute in constructor.

## Context
`storageKey` was missing in `WebchatApp` constructor. I think it could be working when calling it from `index.html` but not when calling directly inside `webchat/index.js`.