### PR TITLE
Fix/custom msg opacity and revert react

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -4384,12 +4384,13 @@
       "integrity": "sha512-f2tdoA7NvJQkU8Y/iCH25ZSNGxnwCXrVbwos38isX6gnjsSZ1aksWvyZddm2N0sHJWyl+oPBz/MzU5cevVDyEQ=="
     },
     "react": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
       }
     },
     "react-base16-styling": {
@@ -4409,24 +4410,14 @@
       "integrity": "sha512-w98UfUMzg7eg008CNmz7VYuog//kcXTnB26r0rGc+7kzKQ1sP9Yry29sDj9AL/TQ9C/7UCkFadaHnNKYdyhL2A=="
     },
     "react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
-      },
-      "dependencies": {
-        "scheduler": {
-          "version": "0.20.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-          "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
       }
     },
     "react-frame-component": {
@@ -4487,34 +4478,16 @@
         "tiny-warning": "^1.0.0"
       }
     },
-    "react-shallow-renderer": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
-      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0"
-      }
-    },
     "react-test-renderer": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
-      "integrity": "sha512-/dRae3mj6aObwkjCcxZPlxDFh73XZLgvwhhyON2haZGUEhiaY5EjfAdw+d/rQmlcFwdTpMXCSGVk374QbCTlrA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
-        "react-is": "^17.0.1",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.1"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "17.0.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
-          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
-          "dev": true
-        }
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.19.1"
       }
     },
     "react-textarea-autosize": {
@@ -4762,10 +4735,9 @@
       }
     },
     "scheduler": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
-      "dev": true,
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -29,9 +29,9 @@
     "framer-motion": "^2.6.6",
     "lodash.merge": "^4.6.2",
     "markdown-it": "^12.0.2",
-    "react": "^17.0.1",
+    "react": "^16.14.0",
     "react-children-utilities": "^2.1.5",
-    "react-dom": "^17.0.1",
+    "react-dom": "^16.14.0",
     "react-frame-component": "^4.1.3",
     "react-json-tree": "^0.12.1",
     "react-reveal": "^1.2.2",
@@ -54,12 +54,12 @@
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
-    "@testing-library/react-hooks": "^3.2.1",
     "@testing-library/react": "^11.0.4",
+    "@testing-library/react-hooks": "^3.2.1",
     "@types/react": "16.9.53",
     "babel-plugin-add-module-exports": "^1.0.2",
     "identity-obj-proxy": "^3.0.0",
-    "react-test-renderer": "^17.0.1"
+    "react-test-renderer": "^16.14.0"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/packages/botonic-react/src/components/custom-message.jsx
+++ b/packages/botonic-react/src/components/custom-message.jsx
@@ -2,6 +2,7 @@ import { INPUT } from '@botonic/core'
 import merge from 'lodash.merge'
 import React from 'react'
 
+import { SENDERS } from '../constants'
 import { createErrorBoundary } from '../util/error-boundary'
 import { warnDeprecatedProps } from '../util/logs'
 import { mapObjectNonBooleanValues } from '../util/react'
@@ -23,6 +24,7 @@ export const customMessage = ({
 }) => {
   const CustomMessage = props => {
     warnDeprecatedProps(defaultProps, 'customMessage:')
+    if (defaultProps.from === SENDERS.user) defaultProps.ack = 1
     return (
       <Message
         {...merge(mapObjectNonBooleanValues(defaultProps), props)}


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Downgrade `react`, `react-dom` and `react-test-renderer` to `@16.14.0` (last working version), causing errors in some class components. Error in new version: https://github.com/facebook/react/issues/20131 (1st commit)
* Fix opacity for custom user messages coming from user. (e.g., CustomRating messages) (2nd commit)