### PR TITLE
fix(core/react): make sending unsent inputs more consistent

### DIFF
--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -98,7 +98,7 @@ export class HubtypeService {
   handleUnsentInput(message) {
     this.onEvent({
       action: 'update_message_info',
-      message: { id: message.id, unsentInput: message },
+      message: { id: message.id, ack: 0, unsentInput: message },
     })
   }
 

--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -137,7 +137,8 @@ export class HubtypeService {
 
   async resendUnsentInputs() {
     for (const message of this.unsentInputs()) {
-      await this.postMessage(this.user, message.unsentInput)
+      message.unsentInput &&
+        (await this.postMessage(this.user, message.unsentInput))
     }
   }
 }

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -81,7 +81,9 @@ export class WebchatApp {
         lastMessageUpdateDate: this.getLastMessageUpdate(),
         onEvent: event => this.onServiceEvent(event),
         unsentInputs: () =>
-          this.webchatRef.current.getMessages().filter(msg => msg.ack === 0),
+          this.webchatRef.current
+            .getMessages()
+            .filter(msg => msg.ack === 0 && msg.unsentInput),
       })
     }
   }

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -550,7 +550,9 @@ export const Webchat = forwardRef((props, ref) => {
       const messageToUpdate = webchatState.messagesJSON.filter(
         m => m.id == msgId
       )[0]
-      updateMessage({ ...messageToUpdate, ...messageInfo })
+      const updatedMsg = merge(messageToUpdate, messageInfo)
+      if (updatedMsg.ack === 1) delete updatedMsg.unsentInput
+      updateMessage(updatedMsg)
     },
     updateWebchatSettings: settings => {
       const themeUpdates = normalizeWebchatSettings(settings)


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
Be more consistent when resending inputs. 
* Filter now takes into account that `unsentInput` comes as a message property, not only the ack set to 0.
* Explicitly handle unsent messages by adding the ack 0.
* Once the message is updated remove unnecessary `unsentInput` property from a message.

## Context
We were having lots of these messages in the server: `Exception: 'message' not found in imp event data: ...`... This happened when in fact a message was sent properly but due to some race condition the `ack` continued being set to 0 and had no `unsentInput` property.

**E.g:**
```
for (const message of this.unsentInputs()) { // this.unsentInputs() --> Sometimes returns some messages without unsentInput property
      await this.postMessage(this.user, message.unsentInput) // --> was being called with this.postMessage(this.user, undefined), hence the error.
}
```