### PR TITLE
fix(react): avoid circular dependency

### DIFF
--- a/packages/botonic-react/src/util/error-boundary.jsx
+++ b/packages/botonic-react/src/util/error-boundary.jsx
@@ -1,7 +1,7 @@
 import { isNode } from '@botonic/core'
 import React from 'react'
 
-import { Text } from '../components'
+import { Text } from '../components/text'
 
 /**
  * Replaces crashed children with the provided fallback component.


### PR DESCRIPTION
Avoid circular dependency between util/errorboundary.jsx and components