### PR TITLE
fix(core/react): retrieve agent messages after connection loss and HubtypeService refactor

### DIFF
--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -151,28 +151,20 @@ export class HubtypeService {
     })
   }
 
-  // eslint-disable-next-line consistent-return
   async postMessage(user, message) {
     try {
       await this.init(user)
-    } catch (e) {
-      this.handleUnsentInput(message)
-      return Promise.resolve()
-    }
-    try {
-      return axios
-        .post(
-          `${_HUBTYPE_API_URL_}/v1/provider_accounts/webhooks/webchat/${this.appId}/`,
-          {
-            sender: this.user,
-            message: message,
-          }
-        )
-        .then(res => {
-          if (res && res.status === 200) this.handleSentInput(message)
-          return
-        })
-        .catch(e => this.handleUnsentInput(message))
+      await axios.post(
+        `${_HUBTYPE_API_URL_}/v1/provider_accounts/webhooks/webchat/${this.appId}/`,
+        {
+          sender: this.user,
+          message: message,
+        },
+        {
+          validateStatus: status => status === 200,
+        }
+      )
+      this.handleSentInput(message)
     } catch (e) {
       this.handleUnsentInput(message)
     }

--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -19,6 +19,10 @@ const _HUBTYPE_API_URL_ = getWebpackEnvVar(
 const ACTIVITY_TIMEOUT = 20 * 1000 // https://pusher.com/docs/channels/using_channels/connection#activitytimeout-integer-
 const PONG_TIMEOUT = 5 * 1000 // https://pusher.com/docs/channels/using_channels/connection#pongtimeout-integer-
 export class HubtypeService {
+  user
+  lastMessageId
+  lastMessageUpdateDate
+
   constructor({
     appId,
     user,
@@ -175,6 +179,20 @@ export class HubtypeService {
     return axios.get(
       `${_HUBTYPE_API_URL_}/v1/provider_accounts/${appId}/visibility/`
     )
+  }
+
+  destroyPusher() {
+    if (!this.pusher) return
+    this.pusher.disconnect()
+    this.pusher.unsubscribe(this.pusherChannel)
+    this.pusher.unbind_all()
+    this.pusher = null
+  }
+
+  async onConnectionRegained() {
+    this.destroyPusher()
+    this.init()
+    this.resendUnsentInputs()
   }
 
   async resendUnsentInputs() {

--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -19,10 +19,6 @@ const _HUBTYPE_API_URL_ = getWebpackEnvVar(
 const ACTIVITY_TIMEOUT = 20 * 1000 // https://pusher.com/docs/channels/using_channels/connection#activitytimeout-integer-
 const PONG_TIMEOUT = 5 * 1000 // https://pusher.com/docs/channels/using_channels/connection#pongtimeout-integer-
 export class HubtypeService {
-  user
-  lastMessageId
-  lastMessageUpdateDate
-
   constructor({
     appId,
     user,

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -121,13 +121,10 @@ export const Message = props => {
   } = resolveMessageTimestamps(getThemeProperty, enabletimestamps)
 
   const getEnvAck = () => {
-    let ack = 0
-    if (isDev) ack = 1
-    else {
-      if (props.ack !== undefined) ack = props.ack
-      else ack = isFromUser ? 0 : 1
-    }
-    return ack
+    if (isDev) return 1
+    if (!isFromUser) return 1
+    if (props.ack !== undefined) return props.ack
+    return 0
   }
 
   const ack = getEnvAck()

--- a/packages/botonic-react/src/index.d.ts
+++ b/packages/botonic-react/src/index.d.ts
@@ -177,7 +177,7 @@ export class WebchatApp {
   getComponent(
     optionsAtRuntime?: WebchatAppArgs
   ): React.ForwardRefExoticComponent<any>
-  getLastMessageUpdate(): Date
+  getLastMessageUpdate(): string
   getMessages(): WebchatMessage[]
   getVisibility(): Promise<boolean>
   isWebchatVisible({ appId: string }): Promise<boolean>
@@ -199,6 +199,7 @@ export class WebchatApp {
   toggle(): void
   toggleCoverComponent(): void
   updateMessageInfo(msgId: string, messageInfo: MessageInfo): void
+  updateLastMessageDate(date: string): void
   updateUser(user: core.SessionUser): void
   updateWebchatSettings(settings: WebchatSettingsProps): void
 }

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -137,7 +137,6 @@ export class WebchatApp {
     } else {
       this.hubtypeService.lastMessageId = lastMessageId
       this.hubtypeService.lastMessageUpdateDate = lastMessageUpdateDate
-      this.hubtypeService.user = user
     }
   }
 
@@ -308,9 +307,7 @@ export class WebchatApp {
         onClose={(...args) => this.onCloseWebchat(...args)}
         onUserInput={(...args) => this.onUserInput(...args)}
         onStateChange={webchatState => this.onStateChange(webchatState)}
-        onConnectionRegained={() =>
-          this.hubtypeService && this.hubtypeService.onConnectionRegained()
-        }
+        onConnectionRegained={() => this.onConnectionRegained()}
         server={server}
       />
     )

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -307,7 +307,6 @@ export class WebchatApp {
         onClose={(...args) => this.onCloseWebchat(...args)}
         onUserInput={(...args) => this.onUserInput(...args)}
         onStateChange={webchatState => this.onStateChange(webchatState)}
-        onConnectionRegained={() => this.onConnectionRegained()}
         server={server}
       />
     )

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -119,24 +119,22 @@ export class WebchatApp {
     const lastMessage = messagesJSON[messagesJSON.length - 1]
     const lastMessageId = lastMessage && lastMessage.id
     const lastMessageUpdateDate = this.getLastMessageUpdate()
-    if (!this.hubtypeService) {
-      if (user) {
-        this.hubtypeService = new HubtypeService({
-          appId: this.appId,
-          user,
-          lastMessageId,
-          lastMessageUpdateDate,
-          onEvent: event => this.onServiceEvent(event),
-          unsentInputs: () =>
-            this.webchatRef.current
-              .getMessages()
-              .filter(msg => msg.ack === 0 && msg.unsentInput),
-          server: this.server,
-        })
-      }
-    } else {
+    if (this.hubtypeService) {
       this.hubtypeService.lastMessageId = lastMessageId
       this.hubtypeService.lastMessageUpdateDate = lastMessageUpdateDate
+    } else if (!this.hubtypeService && user) {
+      this.hubtypeService = new HubtypeService({
+        appId: this.appId,
+        user,
+        lastMessageId,
+        lastMessageUpdateDate,
+        onEvent: event => this.onServiceEvent(event),
+        unsentInputs: () =>
+          this.webchatRef.current
+            .getMessages()
+            .filter(msg => msg.ack === 0 && msg.unsentInput),
+        server: this.server,
+      })
     }
   }
 

--- a/packages/botonic-react/src/webchat/index.d.ts
+++ b/packages/botonic-react/src/webchat/index.d.ts
@@ -37,7 +37,7 @@ export interface WebchatState {
   isEmojiPickerOpen: boolean
   isPersistentMenuOpen: boolean
   isCoverComponentOpen: boolean
-  lastMessageUpdate: undefined
+  lastMessageUpdate: string
   currentAttachment: File | undefined
 }
 

--- a/packages/botonic-react/src/webchat/index.d.ts
+++ b/packages/botonic-react/src/webchat/index.d.ts
@@ -43,7 +43,7 @@ export interface WebchatState {
 
 export interface WebchatProps extends WebchatArgs {
   ref: RefObject<any>
-  resendUnsentInputs?: () => Promise<void>
+  onConnectionRegained?: () => Promise<void>
 }
 export const WebChat: React.ForwardRefExoticComponent<WebchatProps>
 

--- a/packages/botonic-react/src/webchat/messages-reducer.js
+++ b/packages/botonic-react/src/webchat/messages-reducer.js
@@ -14,7 +14,10 @@ export const messagesReducer = (state, action) => {
     case ADD_MESSAGE_COMPONENT:
       return {
         ...state,
-        messagesComponents: [...state.messagesComponents, action.payload],
+        messagesComponents: [
+          ...(state.messagesComponents || []),
+          action.payload,
+        ],
       }
     case UPDATE_MESSAGE:
       return updateMessageReducer(state, action)
@@ -78,6 +81,6 @@ function addMessageReducer(state, action) {
     return state
   return {
     ...state,
-    messagesJSON: [...(state.messagesJSON || []), { ...action.payload }],
+    messagesJSON: [...(state.messagesJSON || []), action.payload],
   }
 }

--- a/packages/botonic-react/src/webchat/messages-reducer.js
+++ b/packages/botonic-react/src/webchat/messages-reducer.js
@@ -7,11 +7,24 @@ import {
   UPDATE_REPLIES,
 } from './actions'
 
+const getMsgComponentId = m => {
+  if (m.props.id) return m.props.id
+  if (m.props.value) return m.props.value.input && m.props.value.input.id
+  return undefined
+}
+
 export const messagesReducer = (state, action) => {
   switch (action.type) {
     case ADD_MESSAGE:
       return addMessageReducer(state, action)
     case ADD_MESSAGE_COMPONENT:
+      if (
+        state.messagesComponents &&
+        state.messagesComponents.find(
+          m => getMsgComponentId(m) === action.payload.id
+        )
+      )
+        return state
       return {
         ...state,
         messagesComponents: [

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -255,8 +255,8 @@ export const Webchat = forwardRef((props, ref) => {
       })
   }
 
-  const resendUnsentInputs = async () =>
-    props.resendUnsentInputs && props.resendUnsentInputs()
+  const onConnectionRegained = async () =>
+    props.onConnectionRegained && props.onConnectionRegained()
 
   // Load styles stored in window._botonicInsertStyles by Webpack
   useComponentWillMount(() => {
@@ -346,7 +346,7 @@ export const Webchat = forwardRef((props, ref) => {
       })
     } else {
       if (!firstUpdate.current) {
-        await resendUnsentInputs()
+        await onConnectionRegained()
         setError(undefined)
       }
     }
@@ -524,7 +524,7 @@ export const Webchat = forwardRef((props, ref) => {
     if (isMedia(input)) input.data = await readDataURL(input.data)
     sendUserInput(input)
     updateLatestInput(input)
-    updateLastMessageDate(new Date())
+    isOnline && updateLastMessageDate(new Date().toISOString())
     updateReplies(false)
     togglePersistentMenu(false)
     toggleEmojiPicker(false)
@@ -550,7 +550,7 @@ export const Webchat = forwardRef((props, ref) => {
         updateHandoff(handoff)
       }
       if (lastRoutePath) updateLastRoutePath(lastRoutePath)
-      updateLastMessageDate(new Date())
+      isOnline && updateLastMessageDate(new Date().toISOString())
     },
     setTyping: typing => updateTyping(typing),
     addUserMessage: message => sendInput(message),

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -193,6 +193,9 @@ export const Webchat = forwardRef((props, ref) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
   } = props.webchatHooks || useWebchat()
   const firstUpdate = useRef(true)
+  const isOnline = () => webchatState.online
+  const updateLastMessageDateIfOnline = () =>
+    isOnline() && updateLastMessageDate(new Date().toISOString())
   const theme = merge(webchatState.theme, props.theme)
   const { initialSession, initialDevSettings, onStateChange } = props
   const getThemeProperty = _getThemeProperty(theme)
@@ -524,7 +527,7 @@ export const Webchat = forwardRef((props, ref) => {
     if (isMedia(input)) input.data = await readDataURL(input.data)
     sendUserInput(input)
     updateLatestInput(input)
-    isOnline && updateLastMessageDate(new Date().toISOString())
+    updateLastMessageDateIfOnline()
     updateReplies(false)
     togglePersistentMenu(false)
     toggleEmojiPicker(false)
@@ -550,7 +553,7 @@ export const Webchat = forwardRef((props, ref) => {
         updateHandoff(handoff)
       }
       if (lastRoutePath) updateLastRoutePath(lastRoutePath)
-      isOnline && updateLastMessageDate(new Date().toISOString())
+      updateLastMessageDateIfOnline()
     },
     setTyping: typing => updateTyping(typing),
     addUserMessage: message => sendInput(message),
@@ -566,7 +569,7 @@ export const Webchat = forwardRef((props, ref) => {
     setError,
     setOnline,
     getMessages: () => webchatState.messagesJSON,
-    isOnline: () => webchatState.online,
+    isOnline,
     clearMessages: () => {
       clearMessages()
       updateReplies(false)

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -194,6 +194,7 @@ export const Webchat = forwardRef((props, ref) => {
   } = props.webchatHooks || useWebchat()
   const firstUpdate = useRef(true)
   const isOnline = () => webchatState.online
+  const currentDateString = () => new Date().toISOString()
   const theme = merge(webchatState.theme, props.theme)
   const { initialSession, initialDevSettings, onStateChange } = props
   const getThemeProperty = _getThemeProperty(theme)
@@ -521,7 +522,7 @@ export const Webchat = forwardRef((props, ref) => {
     if (isMedia(input)) input.data = await readDataURL(input.data)
     sendUserInput(input)
     updateLatestInput(input)
-    isOnline() && updateLastMessageDate(new Date().toISOString())
+    isOnline() && updateLastMessageDate(currentDateString())
     updateReplies(false)
     togglePersistentMenu(false)
     toggleEmojiPicker(false)
@@ -547,7 +548,7 @@ export const Webchat = forwardRef((props, ref) => {
         updateHandoff(handoff)
       }
       if (lastRoutePath) updateLastRoutePath(lastRoutePath)
-      updateLastMessageDate(new Date().toISOString())
+      updateLastMessageDate(currentDateString())
     },
     setTyping: typing => updateTyping(typing),
     addUserMessage: message => sendInput(message),

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -194,8 +194,6 @@ export const Webchat = forwardRef((props, ref) => {
   } = props.webchatHooks || useWebchat()
   const firstUpdate = useRef(true)
   const isOnline = () => webchatState.online
-  const updateLastMessageDateIfOnline = () =>
-    isOnline() && updateLastMessageDate(new Date().toISOString())
   const theme = merge(webchatState.theme, props.theme)
   const { initialSession, initialDevSettings, onStateChange } = props
   const getThemeProperty = _getThemeProperty(theme)
@@ -257,9 +255,6 @@ export const Webchat = forwardRef((props, ref) => {
         lastRoutePath: webchatState.lastRoutePath,
       })
   }
-
-  const onConnectionRegained = async () =>
-    props.onConnectionRegained && props.onConnectionRegained()
 
   // Load styles stored in window._botonicInsertStyles by Webpack
   useComponentWillMount(() => {
@@ -349,7 +344,6 @@ export const Webchat = forwardRef((props, ref) => {
       })
     } else {
       if (!firstUpdate.current) {
-        await onConnectionRegained()
         setError(undefined)
       }
     }
@@ -527,7 +521,7 @@ export const Webchat = forwardRef((props, ref) => {
     if (isMedia(input)) input.data = await readDataURL(input.data)
     sendUserInput(input)
     updateLatestInput(input)
-    updateLastMessageDateIfOnline()
+    isOnline() && updateLastMessageDate(new Date().toISOString())
     updateReplies(false)
     togglePersistentMenu(false)
     toggleEmojiPicker(false)
@@ -553,7 +547,7 @@ export const Webchat = forwardRef((props, ref) => {
         updateHandoff(handoff)
       }
       if (lastRoutePath) updateLastRoutePath(lastRoutePath)
-      updateLastMessageDateIfOnline()
+      updateLastMessageDate(new Date().toISOString())
     },
     setTyping: typing => updateTyping(typing),
     addUserMessage: message => sendInput(message),


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Solve issue regarding enduser not receiving some agent messages when connection was lost.

## Approach
* Moving onConnectionRegained logic within HubtypeService. Every time the event subcription_succeeded is received, we can asure that the auth call has been done. Hence, onConnectionRegained should be called at that point.
* Pusher headers are not refreshed automatically, only when `HubtypeService.init()` is called. So when the state of pusher is `connecting` we must be sure to update the corresponding headers.

Considerations:
* The first approach of destroying pusher and then initialize it again in `onConnectionRegained` breaks the capability of pusher to detect that the application has been reconnected.
* The process is the following:
Connecting --> update auth headers --> Connected --> Do auth call --> subscription:suceeded --> call logic when connection is regained

**References**:
* Authenticating users: https://pusher.com/docs/channels/server_api/authenticating-users
* Connection states: https://pusher.com/docs/channels/using_channels/connection#connection-states


Next steps:
* Randomly, one of the messages is duplicated in messagesComponents object, but not in messagesJSON (which is consistent). https://linear.app/hubtype/issue/BOT-295/investigate-duplicated-messages-randomly-when-connection-is-recovered