### PR TITLE
fix(react): do not call onClose on very first render

### DIFF
--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -214,6 +214,7 @@ export const Webchat = forwardRef((props, ref) => {
     setCurrentAttachment,
     // eslint-disable-next-line react-hooks/rules-of-hooks
   } = props.webchatHooks || useWebchat()
+  const firstUpdate = useRef(true)
   const theme = merge(webchatState.theme, props.theme)
   const { initialSession, initialDevSettings, onStateChange } = props
   const isOnline = useNetwork()
@@ -647,6 +648,10 @@ export const Webchat = forwardRef((props, ref) => {
   }
 
   useEffect(() => {
+    if (firstUpdate.current) {
+      firstUpdate.current = false
+      return
+    }
     if (webchatState.isWebchatOpen && props.onOpen) props.onOpen()
     if (!webchatState.isWebchatOpen && props.onClose) {
       props.onClose()


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
Do not call onClose event on the first app render.

## Context
The first time the app is rendered and the webchat is closed, the `onClose` event is triggered but in fact we are not closing it. Adding a solution to this in order to only call it when the close button is clicked.