### PR TITLE
Contentful Plugin: remove duplicated import

### DIFF
--- a/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery-api.ts
@@ -14,7 +14,6 @@ import { ContentfulOptions } from '../plugin'
 import { DateRangeDelivery } from './contents/date-range'
 import { convertContentfulException, DateRangeFields } from './delivery-utils'
 import { ReducedClientApi } from './delivery/client-api'
-import { DateRangeFields } from './delivery-utils'
 import {
   SearchableByKeywordsDelivery,
   SearchableByKeywordsFields,


### PR DESCRIPTION
## Description

Remove duplicated import of DateRangeFields in file `delivery-api.ts`

## Context

Remove Duplicate identifier 'DateRangeFields'.

## Approach taken / Explain the design


## To document / Usage example


## Testing

No tests
