### PR TITLE
fix(react): update lastMessageUpdate consistently with Webchat Settings

### DIFF
--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -581,6 +581,7 @@ export const Webchat = forwardRef((props, ref) => {
     updateWebchatSettings: settings => {
       const themeUpdates = normalizeWebchatSettings(settings)
       updateTheme(merge(webchatState.theme, themeUpdates), themeUpdates)
+      updateLastMessageDate(currentDateString())
     },
   }))
 


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Update logic to be consistent when resending WebchatSettings.

Linked PR: https://github.com/metis-ai/hubtype-backend/pull/552