### PR TITLE
Fix return types for input method in NodeApp and CoreBot

### DIFF
--- a/packages/botonic-core/src/index.d.ts
+++ b/packages/botonic-core/src/index.d.ts
@@ -297,7 +297,7 @@ export class CoreBot {
 
   constructor(options: BotOptions)
   getString(stringID: string, session: Session): string
-  input(request: BotRequest): BotResponse
+  input(request: BotRequest): Promise<BotResponse>
   setLocale(locale: string, session: Session): void
 }
 

--- a/packages/botonic-react/src/index.d.ts
+++ b/packages/botonic-react/src/index.d.ts
@@ -39,7 +39,7 @@ export class ReactBot extends core.CoreBot {
 export class NodeApp {
   constructor(options: BotOptions)
   bot: ReactBot
-  input(request: core.BotRequest): BotResponse
+  input(request: core.BotRequest): Promise<BotResponse>
   renderNode(args): string
 }
 


### PR DESCRIPTION
## Description
Fix return type for `input` method in `NodeApp` and `CoreBot`, these methods will return Promises.

