### PR TITLE
Docs: update contentful-plugin setup readme

### DIFF
--- a/packages/botonic-plugin-contentful/README.md
+++ b/packages/botonic-plugin-contentful/README.md
@@ -51,12 +51,21 @@ For the previous content, the dashboard allows assigning a list of tags to your 
 npm install @botonic/plugin-contentful
 ```
 
-2. Execute the following script to create content models required by the plugin. Replaced YOUR_ID and YOUR_TOKEN with
-   the space id and token that you obtained in the previous section.
+2. Install the contentful-cli
+
+```javascript```
+npm install -g contentful-cli
+```
+
+3. Execute the following command to create content models required by the plugin. Replaced YOUR_ID and YOUR_TOKEN with
+   the space id and contentful delivery token that you obtained in the previous section. You can find
+the export files in the [package exports directory](https://github.com/hubtype/botonic/tree/master/packages/botonic-plugin-contentful/exports)
 
 ```javascript
-CONTENTFUL_SPACEID=<YOUR_ID> CONTENTFUL_TOKEN=<CONTENT_MANAGEMENT_TOKEN> node_modules/@botonic/plugin-contentful/bin/import-contentful-models.sh
+contentful space import --space-id={SPACE_ID} --management-token={TOKEN} --content-file {EXPORT_FILE}.json
 ```
+
+*note* you will need to ensure your contentful locales are changed from `en-US` to `en` 
 
 ## Use
 
@@ -110,10 +119,10 @@ export const plugins = [
 ...
   {
     id: 'contentful',
-    resolve: contentful,
+    resolve: require('@botonic/plugin-contentful'),
     options: {
-               spaceId = <YOUR_CONTENTFUL_SPACEID>;
-               accessToken = <DELIVERY_API_TOKEN>;
+               spaceId: <YOUR_CONTENTFUL_SPACEID>,
+               accessToken: <DELIVERY_API_TOKEN>
              }
   },
 ...
@@ -124,7 +133,8 @@ export const plugins = [
 To render a botonic _StartUp_, _Texts_ and _Carousels_ with the contents configured at contentful space:
 
 1. Create the following functions, which convert the result from the Contentful plugin to react components (They are not
-   implemented within the Contentful plugin to keep the plugin fully decoupled from React)
+   implemented within the Contentful plugin to keep the plugin fully decoupled from React). Note
+   that the code shown below contains TypeScript annotations.
 
 ```javascript
 import * as cms from '@botonic/plugin-contentful'
@@ -181,11 +191,11 @@ import * as cms from '@botonic/plugin-contentful';
 ....
 
  {
-    payload: cms.ContentCallback.regexForModel(cms.ModelType.TEXT),
+    payload: cms.ContentCallback.regexForModel(cms.TopContentType.TEXT),
     action: Text
   },
   {
-    payload: cms.ContentCallback.regexForModel(cms.ModelType.CAROUSEL),
+    payload: cms.ContentCallback.regexForModel(cms.TopContentType.CAROUSEL),
     action: Carousel
   },
 ```


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

Updated Botonic Contentful plugin readme to address recent breaking changes.

## Context

1. Following [this change](https://github.com/hubtype/botonic/commit/c820e2b32a6d5548f0d1dafd04392b0c5ce9401f) the instructions to setup the contentful plugin require updating as they do not reflect the need to specify the contentful export.json. The code samples also contain a few errors I have addressed.

2. Following this [breaking API change](https://github.com/hubtype/botonic/blob/e12f47c1f5bf8118b8f34ba3a422ba334ed42b6c/CHANGELOG.md#changed-6) I've also updated the code samples to reflect the renamed values.

## Approach taken / Explain the design
Docs updated. Note that I've deliberately used the contentful CLI instead of the script as I wasn't sure about the locale work the script does (and the paths seemed to be incorrect). This is likely ignorance on my part and would welcome guidance.

## To document / Usage example
Remaining question: Is there an export that should be recommended to be imported? I can see two possibilities at the moment: https://github.com/hubtype/botonic/tree/master/packages/botonic-plugin-contentful/exports

- contentful-export-0.9.22.json
- contentful-export-0.11.3.json

Are there significant differences and are they backwards compatible? 

## Testing

The pull request...

- doesn't need tests because it's documentation.
