### PR TITLE
fix(react): webchat to not crash if no user id

### DIFF
--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -185,7 +185,13 @@ const createUser = () => {
     name,
   }
 }
-
+const initSession = session => {
+  if (!session) session = {}
+  const hasUserId = session.user && session.user.id !== undefined
+  if (!session.user || Object.keys(session.user).length === 0 || !hasUserId)
+    session.user = !hasUserId ? merge(session.user, createUser()) : createUser()
+  return session
+}
 // eslint-disable-next-line complexity
 export const Webchat = forwardRef((props, ref) => {
   const {
@@ -289,9 +295,7 @@ export const Webchat = forwardRef((props, ref) => {
       lastMessageUpdate,
       themeUpdates,
     } = botonicState || {}
-    if (!session) session = {}
-    if (!session.user || Object.keys(session.user).length === 0)
-      session.user = createUser()
+    session = initSession(session)
     updateSession(session)
     if (
       !devSettings ||

--- a/packages/botonic-react/tests/webchat/storage.test.jsx
+++ b/packages/botonic-react/tests/webchat/storage.test.jsx
@@ -76,4 +76,17 @@ describe('TEST: storageKey', () => {
     expect(localStorage.getItem('botonicState')).not.toBeNull()
     expect(localStorage.getItem('myCustomKey')).toBeNull()
   })
+
+  it('Inits session correctly with user id (corrupted localStorage)', async () => {
+    localStorage.setItem(
+      'botonicState',
+      '{"user":{"extra_data":{"url":"https://www.some-domain.com/","lang":"GB_en"}},"messages":[],"session":{"user":{"extra_data":{"url":"https://www.some-domain.com/","lang":"GB_en"}}},"lastRoutePath":null,"devSettings":{},"lastMessageUpdate":"2020-12-04T16:30:11.833Z"}'
+    )
+    await act(async () => {
+      TestRenderer.create(<Webchat storage={localStorage} />)
+    })
+    const botonicState = JSON.parse(localStorage.getItem('botonicState'))
+    expect(localStorage.getItem('botonicState')).not.toBeNull()
+    expect(botonicState.session.user.id).not.toBeFalsy()
+  })
 })


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Fixing issues when `botonicState` was corrupted for some reason (still not known) and session comes without `user.id`, this was making some bots to not even start the chat.
* Added test for this specific scenario. 

## Testing
The pull request has unit tests.
