### PR TITLE
Contentful/chores

### DIFF
--- a/.github/workflows/botonic-plugin-contentful-tests.yml
+++ b/.github/workflows/botonic-plugin-contentful-tests.yml
@@ -1,6 +1,13 @@
 name: Botonic plugin-contentful tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - '*'
+      - '.github/**'
+      - 'packages/*'
+      - 'packages/botonic-plugin-contentful/**'
+      - 'scripts/*'
 
 jobs:
   botonic-plugin-contentful-tests:

--- a/packages/botonic-plugin-contentful/jest.config.js
+++ b/packages/botonic-plugin-contentful/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>/tests/tsconfig.json',
+      tsconfig: '<rootDir>/tests/tsconfig.json',
     },
   },
   preset: 'ts-jest',

--- a/packages/botonic-plugin-contentful/tests/tsconfig.json
+++ b/packages/botonic-plugin-contentful/tests/tsconfig.json
@@ -1,3 +1,5 @@
+// Only used for verifying the code
+// use noEmit to have faster builds (~13s -> 9s)
 {
   "extends": "../tsconfig",
   // include need to be specified for running tsc on tests
@@ -7,6 +9,7 @@
     // Options below are for compiling @botonic js/jsx files
     "allowJs": true, //when set, jest does not validate types anymore https://github.com/kulshekhar/ts-jest/issues/740#issuecomment-424123303
     "declaration": false,
-    "declarationDir": null
+    "declarationDir": null,
+    "noEmit": true
   }
 }

--- a/packages/botonic-plugin-dynamodb/jest.config.js
+++ b/packages/botonic-plugin-dynamodb/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>/tests/tsconfig.json',
+      tsconfig: '<rootDir>/tests/tsconfig.json',
     },
   },
   preset: 'ts-jest',

--- a/packages/botonic-plugin-dynamodb/tests/tsconfig.json
+++ b/packages/botonic-plugin-dynamodb/tests/tsconfig.json
@@ -1,8 +1,11 @@
+// Only used for verifying the code
+// use noEmit to have faster builds
 {
   "extends": "../tsconfig",
   "include": ["**/*.ts", "**/*.tsx", "../src/**/*.ts", "../src/**/*.tsx"],
   "compilerOptions": {
-    "rootDir": "../"
+    "rootDir": "../",
+    "noEmit": true
   },
   // test options
   "types": ["@types/jest"]


### PR DESCRIPTION
* Don't run contentful CI when no changes in contentful code or its build config
* rename property in jest config because it'll be deprecated in next version
* don't emit typescript code for tests, as it's only required to validate the code, we don't need the transpiled files  