### PR TITLE
Use lcov report for coverage since clover has issues and seems less maintained

### DIFF
--- a/.github/workflows/botonic-core-tests.yml
+++ b/.github/workflows/botonic-core-tests.yml
@@ -44,6 +44,6 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{env.PACKAGE}}
-        file: ./packages/${{env.PACKAGE}}/coverage/clover.xml
+        file: ./packages/${{env.PACKAGE}}/coverage/lcov.info
         name: ${{env.PACKAGE}}
         env_vars: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-plugin-contentful-tests.yml
+++ b/.github/workflows/botonic-plugin-contentful-tests.yml
@@ -46,5 +46,5 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{env.PACKAGE}}
-        file: ./packages/${{env.PACKAGE}}/coverage/clover.xml
+        file: ./packages/${{env.PACKAGE}}/coverage/lcov.info
         name: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-plugin-dynamo-tests.yml
+++ b/.github/workflows/botonic-plugin-dynamo-tests.yml
@@ -45,5 +45,5 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{env.PACKAGE}}
-        file: ./packages/${{env.PACKAGE}}/coverage/clover.xml
+        file: ./packages/${{env.PACKAGE}}/coverage/lcov.info
         name: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-react-tests.yml
+++ b/.github/workflows/botonic-react-tests.yml
@@ -44,5 +44,5 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{env.PACKAGE}}
-        file: ./packages/${{env.PACKAGE}}/coverage/clover.xml
+        file: ./packages/${{env.PACKAGE}}/coverage/lcov.info
         name: ${{env.PACKAGE}}


### PR DESCRIPTION
## Description
Upload lcov report to codecov instead of clover one.

## Context
The clover report generated by Jest has issues with partial branch coverage and looks like it is not actively maintained (https://github.com/facebook/jest/issues/10262#issuecomment-733018346)

## Approach taken / Explain the design
Since Jest generates lcov report too, we will use it to avoid problems with clover. 
In this PR, all workflows that upload reports to codecov, have bee updated to use lcov.

## To document / Usage example
All workflows will use `file: ./packages/${{env.PACKAGE}}/coverage/lcov.info`

## Testing
Verified that reports in codecov do not show previous problems with partial branch coverage. See https://codecov.io/gh/hubtype/botonic/commit/d4742e70e9d814fb698547e009ecca69c9563cdc
