### PR TITLE
chore(cli): do not enqueue tracking events, bump to 0.18.3

### DIFF
--- a/packages/botonic-cli/README.md
+++ b/packages/botonic-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @botonic/cli
 $ botonic COMMAND
 running command...
 $ botonic (-v|--version|version)
-@botonic/cli/0.18.2 darwin-x64 node-v12.20.1
+@botonic/cli/0.18.3 darwin-x64 node-v12.20.1
 $ botonic --help [COMMAND]
 USAGE
   $ botonic COMMAND
@@ -64,7 +64,7 @@ EXAMPLE
   🚀 Bot deployed!
 ```
 
-_See code: [lib/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.18.2/lib/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.18.3/lib/commands/deploy.js)_
 
 ## `botonic help [COMMAND]`
 
@@ -95,7 +95,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [lib/commands/login.js](https://github.com/hubtype/botonic/blob/v0.18.2/lib/commands/login.js)_
+_See code: [lib/commands/login.js](https://github.com/hubtype/botonic/blob/v0.18.3/lib/commands/login.js)_
 
 ## `botonic logout`
 
@@ -109,7 +109,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [lib/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.18.2/lib/commands/logout.js)_
+_See code: [lib/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.18.3/lib/commands/logout.js)_
 
 ## `botonic new NAME [PROJECTNAME]`
 
@@ -129,7 +129,7 @@ EXAMPLE
   ✨ test_bot was successfully created!
 ```
 
-_See code: [lib/commands/new.js](https://github.com/hubtype/botonic/blob/v0.18.2/lib/commands/new.js)_
+_See code: [lib/commands/new.js](https://github.com/hubtype/botonic/blob/v0.18.3/lib/commands/new.js)_
 
 ## `botonic serve`
 
@@ -144,7 +144,7 @@ EXAMPLE
   > Project is running at http://localhost:8080/
 ```
 
-_See code: [lib/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.18.2/lib/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.18.3/lib/commands/serve.js)_
 
 ## `botonic test`
 
@@ -171,7 +171,7 @@ EXAMPLE
   Ran all test suites.
 ```
 
-_See code: [lib/commands/test.js](https://github.com/hubtype/botonic/blob/v0.18.2/lib/commands/test.js)_
+_See code: [lib/commands/test.js](https://github.com/hubtype/botonic/blob/v0.18.3/lib/commands/test.js)_
 
 ## `botonic train`
 
@@ -189,5 +189,5 @@ EXAMPLE
        TRAINING MODEL FOR {LANGUAGE}...
 ```
 
-_See code: [lib/commands/train.js](https://github.com/hubtype/botonic/blob/v0.18.2/lib/commands/train.js)_
+_See code: [lib/commands/train.js](https://github.com/hubtype/botonic/blob/v0.18.3/lib/commands/train.js)_
 <!-- commandsstop -->

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "license": "MIT",
   "bin": {
     "botonic": "./bin/run"

--- a/packages/botonic-cli/scripts/postinstall.js
+++ b/packages/botonic-cli/scripts/postinstall.js
@@ -23,7 +23,9 @@ try {
   //they run their first command.
   if (process.env.BOTONIC_DISABLE_ANALYTICS !== '1') {
     const Analytics = require('analytics-node')
-    var analytics = new Analytics('YD0jpJHNGW12uhLNbgB4wbdTRQ4Cy1Zu')
+    var analytics = new Analytics('YD0jpJHNGW12uhLNbgB4wbdTRQ4Cy1Zu', {
+      flushAt: 1,
+    })
     analytics.track({
       event: 'Installed Botonic CLI',
       anonymousId: Math.round(Math.random() * 100000000),

--- a/packages/botonic-cli/src/utils.ts
+++ b/packages/botonic-cli/src/utils.ts
@@ -51,7 +51,7 @@ function isAnalyticsEnabled(): boolean {
 }
 
 if (isAnalyticsEnabled()) {
-  analytics = new Analytics('YD0jpJHNGW12uhLNbgB4wbdTRQ4Cy1Zu')
+  analytics = new Analytics('YD0jpJHNGW12uhLNbgB4wbdTRQ4Cy1Zu', { flushAt: 1 })
 }
 
 function isWindows() {


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Add `flushAt: 1` parameter (The number of messages to enqueue before flushing.) when initializing Analytics to be sure we send the tracking events.
* Bump cli to 0.18.3