### PR TITLE
Botonic plugin contentful: add indicationText field

### DIFF
--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -4,7 +4,7 @@ import { SearchableBy } from './fields';
 
 export enum ButtonStyle {
   BUTTON = 0,
-  QUICK_REPLY = 1
+  QUICK_REPLY = 1,
 }
 
 /** Not a Content because it cannot have custom fields */
@@ -34,7 +34,7 @@ export abstract class Content {
   }
 
   static validateContents(contents: Content[]): string | undefined {
-    const invalids = contents.map(c => c.validate()).filter(v => v);
+    const invalids = contents.map((c) => c.validate()).filter((v) => v);
     if (invalids.length == 0) {
       return undefined;
     }
@@ -172,7 +172,8 @@ export class Queue extends Content implements ContentWithKeywords {
     readonly queue: string,
     readonly shortText?: string,
     readonly schedule?: Schedule,
-    readonly searchableBy: SearchableBy = new SearchableBy()
+    readonly searchableBy: SearchableBy = new SearchableBy(),
+    readonly indicationText?: string
   ) {
     super(name);
   }

--- a/packages/botonic-plugin-contentful/src/contentful/queue.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/queue.ts
@@ -54,5 +54,5 @@ export interface QueueFields extends ContentWithNameFields {
   queue: string;
   schedule?: contentful.Entry<ScheduleFields>;
   searchableBy?: contentful.Entry<SearchableByKeywordsFields>[];
-  indicationText: string;
+  indicationText?: string;
 }

--- a/packages/botonic-plugin-contentful/src/contentful/queue.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/queue.ts
@@ -6,7 +6,7 @@ import { ContentWithNameFields, DeliveryApi } from './delivery-api';
 import { ScheduleFields, ScheduleDelivery } from './schedule';
 import {
   SearchableByKeywordsDelivery,
-  SearchableByKeywordsFields
+  SearchableByKeywordsFields,
 } from './searchable-by';
 
 export class QueueDelivery extends ContentDelivery {
@@ -35,7 +35,7 @@ export class QueueDelivery extends ContentDelivery {
 
     const searchableBy =
       fields.searchableBy &&
-      fields.searchableBy.map(searchableBy =>
+      fields.searchableBy.map((searchableBy) =>
         SearchableByKeywordsDelivery.fromEntry(searchableBy)
       );
     return new cms.Queue(
@@ -43,7 +43,8 @@ export class QueueDelivery extends ContentDelivery {
       fields.shortText,
       fields.queue,
       schedule,
-      new cms.SearchableBy(searchableBy)
+      new cms.SearchableBy(searchableBy),
+      fields.indicationText
     );
   }
 }
@@ -53,4 +54,5 @@ export interface QueueFields extends ContentWithNameFields {
   queue: string;
   schedule?: contentful.Entry<ScheduleFields>;
   searchableBy?: contentful.Entry<SearchableByKeywordsFields>[];
+  indicationText: string;
 }


### PR DESCRIPTION
## Description
Added a new field named indicationText in cms queue. This field is used to show a message before a handoff and it is placed in desk queue contentful content model.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
I need this field because I have a bot that uses the indicationText from the desk queue content model in contentful.
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
