### PR TITLE
create 2 tests for Text component (markdown enabled/disabled)

### DIFF
--- a/packages/botonic-react/tests/components/__snapshots__/text.test.jsx.snap
+++ b/packages/botonic-react/tests/components/__snapshots__/text.test.jsx.snap
@@ -81,6 +81,32 @@ Array [
 ]
 `;
 
+exports[`Text Component Text with <BR>: markdown disabled 1`] = `
+<message
+  delay={0}
+  markdown={0}
+  type="text"
+  typing={0}
+>
+  hi
+  <br />
+  bye
+</message>
+`;
+
+exports[`Text Component Text with <BR>: markdown enabled 1`] = `
+<message
+  delay={0}
+  markdown={1}
+  type="text"
+  typing={0}
+>
+  hi
+  &lt;br&gt;
+  bye
+</message>
+`;
+
 exports[`Text Component Text with 1 button 1`] = `
 <message
   delay={0}

--- a/packages/botonic-react/tests/components/text.test.jsx
+++ b/packages/botonic-react/tests/components/text.test.jsx
@@ -14,6 +14,30 @@ describe('Text Component', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('Text with <BR>: markdown disabled', () => {
+    const sut = (
+      <Text markdown={0}>
+        hi
+        <br />
+        bye
+      </Text>
+    )
+    const tree = renderToJSON(sut)
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('Text with <BR>: markdown enabled', () => {
+    const sut = (
+      <Text>
+        hi
+        <br />
+        bye
+      </Text>
+    )
+    const tree = renderToJSON(sut)
+    expect(tree).toMatchSnapshot()
+  })
+
   test('Text with 1 button', () => {
     const sut = (
       <Text>


### PR DESCRIPTION
## Description

Create 2 unit tests for Text component with markdown enabled/disabled

## Context
Since there were no tests for Text component with markdown enabled/disabled, we created 2 tests, one for enabled and another for disabled.

## Approach taken / Explain the design
Add 2 jest tests to text.test.jsx file, along with their corresponding snapshot.

## To document / Usage example


## Testing
Tests are passing and coverage has increased