### PR TITLE
Chore/dialogflow config ts jest codecov #PLA-375

### DIFF
--- a/.github/workflows/botonic-plugin-dialogflow-tests.yml
+++ b/.github/workflows/botonic-plugin-dialogflow-tests.yml
@@ -9,28 +9,50 @@ on:
       - '.github/workflows/botonic-plugin-dialogflow-tests.yml'
  
 jobs:
-  botonic-plugin-dialogflow-tests:
+  botonic-plugin-dialogflow:
     name: Botonic plugin-dialogflow tests
     runs-on: ubuntu-latest
     env:
       PACKAGE: botonic-plugin-dialogflow
     steps:
-    - name: Checking out to current branch (Step 1 of 6)
+    - name: Checking out to current branch 
       uses: actions/checkout@v2
-    - name: Setting up node (Step 2 of 6)
+    - name: Setting up node
       uses: actions/setup-node@v2-beta
       with:
         node-version: '12'
-    - name: Setting up cache (Step 3 of 6)
+    - name: Setting up cache
       uses: actions/cache@v2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - name: Install botonic-plugin-dialogflow (Step 4 of 6)
+    - name: Install dev dependencies 
       run: (cd ./packages/$PACKAGE && npm install -D)
-    - name: Install common packages dependencies (Step 5 of 6)
-      run: npm install -D
-    - name: Verify lint botonic-plugin-dialogflow (Step 6 of 6)
+    - name: Build botonic-plugin-dialogflow
+      run: (cd ./packages/$PACKAGE && npm run build)
+      
+    - name: Run tests 
+      run: (cd ./packages/$PACKAGE && npm run test_ci)
+    
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v1.9
+      if: always()
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        files: ./packages/${{env.PACKAGE}}/junit.xml
+    
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v1.3.1
+      if: always()
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{env.PACKAGE}}
+        file: ./packages/${{env.PACKAGE}}/coverage/lcov.info
+        name: ${{env.PACKAGE}}
+        env_vars: ${{env.PACKAGE}}
+        network_filter: packages/${{env.PACKAGE}}/
+
+    - name: Verify lint botonic-dialogflow 
       run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,11 @@ flags:
     paths:
       - packages/botonic-plugin-contentful
     carryforward: true
+  
+  botonic-plugin-dialogflow:
+    paths:
+      - packages/botonic-plugin-dialogflow
+    carryforward: true
 
   botonic-plugin-dynamodb:
     paths:

--- a/packages/botonic-plugin-dialogflow/jest.config.js
+++ b/packages/botonic-plugin-dialogflow/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+}

--- a/packages/botonic-plugin-dialogflow/package-lock.json
+++ b/packages/botonic-plugin-dialogflow/package-lock.json
@@ -12,6 +12,15 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@botonic/core": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.18.1.tgz",
+      "integrity": "sha512-qLs6FlJPR8FOremUGIS5PF6FWPAKPxIfhvyJ4DnCGn4jzgLfyI/po1FZI8lQZTzPpk9FFgS9UFHOARTHCAle4g==",
+      "requires": {
+        "axios": "^0.21.0",
+        "pusher-js": "^5.1.1"
+      }
+    },
     "axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -35,6 +44,11 @@
       "version": "10.1.5",
       "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.1.5.tgz",
       "integrity": "sha512-xlCtvZ+S2fPnw6YQyPkgMZ1dgMJ02bmK5Rt1umpo/KThBP6Zzq9awzXU71NEw1NYxXmLFnjorpQYKLZzMdF3lg=="
+    },
+    "pusher-js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-5.1.1.tgz",
+      "integrity": "sha512-f2tdoA7NvJQkU8Y/iCH25ZSNGxnwCXrVbwos38isX6gnjsSZ1aksWvyZddm2N0sHJWyl+oPBz/MzU5cevVDyEQ=="
     },
     "regenerator-runtime": {
       "version": "0.13.7",

--- a/packages/botonic-plugin-dialogflow/package.json
+++ b/packages/botonic-plugin-dialogflow/package.json
@@ -2,18 +2,23 @@
   "name": "@botonic/plugin-dialogflow",
   "version": "0.18.0",
   "license": "MIT",
-  "main": "src/index.js",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
+    "build": "rm -rf lib && ../../node_modules/.bin/tsc",
+    "test": "jest --coverage",
+    "test_ci": "../../node_modules/.bin/jest --coverage --ci --reporters=default --reporters=jest-junit",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",
-    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.js'"
+    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts'"
   },
   "dependencies": {
     "@babel/runtime": "^7.4.2",
     "axios": "latest",
     "jsrsasign": "^10.0.4",
+    "@botonic/core": "0.18.1",
     "uuid": "^8.1.0"
   },
   "devDependencies": {

--- a/packages/botonic-plugin-dialogflow/src/types.ts
+++ b/packages/botonic-plugin-dialogflow/src/types.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+//Dialogflow types
+export interface Credentials {
+  private_key_id: string
+  private_key: string
+  client_email: string
+  project_id: string
+}

--- a/packages/botonic-plugin-dialogflow/tests/index.test.ts
+++ b/packages/botonic-plugin-dialogflow/tests/index.test.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line import/named
+import { BotRequest } from '@botonic/core'
+
+import BotonicPluginDialogflow from '../src/index'
+import { Credentials } from '../src/types'
+
+it('Pre response is rejected when using fake crededentials', async () => {
+  /* eslint-disable @typescript-eslint/naming-convention */
+  const fakeCredentials: Credentials = {
+    private_key_id: 'WWW',
+    private_key: 'XXX',
+    client_email: 'fake_key',
+    project_id: 'ZZZ',
+  }
+  const request: BotRequest = {
+    input: { data: 'hi', payload: 'payload', type: 'audio' },
+    session: { bot: { id: 'test' }, user: { id: 'user1', provider: 'dev' } },
+    lastRoutePath: 'initial',
+  }
+
+  expect.assertions(1)
+  await expect(
+    new BotonicPluginDialogflow(fakeCredentials).pre(request)
+  ).rejects.toContain('init failed:')
+})

--- a/packages/botonic-plugin-dialogflow/tsconfig.json
+++ b/packages/botonic-plugin-dialogflow/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  // start of path dependent configuration
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "compilerOptions": {
+    "allowUnreachableCode": false,
+    "baseUrl": "src",
+    "paths": {
+      "*": ["src/*", "lib/src/*", "types/*"]
+    },
+    "rootDir": "src",
+    // end of path dependent configuration
+    "outDir": "lib",
+    "declaration": true,
+    "declarationDir": "lib",
+    "sourceMap": true,
+    "target": "es2015",
+    "module": "commonjs",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    // without typeRoots, it also checks @types of parent folders
+    //"typeRoots" : ["node_modules/@types"],
+
+    // lint options
+    //"strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true
+  },
+  // test options
+  "types": [
+    // @types/node must be a direct dependency. If only defined in a parent package.json, we get TSC errors for
+    // symbols from these libs: "ES2016.Array.Include", "ES2017.object"
+    "@types/jest"
+  ]
+}


### PR DESCRIPTION
## Description
Configure the following in botonic-plugin-dialogflow:
- Convert index.js to typescript
- Add Jest config and create a unit test
- Use codecov to track coverage

## Context
In order to track coverage for botonic, we needed to configure jest, create a test and configure codecov.
Also, since this package is quite small, we also migrated it to typescript.

## To document / Usage example
This PR includes migrating botonic-plugin-dialogflow package to TS

## Testing

The pull request...

- has unit tests? It includes a simple unit test to check coverage
- has integration tests: I tested manually with a bot and real dialogflow configuration

## Note
Big thanks to @marcrabat for helping me with this one!