### PR TITLE
fix(react): add ontouchstart events to allow touch events updates

### DIFF
--- a/packages/botonic-react/src/webchat/devices/scrollbar-controller.js
+++ b/packages/botonic-react/src/webchat/devices/scrollbar-controller.js
@@ -34,7 +34,12 @@ export class ScrollbarController {
     if (isMobileDevice()) {
       if (this.currentDevice !== DEVICES.MOBILE.IPHONE) return
       this.limitScrollBoundaries()
-      this.webchat.ontouchmove = e => this.handleOnTouchMoveEvents(e)
+      this.webchat.ontouchstart = e => {
+        this.handleOnTouchMoveEvents(e)
+      }
+      this.webchat.ontouchmove = e => {
+        this.handleOnTouchMoveEvents(e)
+      }
     } else {
       this.webchat.onmouseover = e => this.handleOnMouseOverEvents(e)
     }
@@ -70,6 +75,7 @@ export class ScrollbarController {
   toggleOnTouchMoveEvents() {
     if (this.hasScrollbar()) {
       this.webchat.ontouchmove = {}
+      this.webchat.ontouchstart = {}
       return
     }
     this.webchat.ontouchmove = e => e.preventDefault()


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Add ontouchstart events in order to be able to recalculate toggling scrolls on Safari.