### PR TITLE
Revert "chore(deps): bump react-textarea-autosize from 7.1.2 to 8.3.0"

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -4506,13 +4506,12 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.0.tgz",
-      "integrity": "sha512-3GLWFAan2pbwBeoeNDoqGmSbrShORtgWfaWX0RJDivsUrpShh01saRM5RU/i4Zmf+whpBVEY5cA90Eq8Ub1N3w==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz",
+      "integrity": "sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==",
       "requires": {
-        "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.0.0",
-        "use-latest": "^1.0.0"
+        "@babel/runtime": "^7.1.2",
+        "prop-types": "^15.6.0"
       }
     },
     "react-use-storage": {
@@ -5154,11 +5153,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "ts-essentials": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
-      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
-    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -5299,27 +5293,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/use-async-effect/-/use-async-effect-2.2.2.tgz",
       "integrity": "sha512-zFas5h1jm4FNCk+txUzfMUAQhIFJGdrhAmg2lSA+Q6BZKYFen/yZlHEx5RGWSUV1USjLFZ+yg989fFyzJHW3Zw=="
-    },
-    "use-composed-ref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
-      "integrity": "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==",
-      "requires": {
-        "ts-essentials": "^2.0.3"
-      }
-    },
-    "use-isomorphic-layout-effect": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.0.tgz",
-      "integrity": "sha512-kady5Z1O1qx5RitodCCKbpJSVEtECXYcnBnb5Q48Bz5V6gBmTu85ZcGdVwVFs8+DaOurNb/L5VdGHoQRMknghw=="
-    },
-    "use-latest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.0.tgz",
-      "integrity": "sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==",
-      "requires": {
-        "use-isomorphic-layout-effect": "^1.0.0"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -36,7 +36,7 @@
     "react-json-tree": "^0.12.1",
     "react-reveal": "^1.2.2",
     "react-router-dom": "^5.2.0",
-    "react-textarea-autosize": "^8.3.0",
+    "react-textarea-autosize": "^7.1.2",
     "react-use-storage": "^0.4.3",
     "rebass": "^4.0.7",
     "simplebar-react": "^2.2.1",


### PR DESCRIPTION
Reverts hubtype/botonic#1076
Newest versions break some styles and have breaking changes: #973