### PR TITLE
Contentful/fix tests

### DIFF
--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -1,6 +1,6 @@
 import * as time from '../time'
 import { shallowClone, Stringable } from '../util/objects'
-import { Callback, ContentCallback, TopContentId } from './callback'
+import { Callback, ContentCallback, ContentId, TopContentId } from './callback'
 import { ContentType, MessageContentType, TopContentType } from './cms'
 import { SearchableBy } from './fields'
 
@@ -38,6 +38,10 @@ export abstract class Content implements Stringable {
   abstract get id(): string
 
   abstract get name(): string
+
+  get contentId(): ContentId {
+    return new ContentId(this.contentType, this.id)
+  }
 
   toString(): string {
     return `'${this.id}/${this.name}'`

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
@@ -4,6 +4,11 @@ import { ContentFieldType } from './fields'
 import { ManageContext } from './manage-context'
 
 export interface FieldsValues {
+  /**
+   * If the field has a fallback locale, after a undefined/null value is set,
+   * the fallback locale's value will be delivered. However, if a '' is set,
+   * an empty string will be delivered.
+   */
   [contentFieldType: string]: any
 }
 

--- a/packages/botonic-plugin-contentful/tests/cms/contents.test.ts
+++ b/packages/botonic-plugin-contentful/tests/cms/contents.test.ts
@@ -1,9 +1,23 @@
-import { Content, Text } from '../../src/cms'
+import {
+  Content,
+  ContentId,
+  ContentType,
+  Text,
+  TopContentId,
+} from '../../src/cms'
 import {
   RndStartUpBuilder,
   RndTextBuilder,
 } from '../../src/cms/test-helpers/builders'
 import { expectEqualExceptOneField } from '../helpers/expect'
+
+test('TEST: contentId', () => {
+  const t1 = new RndTextBuilder().withRandomFields().build()
+  expect(t1.contentId).toEqual(new TopContentId(ContentType.TEXT, t1.id))
+  expect(t1.buttons[0].contentId).toEqual(
+    new ContentId(ContentType.BUTTON, t1.buttons[0].id)
+  )
+})
 
 test('TEST: cloneWithButtons copies all fields except buttons', () => {
   const t1 = new RndTextBuilder().withRandomFields().build()

--- a/packages/botonic-plugin-contentful/tests/contentful/contents/startup.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/contents/startup.test.ts
@@ -18,7 +18,7 @@ test('TEST: contentful startUp', async () => {
         keywords: ['keyword1'],
       }),
 
-      'https://images.ctfassets.net/p2iyhzd1u4a7/1T0ntgNJnDUSwz59zGMZO6/ed6772d3a7b426025540c879b9d95347/red.jpg',
+      'https://images.ctfassets.net/p2iyhzd1u4a7/1T0ntgNJnDUSwz59zGMZO6/8f114c3d3fe8f541fefbec5a539dad35/red.jpg',
       'Le damos la bienvenida a su nuevo asistente virtual.',
       [
         new Button(

--- a/packages/botonic-plugin-contentful/tests/tools/validate-all-contents.test.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/validate-all-contents.test.ts
@@ -20,5 +20,5 @@ test('TEST: ContentsValidator.validateAllTopContents', async () => {
   expect(sut.report.successContents.length).toEqual(
     new Set(sut.report.successContents).size
   )
-  expect(sut.report.successContents.length).toEqual(82)
+  expect(sut.report.successContents.length).toEqual(83)
 }, 60000)


### PR DESCRIPTION
## Description

Fix contentful tests:
*  The QA contentful space was reimported by mistake from an old export, which contained a different asset id. This PR changes an expectation to reflect the current asset id
*   ManageCms.updateFields test has been improved: Now we have individual tests for setting "", undefined and a non empty value. Now we finally set to undefined instead of "" to avoid that validator fails when it finds empty values. Not sure why the validator test didn't fail before. Maybe we had recently disabled English as the fallback of Spanish? Maybe

## Context

* Contentful behaves differently when a string field is set to "" or when set to undefined. "" is interpreted as enforcing empty text. Undefined is interpreted as the default value, which causes delivery to default to the fallback locale (if field is configured as i18nable). However, there's no way to make this distinction from the contentful.com console (where it's always interpreted as default to fallback locale) .

## Approach taken / Explain the design

Improve ManageCms.updateFields readbility.


## Testing

- has integration tests
