### PR TITLE
feat(core): improvements in HubtypeService

### DIFF
--- a/packages/botonic-core/src/hubtype-service.js
+++ b/packages/botonic-core/src/hubtype-service.js
@@ -59,12 +59,19 @@ export class HubtypeService {
     }
   }
 
+  /**
+   * @returns {Promise<void>}
+   */
   init(user, lastMessageId, lastMessageUpdateDate) {
     if (user) this.user = user
     if (lastMessageId) this.lastMessageId = lastMessageId
     if (lastMessageUpdateDate)
       this.lastMessageUpdateDate = lastMessageUpdateDate
-    if (this.pusher || !this.user.id || !this.appId) return null
+    if (this.pusher) return Promise.resolve()
+    if (!this.user.id || !this.appId) {
+      // TODO recover user & appId somehow
+      return Promise.reject('No User or appId. Clear cache and reload')
+    }
     this.pusher = new Pusher(_WEBCHAT_PUSHER_KEY_, {
       cluster: 'eu',
       authEndpoint: `${_HUBTYPE_API_URL_}/v1/provider_accounts/webhooks/webchat/${this.appId}/auth/`,
@@ -168,6 +175,7 @@ export class HubtypeService {
     } catch (e) {
       this.handleUnsentInput(message)
     }
+    return Promise.resolve()
   }
 
   static async getWebchatVisibility({ appId }) {

--- a/packages/botonic-core/src/hubtype-service.test.js
+++ b/packages/botonic-core/src/hubtype-service.test.js
@@ -1,0 +1,23 @@
+import { HubtypeService } from './hubtype-service'
+
+describe('HubtypeService', () => {
+  test.each([
+    [{ user: { id: 'userId' } }],
+    [{ appId: 'appId' }],
+    [{ appId: '', user: { id: 'userId' } }],
+    [{ appId: 'appId', user: { id: undefined } }],
+  ])('init fails if user or appid are empty: %s', async args => {
+    const sut = new HubtypeService(args)
+
+    await expect(sut.init()).rejects.toEqual(
+      'No User or appId. Clear cache and reload'
+    )
+  })
+
+  test('init timeouts when it cannot connect to hubtype', async () => {
+    const sut = new HubtypeService({ appId: 'appId', user: { id: 'userId' } })
+    sut.PUSHER_CONNECT_TIMEOUT_MS = 20
+    // will fail because _HUBTYPE_API_URL_ is not configured for unit tests
+    await expect(sut.init()).rejects.toEqual('Connection Timeout')
+  })
+})


### PR DESCRIPTION
Depends on #1360 
## Description
* Throw an exception when webchat has lost user or appId from session.
* Small HubtypeService refactor to simplify the code
* HubtypeService.init() to fail when user or appId are missing 
* Simple test for HubtypeService

## Context

So far we we were skipping silently.  and it took to long to diagnose it

## Approach taken / Explain the design

Cleanup code, reject the Promise when there are issues
Added unit tests for happy and sad paths of init methos. 

## Testing

- has unit tests
