### PR TITLE
Chore/codecov plugin nlu #PLA-309

### DIFF
--- a/.github/workflows/botonic-nlu-tests.yml
+++ b/.github/workflows/botonic-nlu-tests.yml
@@ -29,7 +29,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Install dev dependencies 
-      run: (cd ./packages/botonic-nlu && npm install -D)
+      run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Build botonic-nlu 
       run: (cd ./packages/$PACKAGE && npm run build)
       
@@ -42,13 +42,6 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         files: ./packages/${{env.PACKAGE}}/junit.xml
-
-    # - name: Jest Github Action Reporter
-    #   uses: IgnusG/jest-report-action@v2.3.3
-    #   if: always() 
-    #   with:
-    #     access-token: ${{ secrets.GITHUB_TOKEN }}
-    #     working-directory: ./packages/${{env.PACKAGE}}
     
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -15,24 +15,43 @@ jobs:
     env:
       PACKAGE: botonic-plugin-nlu
     steps:
-    - name: Checking out to current branch (Step 1 of 7)
+    - name: Checking out to current branch 
       uses: actions/checkout@v2
-    - name: Setting up node (Step 2 of 7)
+    - name: Setting up node
       uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
-    - name: Setting up cache (Step 3 of 7)
+    - name: Setting up cache
       uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - name: Install botonic-plugin-nlu (Step 4 of 7)
-      run: (cd ./packages/botonic-plugin-nlu && npm install -D)
-    - name: Build botonic-plugin-nlu (Step 5 of 7)
+    - name: Install dev dependencies 
+      run: (cd ./packages/$PACKAGE && npm install -D)
+    - name: Build botonic-plugin-nlu
       run: (cd ./packages/$PACKAGE && npm run build)
-    - name: Install common packages dependencies (Step 6 of 7)
-      run: npm install -D
-    - name: Verify lint botonic-plugin-nlu (Step 6 of 7)
+      
+    - name: Run tests 
+      run: (cd ./packages/$PACKAGE && npm run test_ci)
+    
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v1.6
+      if: always()
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        files: ./packages/${{env.PACKAGE}}/junit.xml
+    
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v1
+      if: always()
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{env.PACKAGE}}
+        file: ./packages/${{env.PACKAGE}}/coverage/lcov.info
+        name: ${{env.PACKAGE}}
+        env_vars: ${{env.PACKAGE}}
+
+    - name: Verify lint botonic-nlu 
       run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -37,7 +37,7 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run test_ci)
     
     - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1.6
+      uses: EnricoMi/publish-unit-test-result-action@v1.9
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage.data
 coverage/
 .docusaurus
 .idea
+junit.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,6 +29,11 @@ flags:
     paths:
       - packages/botonic-plugin-dynamodb
     carryforward: true
+
+  botonic-plugin-nlu:
+    paths:
+      - packages/botonic-plugin-nlu
+    carryforward: true
   
   botonic-react:
     paths:

--- a/packages/botonic-plugin-nlu/jest.config.js
+++ b/packages/botonic-plugin-nlu/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+}

--- a/packages/botonic-plugin-nlu/package-lock.json
+++ b/packages/botonic-plugin-nlu/package-lock.json
@@ -3714,8 +3714,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "optional": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "d3": {
       "version": "6.5.0",
@@ -4828,8 +4827,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "optional": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isobject": {
       "version": "3.0.1",
@@ -5465,8 +5463,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "optional": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",

--- a/packages/botonic-plugin-nlu/package.json
+++ b/packages/botonic-plugin-nlu/package.json
@@ -8,14 +8,13 @@
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "build": "rm -rf dist && ../../node_modules/.bin/tsc",
     "test": "jest",
+    "test_ci": "../../node_modules/.bin/jest --coverage --ci --reporters=default --reporters=jest-junit",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core -- -c ../.eslintrc_slow.js",
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"
   },
-  "jest": {
-    "testEnvironment": "node"
-  },
+  
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@botonic/core": "~0.18.0",

--- a/packages/botonic-plugin-nlu/tests/environment-utils.test.ts
+++ b/packages/botonic-plugin-nlu/tests/environment-utils.test.ts
@@ -1,0 +1,5 @@
+import { isProd } from '../src/environment-utils'
+
+test('env is not Prod', () => {
+  expect(isProd).toEqual(false)
+})


### PR DESCRIPTION
## Description
Configure botonic-plugin-nlu package to be taken into account when measuring coverage

## Context
Currently, we cannot compare the coverage of the whole botonic project with previous versions since codecov is not configured for all the packages.
This change will allow us to track the coverage of the nlu plugin with codecov.

## Approach taken / Explain the design
- Configure codecov flag
- Configure workflow to upload coverage results
- Configure jest in botonic-plugin-nlu 
- Include a test to trigger coverage

## To document / Usage example

Coverage can be seen in codecov: https://codecov.io/gh/hubtype/botonic/tree/4021c7af5c6b2732bbc11128bf6255b0fd881da3/packages/botonic-plugin-nlu/src

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
