### PR TITLE
Chore/improve telemetry

### DIFF
--- a/.github/workflows/botonic-cli-tests.yml
+++ b/.github/workflows/botonic-cli-tests.yml
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-node-
       - name: Install dev dependencies
         env:
-          BOTONIC_DISABLE_MIXPANEL: 1
+          BOTONIC_DISABLE_ANALYTICS: ${{ secrets.BOTONIC_DISABLE_ANALYTICS }}
         run: (cd ./packages/$PACKAGE && npm install -D)
       - name: Build
         run: (cd ./packages/$PACKAGE && npm run build)

--- a/.github/workflows/botonic-cli-tests.yml
+++ b/.github/workflows/botonic-cli-tests.yml
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-node-
       - name: Install dev dependencies
         env:
-          BOTONIC_DISABLE_ANALYTICS: ${{ secrets.BOTONIC_DISABLE_ANALYTICS }}
+          BOTONIC_DISABLE_ANALYTICS: '1'
         run: (cd ./packages/$PACKAGE && npm install -D)
       - name: Build
         run: (cd ./packages/$PACKAGE && npm run build)

--- a/packages/botonic-cli/src/botonic-api-service.ts
+++ b/packages/botonic-cli/src/botonic-api-service.ts
@@ -11,6 +11,8 @@ import { hashElement } from 'folder-hash'
 import ora from 'ora'
 import qs from 'qs'
 
+import { readJSON, writeJSON } from './utils'
+
 const BOTONIC_CLIENT_ID: string =
   process.env.BOTONIC_CLIENT_ID || 'jOIYDdvcfwqwSs7ZJ1CpmTKcE7UDapZDOSobFmEp'
 const BOTONIC_CLIENT_SECRET: string =
@@ -51,9 +53,7 @@ export class BotonicAPIService {
   loadGlobalCredentials() {
     let credentials
     try {
-      credentials = JSON.parse(
-        fs.readFileSync(this.globalCredentialsPath, 'utf8')
-      )
+      credentials = readJSON(this.globalCredentialsPath)
     } catch (e) {
       if (fs.existsSync(this.globalCredentialsPath)) {
         console.warn('Credentials could not be loaded', e)
@@ -75,7 +75,7 @@ export class BotonicAPIService {
   loadBotCredentials() {
     let credentials
     try {
-      credentials = JSON.parse(fs.readFileSync(this.botCredentialsPath, 'utf8'))
+      credentials = readJSON(this.botCredentialsPath)
     } catch (e) {
       if (fs.existsSync(this.botCredentialsPath)) {
         console.warn('Credentials could not be loaded', e)
@@ -101,19 +101,19 @@ export class BotonicAPIService {
 
   saveGlobalCredentials() {
     this.checkGlobalCredentialsPath()
-    fs.writeFileSync(
-      this.globalCredentialsPath,
-      JSON.stringify({
-        oauth: this.oauth,
-        me: this.me,
-        analytics: this.analytics,
-      })
-    )
+    writeJSON(this.globalCredentialsPath, {
+      oauth: this.oauth,
+      me: this.me,
+      analytics: this.analytics,
+    })
   }
 
   saveBotCredentials() {
-    const bc = { bot: this.bot, lastBuildHash: this.lastBuildHash }
-    fs.writeFileSync(this.botCredentialsPath, JSON.stringify(bc))
+    const botCredentials = {
+      bot: this.bot,
+      lastBuildHash: this.lastBuildHash,
+    }
+    writeJSON(this.botCredentialsPath, botCredentials)
   }
 
   async getCurrentBuildHash() {

--- a/packages/botonic-cli/src/utils.ts
+++ b/packages/botonic-cli/src/utils.ts
@@ -36,9 +36,7 @@ function readCredentials() {
   try {
     credentials = readJSON(botonicCredentialsPath)
   } catch (e) {
-    if (fs.existsSync(botonicCredentialsPath)) {
-      console.warn('Credentials could not be loaded', e)
-    }
+    console.warn('Credentials could not be loaded', e)
   }
 }
 
@@ -56,15 +54,15 @@ if (isAnalyticsEnabled()) {
   analytics = new Analytics('YD0jpJHNGW12uhLNbgB4wbdTRQ4Cy1Zu')
 }
 
-function getBotonicCliVersion(): string | undefined {
+function getBotonicCliVersion(): string {
   try {
     return String(execSync('botonic --version')).trim()
   } catch (e) {
-    return undefined
+    return String(e)
   }
 }
 
-function getBotonicDependencies(): any[] | undefined {
+function getBotonicDependencies(): any[] | string {
   try {
     const packageJSON = readJSON('package.json')
     const botonicDependencies = Object.entries(
@@ -72,7 +70,7 @@ function getBotonicDependencies(): any[] | undefined {
     ).filter(([k, _]) => k.includes('@botonic'))
     return botonicDependencies
   } catch (e) {
-    return undefined
+    return String(e)
   }
 }
 
@@ -118,7 +116,7 @@ export function sleep(ms: number): Promise<number> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-async function sh(cmd: string) {
+async function sh(cmd: string): Promise<{ stdout: string; stderr: string }> {
   return new Promise(function (resolve, reject) {
     exec(cmd, (err, stdout, stderr) => {
       if (err) {


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Added `BOTONIC_DISABLE_ANALYTICS` secret to the repo and in its corresponding workflow
* Improved analytics by retrieving `@botonic/cli`'s version and `@botonic` dependencies.
* Refactored json logic and renamed linter suggestions.

## Context
`BOTONIC_DISABLE_ANALYTICS` should be declared in order to not track installations run by Github Actions, because they can add noise to the analytics.

## Next steps
Once this PR is approved, I'm gonna apply these changes also in `botonic-examples` track methods. Unifying and improving error messages in related @ericmarcos task: https://linear.app/hubtype/issue/BOT-171/better-understand-1st-time-developer-flow 