### PR TITLE
Codecov & Botonic workflows

### DIFF
--- a/.github/workflows/botonic-cli-tests.yml
+++ b/.github/workflows/botonic-cli-tests.yml
@@ -3,6 +3,8 @@ name: Botonic cli tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-cli/**'
       - '.github/workflows/botonic-cli-tests.yml'
 

--- a/.github/workflows/botonic-cli-tests.yml
+++ b/.github/workflows/botonic-cli-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic cli tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-cli/**'
+      - '.github/workflows/botonic-cli-tests.yml'
 
 jobs:
   botonic-cli-tests:

--- a/.github/workflows/botonic-cli-tests.yml
+++ b/.github/workflows/botonic-cli-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-cli
     steps:
       - name: Checking out to current branch
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setting up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
       - name: Setting up cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-core-tests.yml
+++ b/.github/workflows/botonic-core-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic core tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-core/**'
+      - '.github/workflows/botonic-core-tests.yml'
 
 jobs:
   botonic-core-tests:
@@ -31,4 +35,13 @@ jobs:
     - name: Verify lint
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
     - name: Verify index.d.ts
-      run: scripts/qa/lint-d-ts.sh packages/botonic-core
+      run: scripts/qa/lint-d-ts.sh packages/$PACKAGE
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{env.PACKAGE}}
+        file: ./packages/${{env.PACKAGE}}/coverage/clover.xml
+        name: ${{env.PACKAGE}}
+        env_vars: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-core-tests.yml
+++ b/.github/workflows/botonic-core-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-core
     steps:
     - name: Checking out to current branch
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-core-tests.yml
+++ b/.github/workflows/botonic-core-tests.yml
@@ -3,6 +3,8 @@ name: Botonic core tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-core/**'
       - '.github/workflows/botonic-core-tests.yml'
 

--- a/.github/workflows/botonic-docs-tests.yml
+++ b/.github/workflows/botonic-docs-tests.yml
@@ -3,6 +3,8 @@ name: Botonic docs tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'docs/**'
       - '.github/workflows/botonic-docs-tests.yml'
 

--- a/.github/workflows/botonic-docs-tests.yml
+++ b/.github/workflows/botonic-docs-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic docs tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/botonic-docs-tests.yml'
 
 jobs:
   botonic-core-tests:

--- a/.github/workflows/botonic-docs-tests.yml
+++ b/.github/workflows/botonic-docs-tests.yml
@@ -19,13 +19,13 @@ jobs:
       SEGMENT_DOCS_API_KEY: ${{ secrets.SEGMENT_DOCS_API_KEY }}
     steps:
       - name: Checking out to current branch
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setting up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
       - name: Setting up cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-nlu-tests.yml
+++ b/.github/workflows/botonic-nlu-tests.yml
@@ -3,6 +3,8 @@ name: Botonic nlu tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-nlu/**'
       - '.github/workflows/botonic-nlu-tests.yml'
  

--- a/.github/workflows/botonic-nlu-tests.yml
+++ b/.github/workflows/botonic-nlu-tests.yml
@@ -10,6 +10,8 @@ jobs:
   botonic-plugin-nlu-tests:
     name: Botonic nlu tests
     runs-on: ubuntu-latest
+    env:
+      PACKAGE: botonic-nlu
     steps:
     - name: Checking out to current branch (Step 1 of 7)
       uses: actions/checkout@v1
@@ -27,8 +29,8 @@ jobs:
     - name: Install botonic-nlu (Step 4 of 7)
       run: (cd ./packages/botonic-nlu && npm install -D)
     - name: Build botonic-nlu (Step 5 of 7)
-      run: (cd ./packages/botonic-nlu && npm run build)
+      run: (cd ./packages/$PACKAGE && npm run build)
     - name: Install common packages dependencies (Step 6 of 7)
       run: npm install -D
     - name: Verify lint botonic-nlu (Step 7 of 7)
-      run: (cd ./packages/botonic-nlu && npm run lint_ci)
+      run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-nlu-tests.yml
+++ b/.github/workflows/botonic-nlu-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-nlu
     steps:
     - name: Checking out to current branch (Step 1 of 7)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node (Step 2 of 7)
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache (Step 3 of 7)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-nlu-tests.yml
+++ b/.github/workflows/botonic-nlu-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic nlu tests
  
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-nlu/**'
+      - '.github/workflows/botonic-nlu-tests.yml'
  
 jobs:
   botonic-plugin-nlu-tests:

--- a/.github/workflows/botonic-plugin-contentful-tests.yml
+++ b/.github/workflows/botonic-plugin-contentful-tests.yml
@@ -16,13 +16,13 @@ jobs:
       PACKAGE: botonic-plugin-contentful
     steps:
     - name: Checking out to current branch
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-contentful-tests.yml
+++ b/.github/workflows/botonic-plugin-contentful-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-contentful tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-contentful/**'
       - '.github/workflows/botonic-plugin-contentful-tests.yml'
 

--- a/.github/workflows/botonic-plugin-contentful-tests.yml
+++ b/.github/workflows/botonic-plugin-contentful-tests.yml
@@ -3,11 +3,8 @@ name: Botonic plugin-contentful tests
 on:
   push:
     paths:
-      - '*'
-      - '.github/**'
-      - 'packages/*'
       - 'packages/botonic-plugin-contentful/**'
-      - 'scripts/*'
+      - '.github/workflows/botonic-plugin-contentful-tests.yml'
 
 jobs:
   botonic-plugin-contentful-tests:
@@ -41,3 +38,11 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run test)
     - name: Verify lint
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{env.PACKAGE}}
+        file: ./packages/${{env.PACKAGE}}/coverage/clover.xml
+        name: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-plugin-dashbot-tests.yml
+++ b/.github/workflows/botonic-plugin-dashbot-tests.yml
@@ -1,11 +1,17 @@
 name: Botonic plugin-dashbot tests
  
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-dashbot/**'
+      - '.github/workflows/botonic-plugin-dashbot-tests.yml'
  
 jobs:
   botonic-plugin-dashbot-tests:
     name: Botonic plugin-dashbot tests
     runs-on: ubuntu-latest
+    env:
+      PACKAGE: botonic-plugin-dashbot
     steps:
     - name: Checking out to current branch (Step 1 of 6)
       uses: actions/checkout@v1
@@ -21,8 +27,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install botonic-plugin-dashbot (Step 4 of 6)
-      run: (cd ./packages/botonic-plugin-dashbot && npm install -D)
+      run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Install common packages dependencies (Step 5 of 6)
       run: npm install -D
     - name: Verify lint botonic-plugin-dashbot (Step 6 of 6)
-      run: (cd ./packages/botonic-plugin-dashbot && npm run lint_ci)
+      run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-dashbot-tests.yml
+++ b/.github/workflows/botonic-plugin-dashbot-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-plugin-dashbot
     steps:
     - name: Checking out to current branch (Step 1 of 6)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node (Step 2 of 6)
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache (Step 3 of 6)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-dashbot-tests.yml
+++ b/.github/workflows/botonic-plugin-dashbot-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-dashbot tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-dashbot/**'
       - '.github/workflows/botonic-plugin-dashbot-tests.yml'
  

--- a/.github/workflows/botonic-plugin-dialogflow-tests.yml
+++ b/.github/workflows/botonic-plugin-dialogflow-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-plugin-dialogflow
     steps:
     - name: Checking out to current branch (Step 1 of 6)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node (Step 2 of 6)
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache (Step 3 of 6)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-dialogflow-tests.yml
+++ b/.github/workflows/botonic-plugin-dialogflow-tests.yml
@@ -10,6 +10,8 @@ jobs:
   botonic-plugin-dialogflow-tests:
     name: Botonic plugin-dialogflow tests
     runs-on: ubuntu-latest
+    env:
+      PACKAGE: botonic-plugin-dialogflow
     steps:
     - name: Checking out to current branch (Step 1 of 6)
       uses: actions/checkout@v1
@@ -25,8 +27,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install botonic-plugin-dialogflow (Step 4 of 6)
-      run: (cd ./packages/botonic-plugin-dialogflow && npm install -D)
+      run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Install common packages dependencies (Step 5 of 6)
       run: npm install -D
     - name: Verify lint botonic-plugin-dialogflow (Step 6 of 6)
-      run: (cd ./packages/botonic-plugin-dialogflow && npm run lint_ci)
+      run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-dialogflow-tests.yml
+++ b/.github/workflows/botonic-plugin-dialogflow-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic plugin-dialogflow tests
  
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-dialogflow/**'
+      - '.github/workflows/botonic-plugin-dialogflow-tests.yml'
  
 jobs:
   botonic-plugin-dialogflow-tests:

--- a/.github/workflows/botonic-plugin-dialogflow-tests.yml
+++ b/.github/workflows/botonic-plugin-dialogflow-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-dialogflow tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-dialogflow/**'
       - '.github/workflows/botonic-plugin-dialogflow-tests.yml'
  

--- a/.github/workflows/botonic-plugin-dynamo-tests.yml
+++ b/.github/workflows/botonic-plugin-dynamo-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-plugin-dynamodb
     steps:
     - name: Checking out to current branch
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-dynamo-tests.yml
+++ b/.github/workflows/botonic-plugin-dynamo-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-dynamodb tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-dynamodb/**'
       - '.github/workflows/botonic-plugin-dynamo-tests.yml'
 

--- a/.github/workflows/botonic-plugin-dynamo-tests.yml
+++ b/.github/workflows/botonic-plugin-dynamo-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - 'packages/botonic-plugin-dynamodb/**'
-      - '.github/workflows/botonic-plugin-dynamodb-tests.yml'
+      - '.github/workflows/botonic-plugin-dynamo-tests.yml'
 
 jobs:
   botonic-plugin-dynamodb-tests:

--- a/.github/workflows/botonic-plugin-dynamo-tests.yml
+++ b/.github/workflows/botonic-plugin-dynamo-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic plugin-dynamodb tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-dynamodb/**'
+      - '.github/workflows/botonic-plugin-dynamodb-tests.yml'
 
 jobs:
   botonic-plugin-dynamodb-tests:
@@ -33,3 +37,11 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run test)
     - name: Verify lint
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{env.PACKAGE}}
+        file: ./packages/${{env.PACKAGE}}/coverage/clover.xml
+        name: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-plugin-google-analytics-tests.yml
+++ b/.github/workflows/botonic-plugin-google-analytics-tests.yml
@@ -10,6 +10,8 @@ jobs:
   botonic-plugin-google-analytics-tests:
     name: Botonic plugin-google-analytics tests
     runs-on: ubuntu-latest
+    env:
+      PACKAGE: botonic-plugin-google-analytics
     steps:
     - name: Checking out to current branch (Step 1 of 6)
       uses: actions/checkout@v1
@@ -25,8 +27,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install botonic-plugin-google-analytics (Step 4 of 6)
-      run: (cd ./packages/botonic-plugin-google-analytics && npm install -D)
+      run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Install common packages dependencies (Step 5 of 6)
       run: npm install -D
     - name: Verify lint botonic-plugin-google-analytics (Step 6 of 6)
-      run: (cd ./packages/botonic-plugin-google-analytics && npm run lint_ci)
+      run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-google-analytics-tests.yml
+++ b/.github/workflows/botonic-plugin-google-analytics-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-plugin-google-analytics
     steps:
     - name: Checking out to current branch (Step 1 of 6)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node (Step 2 of 6)
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache (Step 3 of 6)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-google-analytics-tests.yml
+++ b/.github/workflows/botonic-plugin-google-analytics-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-google-analytics tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-google-analytics/**'
       - '.github/workflows/botonic-plugin-google-analytics-tests.yml'
 

--- a/.github/workflows/botonic-plugin-google-analytics-tests.yml
+++ b/.github/workflows/botonic-plugin-google-analytics-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic plugin-google-analytics tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-google-analytics/**'
+      - '.github/workflows/botonic-plugin-google-analytics-tests.yml'
 
 jobs:
   botonic-plugin-google-analytics-tests:

--- a/.github/workflows/botonic-plugin-inbenta-tests.yml
+++ b/.github/workflows/botonic-plugin-inbenta-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-inbenta tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-inbenta/**'
       - '.github/workflows/botonic-plugin-inbenta-tests.yml'
 

--- a/.github/workflows/botonic-plugin-inbenta-tests.yml
+++ b/.github/workflows/botonic-plugin-inbenta-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic plugin-inbenta tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-inbenta/**'
+      - '.github/workflows/botonic-plugin-inbenta-tests.yml'
 
 jobs:
   botonic-plugin-inbenta-tests:

--- a/.github/workflows/botonic-plugin-inbenta-tests.yml
+++ b/.github/workflows/botonic-plugin-inbenta-tests.yml
@@ -10,6 +10,8 @@ jobs:
   botonic-plugin-inbenta-tests:
     name: Botonic plugin-inbenta tests
     runs-on: ubuntu-latest
+    env:
+      PACKAGE: botonic-plugin-inbenta
     steps:
     - name: Checking out to current branch (Step 1 of 6)
       uses: actions/checkout@v1
@@ -25,8 +27,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install botonic-plugin-inbenta (Step 4 of 6)
-      run: (cd ./packages/botonic-plugin-inbenta && npm install -D)
+      run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Install common packages dependencies (Step 5 of 6)
       run: npm install -D
     - name: Verify lint botonic-plugin-inbenta (Step 6 of 6)
-      run: (cd ./packages/botonic-plugin-inbenta && npm run lint_ci)
+      run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-inbenta-tests.yml
+++ b/.github/workflows/botonic-plugin-inbenta-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-plugin-inbenta
     steps:
     - name: Checking out to current branch (Step 1 of 6)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node (Step 2 of 6)
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache (Step 3 of 6)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-luis-tests.yml
+++ b/.github/workflows/botonic-plugin-luis-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic plugin-luis tests
  
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-luis/**'
+      - '.github/workflows/botonic-plugin-luis-tests.yml'
  
 jobs:
   botonic-plugin-luis-tests:

--- a/.github/workflows/botonic-plugin-luis-tests.yml
+++ b/.github/workflows/botonic-plugin-luis-tests.yml
@@ -10,6 +10,8 @@ jobs:
   botonic-plugin-luis-tests:
     name: Botonic plugin-luis tests
     runs-on: ubuntu-latest
+    env:
+      PACKAGE: botonic-plugin-luis
     steps:
     - name: Checking out to current branch (Step 1 of 6)
       uses: actions/checkout@v1
@@ -25,8 +27,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install botonic-plugin-luis (Step 4 of 6)
-      run: (cd ./packages/botonic-plugin-luis && npm install -D)
+      run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Install common packages dependencies (Step 5 of 6)
       run: npm install -D
     - name: Verify lint botonic-plugin-luis (Step 6 of 6)
-      run: (cd ./packages/botonic-plugin-luis && npm run lint_ci)
+      run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-luis-tests.yml
+++ b/.github/workflows/botonic-plugin-luis-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-luis tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-luis/**'
       - '.github/workflows/botonic-plugin-luis-tests.yml'
  

--- a/.github/workflows/botonic-plugin-luis-tests.yml
+++ b/.github/workflows/botonic-plugin-luis-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-plugin-luis
     steps:
     - name: Checking out to current branch (Step 1 of 6)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node (Step 2 of 6)
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache (Step 3 of 6)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -10,6 +10,8 @@ jobs:
   botonic-plugin-nlu-tests:
     name: Botonic plugin-nlu tests
     runs-on: ubuntu-latest
+    env:
+      PACKAGE: botonic-plugin-nlu
     steps:
     - name: Checking out to current branch (Step 1 of 7)
       uses: actions/checkout@v1
@@ -27,8 +29,8 @@ jobs:
     - name: Install botonic-plugin-nlu (Step 4 of 7)
       run: (cd ./packages/botonic-plugin-nlu && npm install -D)
     - name: Build botonic-plugin-nlu (Step 5 of 7)
-      run: (cd ./packages/botonic-plugin-nlu && npm run build)
+      run: (cd ./packages/$PACKAGE && npm run build)
     - name: Install common packages dependencies (Step 6 of 7)
       run: npm install -D
     - name: Verify lint botonic-plugin-nlu (Step 6 of 7)
-      run: (cd ./packages/botonic-plugin-nlu && npm run lint_ci)
+      run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic plugin-nlu tests
  
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-nlu/**'
+      - '.github/workflows/botonic-plugin-nlu-tests.yml'
  
 jobs:
   botonic-plugin-nlu-tests:

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-plugin-nlu
     steps:
     - name: Checking out to current branch (Step 1 of 7)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node (Step 2 of 7)
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache (Step 3 of 7)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-nlu tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-nlu/**'
       - '.github/workflows/botonic-plugin-nlu-tests.yml'
  

--- a/.github/workflows/botonic-plugin-segment-tests.yml
+++ b/.github/workflows/botonic-plugin-segment-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic plugin-segment tests
  
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-segment/**'
+      - '.github/workflows/botonic-plugin-segment-tests.yml'
  
 jobs:
   botonic-plugin-segment-tests:

--- a/.github/workflows/botonic-plugin-segment-tests.yml
+++ b/.github/workflows/botonic-plugin-segment-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-plugin-segment
     steps:
     - name: Checking out to current branch (Step 1 of 6)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node (Step 2 of 6)
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache (Step 3 of 6)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-segment-tests.yml
+++ b/.github/workflows/botonic-plugin-segment-tests.yml
@@ -10,6 +10,8 @@ jobs:
   botonic-plugin-segment-tests:
     name: Botonic plugin-segment tests
     runs-on: ubuntu-latest
+    env:
+      PACKAGE: botonic-plugin-segment
     steps:
     - name: Checking out to current branch (Step 1 of 6)
       uses: actions/checkout@v1
@@ -25,8 +27,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install botonic-plugin-segment (Step 4 of 6)
-      run: (cd ./packages/botonic-plugin-segment && npm install -D)
+      run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Install common packages dependencies (Step 5 of 6)
       run: npm install -D
     - name: Verify lint botonic-plugin-segment (Step 6 of 6)
-      run: (cd ./packages/botonic-plugin-segment && npm run lint_ci)
+      run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-segment-tests.yml
+++ b/.github/workflows/botonic-plugin-segment-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-segment tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-segment/**'
       - '.github/workflows/botonic-plugin-segment-tests.yml'
  

--- a/.github/workflows/botonic-plugin-watson-tests.yml
+++ b/.github/workflows/botonic-plugin-watson-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-plugin-watson
     steps:
     - name: Checking out to current branch (Step 1 of 6)
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node (Step 2 of 6)
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache (Step 3 of 6)
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-plugin-watson-tests.yml
+++ b/.github/workflows/botonic-plugin-watson-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic plugin-watson tests
  
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-watson/**'
+      - '.github/workflows/botonic-plugin-watson-tests.yml'
  
 jobs:
   botonic-plugin-watson-tests:

--- a/.github/workflows/botonic-plugin-watson-tests.yml
+++ b/.github/workflows/botonic-plugin-watson-tests.yml
@@ -3,6 +3,8 @@ name: Botonic plugin-watson tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-plugin-watson/**'
       - '.github/workflows/botonic-plugin-watson-tests.yml'
  

--- a/.github/workflows/botonic-plugin-watson-tests.yml
+++ b/.github/workflows/botonic-plugin-watson-tests.yml
@@ -10,6 +10,8 @@ jobs:
   botonic-plugin-watson-tests:
     name: Botonic plugin-watson tests
     runs-on: ubuntu-latest
+    env:
+      PACKAGE: botonic-plugin-watson
     steps:
     - name: Checking out to current branch (Step 1 of 6)
       uses: actions/checkout@v1
@@ -25,8 +27,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install botonic-plugin-watson (Step 4 of 6)
-      run: (cd ./packages/botonic-plugin-watson && npm install -D)
+      run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Install common packages dependencies (Step 5 of 6)
       run: npm install -D
     - name: Verify lint botonic-plugin-watson (Step 6 of 6)
-      run: (cd ./packages/botonic-plugin-watson && npm run lint_ci)
+      run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-react-tests.yml
+++ b/.github/workflows/botonic-react-tests.yml
@@ -1,6 +1,10 @@
 name: Botonic react tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'packages/botonic-react/**'
+      - '.github/workflows/botonic-react-tests.yml'
 
 jobs:
   botonic-react-tests:
@@ -31,4 +35,12 @@ jobs:
     - name: Verify lint
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
     - name: Verify index.d.ts
-      run: scripts/qa/lint-d-ts.sh packages/botonic-core
+      run: scripts/qa/lint-d-ts.sh ./packages/$PACKAGE
+    
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{env.PACKAGE}}
+        file: ./packages/${{env.PACKAGE}}/coverage/clover.xml
+        name: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-react-tests.yml
+++ b/.github/workflows/botonic-react-tests.yml
@@ -14,13 +14,13 @@ jobs:
       PACKAGE: botonic-react
     steps:
     - name: Checking out to current branch
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setting up node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
     - name: Setting up cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/botonic-react-tests.yml
+++ b/.github/workflows/botonic-react-tests.yml
@@ -3,6 +3,8 @@ name: Botonic react tests
 on:
   push:
     paths:
+      - '*'
+      - 'packages/*'
       - 'packages/botonic-react/**'
       - '.github/workflows/botonic-react-tests.yml'
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  status:
+    project:
+      default:
+        # if the coverage is under this value the Codecov GitHub check will fail
+        threshold: 40%
+flags:
+  botonic-plugin-contentful:
+    paths:
+      - packages/botonic-plugin-contentful
+    carryforward: true
+  botonic-react:
+    paths:
+      - packages/botonic-react
+    carryforward: true
+  botonic-core:
+    paths:
+      - packages/botonic-core
+    carryforward: true
+  botonic-plugin-dynamodb:
+    paths:
+      - packages/botonic-plugin-dynamodb
+    carryforward: true


### PR DESCRIPTION
## Description

1. **Setup codecov** for botonic:
    - Configure initial codecov setup
    - Upload coverage report to https://codecov.io/gh/hubtype/botonic
2. Trigger **Github workflows only when necessary**. 


## Context
1. Codecov
Configuring codecov will allow us to improve the coverage on every push (or at least keep it as the level of previous push)
The configuration in [codecov.yml](https://docs.codecov.io/docs/codecovyml-reference) includes an initial setup with the following:
    - Minimum coverage of 40% threshold
    - [Flags](https://docs.codecov.io/docs/flags) for the different projects in packages/ that have unit tests running. (Flags help us isolating reports in a monorepo setup)
You can see the reports in https://codecov.io/gh/hubtype/botonic

2. Trigger Github workflows only when necessary 
Prior to this PR, all workflows were triggered, no matter where the change was coming from.
Now, each workflow is triggered only when the change is originated in the path where the workflow operates. For instance, changes in packages/botonic-plugin-dynamodb/** will trigger botonic-plugin-dynamo-tests.yml workflow only. Of course, if we change a workflow file, it will be executed once it is pushed.

## Approach taken / Explain the design
1. Codecov
    - Include a codecov config file with the initial setup
    - add codecov/codecov-action@v1 to worflows in order to upload coverage reports
2. Trigger Github workflows only when necessary 
    - Include paths section on the trigger pointing to the related codebase in the packages folder. Also it makes reference to the workflow itself, to make sure it is executed if changes on it are pushed.

## To document / Usage example
You can see last generated reports at https://codecov.io/gh/hubtype/botonic

## Testing
I executed some tests to see that results from the different paths appear in the codecov page.
Regarding the event that triggers the workflows, I also did some tests but, as I have changed all workflows and paths sometimes are hard to validate, something might have fallen through the cracks, please let me know if you see that workflows are not being triggered upon your changes. 
