### PR TITLE
fix(contentful): Reimplementation of the stemmer-uk without lookbehind regex.

### DIFF
--- a/packages/botonic-plugin-contentful/src/nlp/stemmer.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/stemmer.ts
@@ -76,8 +76,8 @@ const stemmers = new SingletonMap<Stemmer>({
     return new StemmerCs()
   },
   [locales.UKRAINIAN]: () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const StemmerUk = require('@nlpjs/lang-uk/src/stemmer-uk')
+    // eslint-disable-next-line @typescript-eslint/no-var-requires,node/no-missing-require
+    const { StemmerUk } = require('./stemmers/stemmer-uk')
     return new StemmerUk()
   },
   [locales.CROATIAN]: () => {

--- a/packages/botonic-plugin-contentful/src/nlp/stemmers/stemmer-hr.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/stemmers/stemmer-hr.ts
@@ -38,7 +38,7 @@ export class StemmerHr implements Stemmer {
   private getRoot(token: string): string {
     for (const rule of hrRules) {
       const match = new RegExp(rule).exec(token)
-      if (match != undefined) {
+      if (match) {
         const root = match[1]
         if (this.containsVocal(root) && root.length > 1) {
           return root

--- a/packages/botonic-plugin-contentful/src/nlp/stemmers/stemmer-uk.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/stemmers/stemmer-uk.ts
@@ -1,0 +1,88 @@
+import Stemmer from '@nlpjs/core/src/stemmer'
+
+export class StemmerUk implements Stemmer {
+  public stem(tokens: string[]): string[] {
+    return tokens.map(token => this.stemToken(token))
+  }
+
+  private stemToken(token: string): string {
+    const vowelMatch = token.match(/[аеиоуюяіїє]/)
+    if (!vowelMatch) {
+      return token
+    } else if (vowelMatch.index != undefined) {
+      const start = token.slice(0, vowelMatch.index + 1)
+      token = token.slice(vowelMatch.index + 1)
+
+      if (token === '') {
+        return start
+      }
+
+      token = this.step1(token)
+      token = this.step2(token)
+      token = this.step3(token)
+      token = this.step4(token)
+
+      return `${start}${token}`
+    } else {
+      return token
+    }
+  }
+
+  private replace(token: string, regex: RegExp, replacement = ''): string {
+    return token.replace(regex, replacement)
+  }
+
+  private step1(token: string): string {
+    let originalToken = token
+    token = this.replace(token, /(?:[иы]в(?:ши(?:сь)?)?)$/)
+    token = this.replace(token, /(?:а(?:в(?:ши(?:сь)?)?))$/, 'а')
+    token = this.replace(token, /(?:я(?:в(?:ши(?:сь)?)?))$/, 'я')
+    if (originalToken === token) {
+      token = this.replace(token, /с[яьи]$/)
+      originalToken = token
+      token = this.replace(
+        token,
+        /(?:[аеєуюя]|еє|ем|єє|ий|их|іх|ів|ій|ім|їй|ім|им|ими|іми|йми|ої|ою|ова|ове|ого|ому)$/
+      )
+      if (originalToken !== token) {
+        token = this.replace(token, /(?:[аіу]|ій|ий|им|ім|их|йми|ого|ому|ою)$/)
+      } else {
+        originalToken = token
+        token = this.replace(
+          token,
+          /(?:[еєую]|ав|али|ати|вши|ив|ити|ме|сь|ся|ши|учи|яти|ячи|ать|ять)$/g
+        )
+        if (originalToken === token) {
+          token = this.replace(
+            token,
+            /(?:[аеєіїийоуыьюя]|ам|ах|ами|ев|еві|еи|ей|ем|ею|єм|єю|ів|їв|ий|ием|ию|ия|иям|иях|ов|ові|ой|ом|ою|ью|ья|ям|ями|ях)$/g
+          )
+        }
+      }
+    }
+    return token
+  }
+
+  private step2(token: string): string {
+    return this.replace(token, /и$/)
+  }
+
+  private step3(token: string): string {
+    if (
+      /[^аеиоуюяіїє][аеиоуюяіїє]+[^аеиоуюяіїє]+[аеиоуюяіїє].*oсть/g.test(token)
+    ) {
+      token = this.replace(token, /ость$/)
+    }
+    return token
+  }
+
+  private step4(token: string): string {
+    const originalToken = token
+    token = this.replace(originalToken, /ь$/)
+    if (originalToken === token) {
+      token = this.replace(token, /ейше$/)
+      token = this.replace(token, /нн$/, 'н')
+    }
+    return token
+  }
+}

--- a/packages/botonic-plugin-contentful/src/nlp/stemmers/stemmer-uk.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/stemmers/stemmer-uk.ts
@@ -6,7 +6,7 @@ export class StemmerUk implements Stemmer {
   }
 
   private stemToken(token: string): string {
-    const vowelMatch = token.match(/[аеиоуюяіїє]/)
+    const vowelMatch = /[аеиоуюяіїє]/.exec(token)
     if (!vowelMatch) {
       return token
     } else if (vowelMatch.index != undefined) {
@@ -69,7 +69,7 @@ export class StemmerUk implements Stemmer {
 
   private step3(token: string): string {
     if (
-      /[^аеиоуюяіїє][аеиоуюяіїє]+[^аеиоуюяіїє]+[аеиоуюяіїє].*oсть/g.test(token)
+      /[^аеиоуюяіїє][аеиоуюяіїє]+[^аеиоуюяіїє]+[аеиоуюяіїє].*oсть/g.exec(token)
     ) {
       token = this.replace(token, /ость$/)
     }

--- a/packages/botonic-plugin-contentful/src/nlp/stemmers/stemmer-uk.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/stemmers/stemmer-uk.ts
@@ -1,4 +1,5 @@
 import Stemmer from '@nlpjs/core/src/stemmer'
+// Replaced the orginal lookbehind regex because they were not supported by Safari
 
 export class StemmerUk implements Stemmer {
   public stem(tokens: string[]): string[] {

--- a/packages/botonic-plugin-contentful/src/typings.d.ts
+++ b/packages/botonic-plugin-contentful/src/typings.d.ts
@@ -238,13 +238,6 @@ declare module '@nlpjs/lang-uk/src/tokenizer-uk' {
   export = TokenizerUk
 }
 
-declare module '@nlpjs/lang-uk/src/stemmer-uk' {
-  import BaseStemmer from '@nlpjs/core/src/base-stemmer'
-
-  class StemmerUk extends BaseStemmer {}
-  export = StemmerUk
-}
-
 declare module '@nlpjs/lang-sl/src/tokenizer-sl' {
   import Tokenizer from '@nlpjs/core/src/tokenizer'
 

--- a/packages/botonic-plugin-contentful/tests/nlp/stemmers/stemmer-uk.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/stemmers/stemmer-uk.test.ts
@@ -7,6 +7,7 @@ test.each<any>([
   ['парковка', ['парковк']],
   ['експеримент', ['експеримент']],
   ['зустрічі', ['зустріч']],
+  ['потурбувавши', ['потурбува']], //Solved without lookbehind regex
 ])('TEST: Ukrainian stemmer("%s")->"%s"', (word: string, expected: string) => {
   const tokenizer = tokenizerPerLocale('hr')
   const sut = new StemmerUk()

--- a/packages/botonic-plugin-contentful/tests/nlp/stemmers/stemmer-uk.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/stemmers/stemmer-uk.test.ts
@@ -1,0 +1,15 @@
+import { tokenizerPerLocale } from '../../../src/nlp'
+import { StemmerUk } from '../../../src/nlp/stemmers/stemmer-uk'
+
+test.each<any>([
+  ['розмовляючи', ['розмовляюч']],
+  ['говорити', ['говор']],
+  ['парковка', ['парковк']],
+  ['експеримент', ['експеримент']],
+  ['зустрічі', ['зустріч']],
+])('TEST: Ukrainian stemmer("%s")->"%s"', (word: string, expected: string) => {
+  const tokenizer = tokenizerPerLocale('hr')
+  const sut = new StemmerUk()
+  const result = sut.stem(tokenizer.tokenize(word, false))
+  expect(result).toEqual(expected)
+})


### PR DESCRIPTION
## Description
The stemmer used for Ukrainian had lookbehind regex that was not supported by Safari, so it has been implemented without including that type of unsupported regex.

## Context

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->
Is trying to fix this bug reported by @vanbasten17 in [this issue](https://github.com/axa-group/nlp.js/issues/741).

## Approach taken / Explain the design
The stemmer has been reimplemented in Botonic contentful but replacing the lookbehind regex.

## Testing

The pull request...

- [x] has unit tests
- [x] has integration tests
