### PR TITLE
Contentful - Make buttonStyle undefined if not specified + new RenderOption to specify default buttonStyle

### DIFF
--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -326,7 +326,7 @@ export class Text extends MessageContent {
     // Full text
     readonly text: string,
     readonly buttons: Button[],
-    readonly buttonsStyle = ButtonStyle.BUTTON
+    readonly buttonsStyle?: ButtonStyle
   ) {
     super(common, ContentType.TEXT)
   }

--- a/packages/botonic-plugin-contentful/src/contentful/contents/text.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/text.ts
@@ -38,14 +38,14 @@ export class TextDelivery extends DeliveryWithFollowUp {
     const followUp = followUpAndButtons[0] as cms.FollowUp | undefined
     const buttons = followUpAndButtons[1] as cms.Button[]
     const common = ContentfulEntryUtils.commonFieldsFromEntry(entry, followUp)
-    return new cms.Text(
-      common,
-      fields.text ?? '',
-      buttons,
-      fields.buttonsStyle == 'QuickReplies'
-        ? cms.ButtonStyle.QUICK_REPLY
-        : cms.ButtonStyle.BUTTON
-    )
+    const buttonsStyle = this.getButtonsStyle(fields.buttonsStyle)
+    return new cms.Text(common, fields.text ?? '', buttons, buttonsStyle)
+  }
+
+  getButtonsStyle(buttonsStyle?: string): cms.ButtonStyle | undefined {
+    if (buttonsStyle == 'QuickReplies') return cms.ButtonStyle.QUICK_REPLY
+    if (buttonsStyle == 'Buttons') return cms.ButtonStyle.BUTTON
+    return undefined
   }
 }
 

--- a/packages/botonic-plugin-contentful/src/render/botonic-converter.ts
+++ b/packages/botonic-plugin-contentful/src/render/botonic-converter.ts
@@ -7,6 +7,7 @@ export class RenderOptions {
   maxQuickReplies = 5
   /** Some integrations fail when a field is empty*/
   replaceEmptyStringsWith?: string
+  defaultButtonsStyle?: ButtonStyle = ButtonStyle.BUTTON
 }
 
 // TODO consider moving it to @botonic/core
@@ -97,8 +98,9 @@ export class BotonicMsgConverter {
       delay: delayS,
       data: { text: this.str(text.text) },
     }
-    const buttons = this.convertButtons(text.buttons, text.buttonsStyle)
-    if (text.buttonsStyle == ButtonStyle.QUICK_REPLY) {
+    const buttonsStyle = text.buttonsStyle || this.options.defaultButtonsStyle
+    const buttons = this.convertButtons(text.buttons, buttonsStyle!)
+    if (buttonsStyle == ButtonStyle.QUICK_REPLY) {
       msg['replies'] = buttons
     } else {
       msg['buttons'] = buttons

--- a/packages/botonic-plugin-contentful/tests/render/botonic-converter.test.ts
+++ b/packages/botonic-plugin-contentful/tests/render/botonic-converter.test.ts
@@ -1,3 +1,4 @@
+import { ButtonStyle } from '../../src/cms'
 import { RndTextBuilder } from '../../src/cms/test-helpers'
 import { BotonicMsgConverter } from '../../src/render'
 
@@ -43,5 +44,21 @@ describe('TEST BotonicMsgConverter', () => {
     // assert
     expect((msg as any)['data']['text']).toEqual('x')
     expect((msg as any)['buttons'][0]['title']).toEqual('x')
+  })
+
+  test('text with reply as default buttonsStyle', () => {
+    const sut = new BotonicMsgConverter({
+      defaultButtonsStyle: ButtonStyle.QUICK_REPLY,
+    })
+    const builder = new RndTextBuilder()
+    builder.buttonsBuilder.withText('Test').addButton()
+    const text = builder.build()
+
+    // act
+    const msg = sut.text(text, 42)
+
+    // assert
+    expect((msg as any)['replies'].length).toEqual(1)
+    expect((msg as any)['buttons']).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Description
Remove the default assignment of `buttonsStyle` to `ButtonStyle.BUTTON` in `Text` and add a new option in `RenderOptions` to be able to specify the default value if no selection has been made in Contentful.

With these changes made, if no selection of button styling has been made in Contentful, you can change decide if you want to show all the buttons as buttons or as replies with just one parameter.


## Context
Now there is no way to show all buttons as replies unless you specify it in every button in Contentful.

## Approach taken / Explain the design
Remove the default assignment of `buttonStyle` to `ButtonStyle.BUTTON` in `Text` in favour of defaulting it when converting the `Text` to a `BotonisMsg`.

## To document / Usage example


## Testing

The pull request has unit test.
