### PR TITLE
React/error boundary

### DIFF
--- a/.github/workflows/botonic-core.tests.yml
+++ b/.github/workflows/botonic-core.tests.yml
@@ -30,3 +30,5 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run test)
     - name: Verify lint
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
+    - name: Verify index.d.ts
+      run: scripts/qa/lint-d-ts.sh packages/botonic-core

--- a/.github/workflows/botonic-react-tests.yml
+++ b/.github/workflows/botonic-react-tests.yml
@@ -30,3 +30,5 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run test)
     - name: Verify lint
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
+    - name: Verify index.d.ts
+      run: scripts/qa/lint-d-ts.sh packages/botonic-core

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
         language: system
         files: ^packages/botonic-core/
 
+      - id: core-d-ts
+        name: core-d-ts
+        entry: scripts/qa/lint-d-ts.sh packages/botonic-core
+        language: system
+        files: ^packages/botonic-core/src/.*\.d\.ts
+
       - id: nlu
         name: nlu
         entry: scripts/qa/lint-package.sh packages/botonic-plugin-nlu
@@ -80,6 +86,12 @@ repos:
         entry: scripts/qa/lint-package.sh packages/botonic-react
         language: system
         files: ^packages/botonic-react/
+
+      - id: react-d-ts
+        name: react-d-ts
+        entry: scripts/qa/lint-d-ts.sh packages/botonic-react
+        language: system
+        files: ^packages/botonic-react/src/.*\.d\.ts
 
       - id: google-analytics
         name: google-analytics

--- a/packages/botonic-core/tsconfig.json
+++ b/packages/botonic-core/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.d.ts"],
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/packages/botonic-react/src/components/components.js
+++ b/packages/botonic-react/src/components/components.js
@@ -1,0 +1,17 @@
+/**
+ * Get the name of an element (instantiated component)
+ * @param {React.Element} component
+ * @returns {string}
+ */
+export function getElementName(component) {
+  return component.type.name
+}
+
+/**
+ * Get the name of a component TYPE
+ * @param {React.ComponentType} component
+ * @returns {string}
+ */
+export function getComponentTypeName(component) {
+  return component.displayName || component.name || 'Component'
+}

--- a/packages/botonic-react/src/components/custom-message.jsx
+++ b/packages/botonic-react/src/components/custom-message.jsx
@@ -2,15 +2,24 @@ import { INPUT } from '@botonic/core'
 import merge from 'lodash.merge'
 import React from 'react'
 
+import { createErrorBoundary } from '../util/error-boundary'
 import { warnDeprecatedProps } from '../util/logs'
 import { mapObjectNonBooleanValues } from '../util/react'
 import { Message } from './message'
 import { Reply } from './reply'
 
+/**
+ *
+ * @param name as it appears at ThemeProps' message.customTypes key
+ * @param CustomMessageComponent
+ * @param defaultProps Props for the wrapper Message
+ * @param ErrorBoundary to recover in case it fails
+ */
 export const customMessage = ({
   name,
   component: CustomMessageComponent,
-  defaultProps,
+  defaultProps = {},
+  errorBoundary: ErrorBoundary = createErrorBoundary(),
 }) => {
   const CustomMessage = props => {
     warnDeprecatedProps(defaultProps, 'customMessage:')
@@ -54,9 +63,11 @@ export const customMessage = ({
           customTypeName: name,
         }}
       >
-        <CustomMessageComponent {...customMessageProps}>
-          {childrenWithoutReplies}
-        </CustomMessageComponent>
+        <ErrorBoundary key={'errorBoundary'} {...customMessageProps}>
+          <CustomMessageComponent {...customMessageProps}>
+            {childrenWithoutReplies}
+          </CustomMessageComponent>
+        </ErrorBoundary>
         {replies}
       </CustomMessage>
     )

--- a/packages/botonic-react/src/components/custom-message.jsx
+++ b/packages/botonic-react/src/components/custom-message.jsx
@@ -22,24 +22,28 @@ export const customMessage = ({
     )
   }
 
-  const SplitChildren = props => {
+  const splitChildren = props => {
     const { children } = props
+    const isReply = e => e.type === Reply
     try {
-      const replies = React.Children.toArray(children).filter(
-        e => e.type === Reply
-      )
-      const childrenWithoutReplies = React.Children.toArray(children).filter(
-        e => ![Reply].includes(e.type)
-      )
-      return { replies, childrenWithoutReplies }
+      if (!Array.isArray(children) && !isReply(children)) {
+        return { replies: null, childrenWithoutReplies: children }
+      }
+      const childrenArray = React.Children.toArray(children)
+      const replies = childrenArray.filter(isReply)
+      const childrenWithoutReplies = childrenArray.filter(e => !isReply(e))
+      return {
+        replies: replies,
+        childrenWithoutReplies,
+      }
     } catch (e) {
-      return { replies: [], childrenWithoutReplies: children }
+      return { replies: null, childrenWithoutReplies: children }
     }
   }
 
   const WrappedComponent = props => {
     const { id, children, ...customMessageProps } = props
-    const { replies, childrenWithoutReplies } = SplitChildren(props)
+    const { replies, childrenWithoutReplies } = splitChildren(props)
     return (
       <CustomMessage
         id={id}

--- a/packages/botonic-react/src/components/index.d.ts
+++ b/packages/botonic-react/src/components/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ErrorInfo } from 'react'
 
 export type MessageType =
   | 'audio'

--- a/packages/botonic-react/src/components/index.d.ts
+++ b/packages/botonic-react/src/components/index.d.ts
@@ -186,4 +186,28 @@ export interface WebchatSettingsProps {
 }
 export const WebchatSettings: React.FunctionComponent<WebchatSettingsProps>
 
+export type WrappedComponent<Props> = React.FunctionComponent<Props> & {
+  customTypeName: string
+}
+
+export class ErrorBoundary<Props> extends React.Component<Props> {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void
+}
+
+export function createErrorBoundary<Props>(_?: {
+  errorComponent: React.ComponentType
+}): ErrorBoundary<Props>
+
+export function customMessage<
+  Props,
+  CustomMessageComponent extends React.ComponentType<Props>
+>(_: {
+  name: string
+  component: CustomMessageComponent
+  defaultProps?: Record<string, unknown>
+  errorBoundary?: ErrorBoundary<Props>
+}): WrappedComponent<Props>
+
+export function getDisplayName(component: React.ComponentType): string
+
 export * from './multichannel'

--- a/packages/botonic-react/src/util/error-boundary.jsx
+++ b/packages/botonic-react/src/util/error-boundary.jsx
@@ -1,0 +1,50 @@
+import { isNode } from '@botonic/core'
+import React from 'react'
+
+import { Text } from '../components'
+
+/**
+ * Replaces crashed children with the provided fallback component.
+ * https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html
+ * See alternative at https://stackoverflow.com/a/60255291/145289
+ */
+export const createErrorBoundary = ({
+  errorComponent = props => <Text>The message cannot be displayed</Text>,
+} = {}) => {
+  class ErrorBoundary extends React.Component {
+    constructor(props) {
+      super(props)
+      this.state = { error: null }
+    }
+
+    /**
+     * @param error the exception which was trown
+     * @param errorInfo the stack of component names at the error
+     */
+    componentDidCatch(error, errorInfo) {
+      // No need to log the error because at least chrome & firefox already show
+      // both component and call stacks
+      if (isNode()) {
+        // In node, only the component stack is displayed
+        console.error(`Failure at:`, error)
+      }
+    }
+
+    static getDerivedStateFromError(error) {
+      return { error }
+    }
+
+    render() {
+      if (this.state.error) {
+        return errorComponent({
+          ...this.props,
+          errorMessage: this.state.error.message,
+        })
+      } else {
+        return this.props.children
+      }
+    }
+  }
+
+  return ErrorBoundary
+}

--- a/packages/botonic-react/tests/components/__snapshots__/custom-message.test.jsx.snap
+++ b/packages/botonic-react/tests/components/__snapshots__/custom-message.test.jsx.snap
@@ -1,0 +1,186 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomMessage failing TEST: ErrorBoundary different errorComponent which gets the props 1`] = `
+<message
+  delay={0}
+  json="{\\"bang\\":\\"Bang!\\",\\"customTypeName\\":\\"test1\\"}"
+  type="custom"
+  typing={0}
+>
+  <message
+    delay={0}
+    markdown={1}
+    type="text"
+    typing={0}
+  >
+    Boom!Bang!: Forced exception
+  </message>
+</message>
+`;
+
+exports[`CustomMessage failing TEST: ErrorBoundary on a failing component 1`] = `
+<message
+  delay={0}
+  json="{\\"customTypeName\\":\\"test1\\"}"
+  type="custom"
+  typing={0}
+  wrapperProp="wrapperPropV"
+>
+  <message
+    delay={0}
+    markdown={1}
+    type="text"
+    typing={0}
+  >
+    The message cannot be displayed
+  </message>
+</message>
+`;
+
+exports[`CustomMessage replies TEST: replies are moved outside the custom component Button 1`] = `
+<message
+  delay={0}
+  json="{\\"children\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"payload\\":\\"payloadundefined\\",\\"children\\":[\\"button\\",null]},\\"_owner\\":null,\\"_store\\":{}},\\"customTypeName\\":\\"test1\\"}"
+  type="custom"
+  typing={0}
+>
+  <message
+    delay={0}
+    markdown={1}
+    type="text"
+    typing={0}
+  >
+    <button
+      payload="payloadundefined"
+    >
+      button
+    </button>
+  </message>
+</message>
+`;
+
+exports[`CustomMessage replies TEST: replies are moved outside the custom component Button,Button 1`] = `
+<message
+  delay={0}
+  json="{\\"children\\":[{\\"key\\":\\".$1\\",\\"ref\\":null,\\"props\\":{\\"payload\\":\\"payload1\\",\\"children\\":[\\"button\\",1]},\\"_owner\\":null,\\"_store\\":{}},{\\"key\\":\\".$2\\",\\"ref\\":null,\\"props\\":{\\"payload\\":\\"payload2\\",\\"children\\":[\\"button\\",2]},\\"_owner\\":null,\\"_store\\":{}}],\\"customTypeName\\":\\"test1\\"}"
+  type="custom"
+  typing={0}
+>
+  <message
+    delay={0}
+    markdown={1}
+    type="text"
+    typing={0}
+  >
+    <button
+      payload="payload1"
+    >
+      button
+      1
+    </button>
+    <button
+      payload="payload2"
+    >
+      button
+      2
+    </button>
+  </message>
+</message>
+`;
+
+exports[`CustomMessage replies TEST: replies are moved outside the custom component Reply 1`] = `
+<message
+  delay={0}
+  json="{\\"children\\":[],\\"customTypeName\\":\\"test1\\"}"
+  type="custom"
+  typing={0}
+>
+  <message
+    delay={0}
+    markdown={1}
+    type="text"
+    typing={0}
+  />
+  <reply
+    payload="payloadundefined"
+  >
+    reply
+  </reply>
+</message>
+`;
+
+exports[`CustomMessage replies TEST: replies are moved outside the custom component Reply,Button 1`] = `
+<message
+  delay={0}
+  json="{\\"children\\":[{\\"key\\":\\".$2\\",\\"ref\\":null,\\"props\\":{\\"payload\\":\\"payload2\\",\\"children\\":[\\"button\\",2]},\\"_owner\\":null,\\"_store\\":{}}],\\"customTypeName\\":\\"test1\\"}"
+  type="custom"
+  typing={0}
+>
+  <message
+    delay={0}
+    markdown={1}
+    type="text"
+    typing={0}
+  >
+    <button
+      payload="payload2"
+    >
+      button
+      2
+    </button>
+  </message>
+  <reply
+    payload="payload1"
+  >
+    reply
+    1
+  </reply>
+</message>
+`;
+
+exports[`CustomMessage replies TEST: replies are moved outside the custom component Reply,Reply 1`] = `
+<message
+  delay={0}
+  json="{\\"children\\":[],\\"customTypeName\\":\\"test1\\"}"
+  type="custom"
+  typing={0}
+>
+  <message
+    delay={0}
+    markdown={1}
+    type="text"
+    typing={0}
+  />
+  <reply
+    payload="payload1"
+  >
+    reply
+    1
+  </reply>
+  <reply
+    payload="payload2"
+  >
+    reply
+    2
+  </reply>
+</message>
+`;
+
+exports[`TEST: CustomMessage defaultProps, props and children are injected into the component 1`] = `
+<message
+  delay={0}
+  json="{\\"wrappedProp\\":\\"wrappedPropV\\",\\"children\\":\\"body\\",\\"customTypeName\\":\\"test1\\"}"
+  type="custom"
+  typing={0}
+  wrapperProp="wrapperPropV"
+>
+  <message
+    delay={0}
+    markdown={1}
+    type="text"
+    typing={0}
+  >
+    wrappedPropVbody
+  </message>
+</message>
+`;

--- a/packages/botonic-react/tests/components/components.test.jsx
+++ b/packages/botonic-react/tests/components/components.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { Text } from '../../src/components'
+import {
+  getComponentTypeName,
+  getElementName,
+} from '../../src/components/components'
+
+describe('getDisplayName', () => {
+  test('React.Component', () => {
+    class Comp extends React.Component {
+      render() {
+        return null
+      }
+    }
+    expect(getElementName(<Comp />)).toEqual('Comp')
+    expect(getComponentTypeName(Comp)).toEqual('Comp')
+  })
+
+  test('React.Function', () => {
+    const Func = props => <Text />
+    expect(getElementName(<Func />)).toEqual('Func')
+    expect(getComponentTypeName(Func)).toEqual('Func')
+  })
+})

--- a/packages/botonic-react/tests/components/custom-message.test.jsx
+++ b/packages/botonic-react/tests/components/custom-message.test.jsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import TestRenderer from 'react-test-renderer'
+
+import { Button, customMessage, Reply, Text } from '../../src/components'
+import { getElementName } from '../../src/components/components'
+import { createErrorBoundary } from '../../src/util/error-boundary'
+
+const renderToJSON = sut => TestRenderer.create(sut).toJSON()
+
+test('TEST: CustomMessage defaultProps, props and children are injected into the component', () => {
+  class CustomComponent extends React.Component {
+    render() {
+      return <Text>{this.props.wrappedProp + this.props.children}</Text>
+    }
+  }
+
+  const Sut = customMessage({
+    name: 'test1',
+    component: CustomComponent,
+    defaultProps: { wrapperProp: 'wrapperPropV' },
+  })
+  const tree = renderToJSON(<Sut wrappedProp='wrappedPropV'>body</Sut>)
+  expect(tree).toMatchSnapshot()
+})
+
+describe('CustomMessage replies', () => {
+  function names(children) {
+    if (Array.isArray(children)) {
+      return children.map(c => getElementName(c)).join(',')
+    }
+    return getElementName(children)
+  }
+
+  function reply(key) {
+    return (
+      <Reply key={key} payload={`payload${key}`}>
+        reply{key}
+      </Reply>
+    )
+  }
+
+  function button(key) {
+    return (
+      <Button key={key} payload={`payload${key}`}>
+        button{key}
+      </Button>
+    )
+  }
+
+  for (const children of [
+    reply(), // single reply
+    button(), // single no reply
+    [reply(1), reply(2)], // multiple all reply
+    [reply(1), button(2)], // mix reply & no reply
+    [button(1), button(2)], // multiple no reply
+  ]) {
+    test(`TEST: replies are moved outside the custom component ${names(
+      children
+    )}`, () => {
+      class CustomComponent extends React.Component {
+        render() {
+          return <Text>{this.props.children}</Text>
+        }
+      }
+
+      const Sut = customMessage({
+        name: 'test1',
+        component: CustomComponent,
+      })
+      const tree = renderToJSON(<Sut>{children}</Sut>)
+      expect(tree).toMatchSnapshot()
+    })
+  }
+})
+
+describe('CustomMessage failing', () => {
+  class FailingComponent extends React.Component {
+    // eslint-disable-next-line react/require-render-return
+    render() {
+      throw Error('Forced exception')
+    }
+  }
+
+  test('TEST: ErrorBoundary on a failing component', () => {
+    const Sut = customMessage({
+      name: 'test1',
+      component: FailingComponent,
+      defaultProps: { wrapperProp: 'wrapperPropV' },
+    })
+    const tree = renderToJSON(<Sut />)
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('TEST: ErrorBoundary different errorComponent which gets the props', () => {
+    const Sut = customMessage({
+      name: 'test1',
+      component: FailingComponent,
+      errorBoundary: createErrorBoundary({
+        // eslint-disable-next-line react/display-name
+        errorComponent: props => (
+          <Text>{`Boom!${props.bang}: ${props.errorMessage}`}</Text>
+        ),
+      }),
+    })
+    const tree = renderToJSON(<Sut bang='Bang!' />)
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/packages/botonic-react/tsconfig.json
+++ b/packages/botonic-react/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.d.ts"],
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/scripts/qa/lint-d-ts.sh
+++ b/scripts/qa/lint-d-ts.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+
+cd "$BIN_DIR/../../$1" || exit
+# useful to test index.d.ts files for JS projects
+"$BIN_DIR"/../../node_modules/.bin/tsc --noEmit

--- a/scripts/qa/lint-package.sh
+++ b/scripts/qa/lint-package.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 cd "$1" || exit
+
+# quick lint. Not running slow lint to avoid penalizing pre-commit
 npm run lint
+
 EXIT_CODE=$?
 # when lint can fix all errors, npm will return 0
 # In this case, we want to see which files were changed


### PR DESCRIPTION
## Description

We want that if CustomMessage crashes, it will be replaced by the specified component (typically a simple error message). So far the solution only works if the failure occurs while deserializing the component. Pending to understand why it does not working yet if it fails during rendering of a new component.

## Context
CustomMessage can fail if there's a bug in their implementation. A typical case is when restoring a serialized component from the browser local storage.



## Approach taken / Explain the design

## To document / Usage example

React [ErrorBoundary](https://reactjs.org/docs/error-boundaries.html)

## Testing

The pull request...

- has integration tests
