### PR TITLE
fix(core/react): include lib as files to be published

### DIFF
--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -40,8 +40,7 @@
     "/lib",
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json",
-    "/scripts",
-    "/templates"
+    "/scripts"
   ],
   "homepage": "https://github.com/hubtype/botonic",
   "main": "lib/index.js",

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "src/**",
+    "lib/**",
     "src/index.d.ts"
   ],
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -21,6 +21,7 @@
   "author": "",
   "files": [
     "src/**",
+    "lib/**",
     "index.d.ts",
     "MIGRATION_GUIDE.md"
   ],


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Lib was not published to npm because of missing in "files" property of `package.json` in core/react.