### PR TITLE
feat(core): add new request matcher, fix minor issues

### DIFF
--- a/packages/botonic-core/src/core-bot.js
+++ b/packages/botonic-core/src/core-bot.js
@@ -66,7 +66,10 @@ export class CoreBot {
 
     if (isFunction(this.routes)) {
       this.router = new Router(
-        [...(await this.routes({ input, session })), ...this.defaultRoutes],
+        [
+          ...(await this.routes({ input, session, lastRoutePath })),
+          ...this.defaultRoutes,
+        ],
         this.inspector.routeInspector
       )
     }

--- a/packages/botonic-core/src/index.d.ts
+++ b/packages/botonic-core/src/index.d.ts
@@ -119,15 +119,18 @@ export interface Session {
   user: SessionUser
 }
 
-type StringMatcher = RegExp | string | ((data: string) => boolean)
+type InputMatcher = (input: Input) => boolean
 type ParamsMatcher =
   | { [key: string]: string }
   | ((params: { [key: string]: string }) => boolean)
 type SessionMatcher = (session: Session) => boolean
-type InputMatcher = (input: Input) => boolean
+type RequestMatcher = (input: Input, session: Session) => boolean
+type StringMatcher = RegExp | string | ((data: string) => boolean)
+
 type RouteMatcher =
   | InputMatcher
   | ParamsMatcher
+  | RequestMatcher
   | SessionMatcher
   | StringMatcher
 

--- a/packages/botonic-core/src/index.d.ts
+++ b/packages/botonic-core/src/index.d.ts
@@ -124,7 +124,7 @@ type ParamsMatcher =
   | { [key: string]: string }
   | ((params: { [key: string]: string }) => boolean)
 type SessionMatcher = (session: Session) => boolean
-type RequestMatcher = (input: Input, session: Session) => boolean
+type RequestMatcher = (request: BotRequest) => boolean
 type StringMatcher = RegExp | string | ((data: string) => boolean)
 
 type RouteMatcher =
@@ -146,6 +146,7 @@ export interface Route {
   intent?: StringMatcher
   params?: ParamsMatcher
   payload?: StringMatcher
+  request?: RequestMatcher
   session?: SessionMatcher
   text?: StringMatcher
   type?: StringMatcher

--- a/packages/botonic-core/src/router.js
+++ b/packages/botonic-core/src/router.js
@@ -195,7 +195,7 @@ export class Router {
 
   matchRoute(route, prop, matcher, input, session) {
     /*
-        prop: ('text' | 'payload' | 'intent' | 'type' | 'input' | 'session' |...)
+        prop: ('text' | 'payload' | 'intent' | 'type' | 'input' | 'session' | 'request' ...)
         matcher: (string: exact match | regex: regular expression match | function: return true)
         input: user input object, ex: {type: 'text', data: 'Hi'}
       */
@@ -205,6 +205,7 @@ export class Router {
       if (input.type == 'text') value = input.data
     } else if (prop == 'input') value = input
     else if (prop == 'session') value = session
+    else if (prop == 'request') value = { input, session }
     const matched = this.matchValue(matcher, value)
     if (matched) {
       this.routeInspector.routeMatched(route, prop, matcher, value)

--- a/packages/botonic-core/src/router.js
+++ b/packages/botonic-core/src/router.js
@@ -47,7 +47,7 @@ export class Router {
       //get in childRoute if one has path ''
       let defaultAction
       if (
-        !routeParams.route.path &&
+        !(routeParams.route && routeParams.route.path) &&
         routeParams.route &&
         routeParams.route.childRoutes &&
         routeParams.route.childRoutes.length
@@ -58,7 +58,7 @@ export class Router {
           session
         )
       }
-      if ('action' in routeParams.route) {
+      if (routeParams.route && 'action' in routeParams.route) {
         if (
           brokenFlow &&
           routeParams.route.ignoreRetry != true &&
@@ -94,7 +94,7 @@ export class Router {
           params: defaultAction.params,
           lastRoutePath: lastRoutePath,
         }
-      } else if ('redirect' in routeParams.route) {
+      } else if (routeParams.route && 'redirect' in routeParams.route) {
         lastRoutePath = routeParams.route.redirect
         const redirectRoute = this.getRouteByPath(lastRoutePath, this.routes)
         if (redirectRoute) {

--- a/packages/botonic-core/src/router.test.js
+++ b/packages/botonic-core/src/router.test.js
@@ -5,6 +5,10 @@ const textInputComplex = { type: 'text', data: 'Cömplêx input &% 🚀' }
 const textPayloadInput = { type: 'text', data: 'hi', payload: 'foo' }
 const postbackInput = { type: 'postback', payload: 'foo' }
 const route = 'route'
+const requestInput = {
+  input: textInput,
+  session: { organization: '' },
+}
 
 describe('Bad router initialization', () => {
   test('empty routes throw TypeError', () => {
@@ -29,6 +33,8 @@ describe('Match route by MATCHER <> INPUT', () => {
     router.matchRoute(route, 'text', matcher, textInput)
   const matchPayloadProp = (matcher, payload) =>
     router.matchRoute(route, 'payload', matcher, payload)
+  const matchRequestProp = (matcher, request) =>
+    router.matchRoute(route, 'request', matcher, request.input, request.session)
   test('text <> text', () => {
     expect(matchTextProp('hi', textInput)).toBeTruthy()
     expect(matchTextProp('hii', textInput)).toBeFalsy()
@@ -97,6 +103,22 @@ describe('Match route by MATCHER <> INPUT', () => {
     ).toBeTruthy()
     expect(
       matchPayloadProp(v => !v.startsWith('fo'), postbackInput)
+    ).toBeFalsy()
+  })
+  test('function <> request', () => {
+    expect(
+      matchRequestProp(
+        request =>
+          request.input.data === 'hi' && request.session.organization === '',
+        requestInput
+      )
+    ).toBeTruthy()
+    expect(
+      matchRequestProp(
+        request =>
+          request.input.data === 'hello' && request.session.organization === '',
+        requestInput
+      )
     ).toBeFalsy()
   })
 })

--- a/packages/botonic-core/src/router.test.js
+++ b/packages/botonic-core/src/router.test.js
@@ -7,7 +7,8 @@ const postbackInput = { type: 'postback', payload: 'foo' }
 const route = 'route'
 const requestInput = {
   input: textInput,
-  session: { organization: '' },
+  session: { organization: 'myOrg' },
+  lastRoutePath: 'initial',
 }
 
 describe('Bad router initialization', () => {
@@ -34,7 +35,14 @@ describe('Match route by MATCHER <> INPUT', () => {
   const matchPayloadProp = (matcher, payload) =>
     router.matchRoute(route, 'payload', matcher, payload)
   const matchRequestProp = (matcher, request) =>
-    router.matchRoute(route, 'request', matcher, request.input, request.session)
+    router.matchRoute(
+      route,
+      'request',
+      matcher,
+      request.input,
+      request.session,
+      request.lastRoutePath
+    )
   test('text <> text', () => {
     expect(matchTextProp('hi', textInput)).toBeTruthy()
     expect(matchTextProp('hii', textInput)).toBeFalsy()
@@ -109,14 +117,18 @@ describe('Match route by MATCHER <> INPUT', () => {
     expect(
       matchRequestProp(
         request =>
-          request.input.data === 'hi' && request.session.organization === '',
+          request.input.data === 'hi' &&
+          request.session.organization === 'myOrg' &&
+          request.lastRoutePath === 'initial',
         requestInput
       )
     ).toBeTruthy()
     expect(
       matchRequestProp(
         request =>
-          request.input.data === 'hello' && request.session.organization === '',
+          request.input.data === 'hello' &&
+          request.session.organization === 'myOrg' &&
+          request.lastRoutePath === 'initial',
         requestInput
       )
     ).toBeFalsy()


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Added new `request` matcher
* Check that `route.path` exists, causing 'cannot read path of undefined', failing with https://github.com/hubtype/botonic/pull/1072


## To document / Usage example
To use this new matcher:
```javascript
{
    path: 'hi',
    request: request =>
      request.input.data === 'hi' && request.session.organization === '',
    action: Hi,
  },
```
## Testing

The pull request...

**- has unit tests**
