### PR TITLE
Configure Jest to scan all files in src dirs when measuring coverage

### DIFF
--- a/packages/botonic-core/jest.config.js
+++ b/packages/botonic-core/jest.config.js
@@ -1,0 +1,24 @@
+// Options about JS are for compiling @botonic .js/jsx files
+module.exports = {
+  roots: ['src/'],
+  testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.(js|jsx)$',
+  testPathIgnorePatterns: [
+    'lib',
+    '.*.d.ts',
+    'tests/helpers',
+    '.*.helper.js',
+    'tests/__mocks__',
+  ],
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
+  transformIgnorePatterns: [
+    'node_modules/(?!@botonic|react-children-utilities).+\\.(js|jsx)$',
+  ],
+  moduleFileExtensions: ['js', 'jsx', 'json'],
+  snapshotSerializers: [],
+  modulePaths: ['node_modules', 'src'],
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '<rootDir>/tests/__mocks__/file-mock.js',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+}

--- a/packages/botonic-plugin-contentful/jest.config.js
+++ b/packages/botonic-plugin-contentful/jest.config.js
@@ -1,6 +1,6 @@
 // Options about JS are for compiling @botonic .js/jsx files
 module.exports = {
-  roots: ['tests/'],
+  roots: ['src/', 'tests/'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
     '^.+\\.jsx?$': 'ts-jest',

--- a/packages/botonic-plugin-dynamodb/jest.config.js
+++ b/packages/botonic-plugin-dynamodb/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  roots: ['tests/'],
+  roots: ['src/', 'tests/'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/packages/botonic-react/jest.config.js
+++ b/packages/botonic-react/jest.config.js
@@ -1,6 +1,6 @@
 // Options about JS are for compiling @botonic .js/jsx files
 module.exports = {
-  roots: ['tests/'],
+  roots: ['src/', 'tests/'],
   testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.(js|jsx)$',
   testPathIgnorePatterns: [
     'lib',


### PR DESCRIPTION
## Description
Configure Jest to look for all files in src dir in order to measure coverage properly.
Same config has been propposed to bots-definition in https://github.com/metis-ai/bots-definition/pull/404

## Context
With the previous configuration, Jest would only look for items imported in the tests files, resulting in an unrealistic coverage. e.g. A src file without tests and not referenced by other tests, will not be taken into account for the coverage.

## Approach taken / Explain the design
Adding src dir to the roots of the Jest configuration will force Jest to scan ALL src files no matter if they are imported or not.
In all jest config files, we have changed the line `roots: ['tests/'],` to `roots: ['src/', 'tests/'],`

## Testing
Tested in `packages/botonic-react` folder with `npm test`:
After applying the changes, we observe that coverage has slighltly decreased, since more files are taken into account for measuring the whole coverage
