### PR TITLE
style(react): make mobileBreakpoint and mobileStyle props optional in ThemeProps

### DIFF
--- a/packages/botonic-react/src/components/index.d.ts
+++ b/packages/botonic-react/src/components/index.d.ts
@@ -123,8 +123,8 @@ export interface ScrollbarProps {
 }
 
 export interface ThemeProps extends StyleProp {
-  mobileBreakpoint: number
-  mobileStyle: any
+  mobileBreakpoint?: number
+  mobileStyle?: any
   webview?: StyleProp & { header?: StyleProp }
   animations?: EnableProp
   intro?: StyleProp & ImageProp & CustomProp


### PR DESCRIPTION
## Description
Make `mobileBreakpoint` and `mobileStyle` props optional in `ThemeProps`.

## Context
Using typescript, if `theme` prop is modified through `<WebchatSettings>`, this typescript error shows up:
```
TS2739: Type '{}' is missing the following properties from type 'ThemeProps': mobileBreakpoint, mobileStyle
```
This PR solves this problem.

## Approach taken / Explain the design


## To document / Usage example

## Testing

The pull request has no tests.
