### PR TITLE
fix(processor): ner processor needs to pad sequence

### DIFF
--- a/packages/botonic-nlp/src/tasks/ner/process/processor.ts
+++ b/packages/botonic-nlp/src/tasks/ner/process/processor.ts
@@ -25,7 +25,10 @@ export class Processor {
 
   // Generates the Input data and the unmasked sequence.
   generateInput(text: string): { sequence: string[]; input: InputData } {
-    const sequence = this.processText(text)
+    const sequence = this.preprocessor.pad(
+      this.processText(text),
+      PADDING_TOKEN
+    )
     const input = tensor([this.processTokens(sequence)]) as Tensor2D
     return { sequence, input }
   }

--- a/packages/botonic-nlp/tests/helpers/tasks/ner/helper.ts
+++ b/packages/botonic-nlp/tests/helpers/tasks/ner/helper.ts
@@ -14,7 +14,7 @@ export { EMBEDDINGS_MATRIX } from './embeddings-matrix'
 
 export const LOCALE: Locale = 'en'
 
-export const MAX_LENGTH = 12
+export const MAX_SEQUENCE_LENGTH = 12
 
 export const MODEL_NAME = 'BiLstmNerModel'
 
@@ -94,7 +94,7 @@ export const entitiesCodifier = new Codifier(ENTITIES, {
   isCategorical: true,
 })
 
-export const preprocessor = new Preprocessor(LOCALE, MAX_LENGTH)
+export const preprocessor = new Preprocessor(LOCALE, MAX_SEQUENCE_LENGTH)
 
 class TestWordEmbeddingStorage implements WordEmbeddingStorage {
   constructor(readonly dimension: EmbeddingsDimension) {}

--- a/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
@@ -6,13 +6,13 @@ describe('Botonic NER', () => {
   test('Loading model', async () => {
     const ner = await BotonicNer.load(nerHelper.MODEL_DIR_PATH)
     expect(ner.locale).toEqual(nerHelper.LOCALE)
-    expect(ner.maxLength).toEqual(nerHelper.MAX_LENGTH)
+    expect(ner.maxLength).toEqual(nerHelper.MAX_SEQUENCE_LENGTH)
     expect(ner.entities).toEqual(nerHelper.ENTITIES)
     expect(ner.vocabulary).toEqual(nerHelper.VOCABULARY)
   })
 
   test('Load data', () => {
-    const ner = BotonicNer.with(nerHelper.LOCALE, nerHelper.MAX_LENGTH)
+    const ner = BotonicNer.with(nerHelper.LOCALE, nerHelper.MAX_SEQUENCE_LENGTH)
     const { trainSet, testSet } = ner.splitDataset(nerHelper.DATASET)
     expect(trainSet.length).toEqual(4)
     expect(testSet.length).toEqual(1)
@@ -20,7 +20,7 @@ describe('Botonic NER', () => {
 
   test('Generate vocabulary', () => {
     // arrange
-    const ner = BotonicNer.with(nerHelper.LOCALE, nerHelper.MAX_LENGTH)
+    const ner = BotonicNer.with(nerHelper.LOCALE, nerHelper.MAX_SEQUENCE_LENGTH)
 
     // act
     ner.generateVocabulary([
@@ -33,7 +33,7 @@ describe('Botonic NER', () => {
 
   test('Evaluate model', async () => {
     // arrange
-    const ner = BotonicNer.with(nerHelper.LOCALE, nerHelper.MAX_LENGTH)
+    const ner = BotonicNer.with(nerHelper.LOCALE, nerHelper.MAX_SEQUENCE_LENGTH)
     const dataset = ner.loadDataset(nlpHelper.SHOPPING_DATA_PATH)
     const { trainSet, testSet } = ner.splitDataset(dataset)
     ner.generateVocabulary(trainSet)
@@ -51,7 +51,7 @@ describe('Botonic NER', () => {
 
   test('Recognize entities', async () => {
     // arrange
-    const ner = BotonicNer.with(nerHelper.LOCALE, nerHelper.MAX_LENGTH)
+    const ner = BotonicNer.with(nerHelper.LOCALE, nerHelper.MAX_SEQUENCE_LENGTH)
     const dataset = ner.loadDataset(nlpHelper.SHOPPING_DATA_PATH)
     const { trainSet } = ner.splitDataset(dataset)
     ner.generateVocabulary(trainSet)

--- a/packages/botonic-nlp/tests/tasks/ner/process/processor.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/process/processor.test.ts
@@ -1,7 +1,8 @@
+import { PADDING_TOKEN } from '../../../../src/preprocess/constants'
 import { Processor } from '../../../../src/tasks/ner/process/processor'
 import * as helper from '../../../helpers/tasks/ner/helper'
 
-describe('NER Sample Processor', () => {
+describe('NER Processor', () => {
   const processor = new Processor(
     helper.preprocessor,
     helper.sequenceCodifier,
@@ -19,7 +20,20 @@ describe('NER Sample Processor', () => {
 
   test('Generate Input data', () => {
     const { sequence, input } = processor.generateInput('I love this t-shirt')
-    expect(sequence).toEqual(['i', 'love', 't-shirt'])
+    expect(sequence).toEqual([
+      'i',
+      'love',
+      't-shirt',
+      PADDING_TOKEN,
+      PADDING_TOKEN,
+      PADDING_TOKEN,
+      PADDING_TOKEN,
+      PADDING_TOKEN,
+      PADDING_TOKEN,
+      PADDING_TOKEN,
+      PADDING_TOKEN,
+      PADDING_TOKEN,
+    ])
     expect(input.arraySync()).toEqual([[2, 28, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
   })
 })

--- a/packages/botonic-nlp/tests/tasks/ner/storage/config-storage.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/storage/config-storage.test.ts
@@ -9,7 +9,7 @@ describe('Config handler', () => {
   test('Load config', () => {
     const config = NerConfigStorage.load(helper.MODEL_DIR_PATH)
     expect(config.locale).toEqual(helper.LOCALE)
-    expect(config.maxLength).toEqual(helper.MAX_LENGTH)
+    expect(config.maxLength).toEqual(helper.MAX_SEQUENCE_LENGTH)
     expect(config.vocabulary).toEqual(helper.VOCABULARY)
     expect(config.entities).toEqual(helper.ENTITIES)
   })
@@ -27,7 +27,7 @@ describe('Config handler', () => {
     )
     NerConfigStorage.save(path, {
       locale: helper.LOCALE,
-      maxLength: helper.MAX_LENGTH,
+      maxLength: helper.MAX_SEQUENCE_LENGTH,
       vocabulary: helper.VOCABULARY,
       entities: helper.ENTITIES,
     })


### PR DESCRIPTION
**Depends on #1377.** Please, review it first. :warning: 

## Description
The `generateInput` method of `Processor` needs to pad the sequence so it matches the defined maxLength.

## Context
The sequence generated by the `generateInput` method of `Processor` was not padded. So it can result in a sequence which length exceeds `maxLength`. 

## Solution
Padding the sequence before it was returned.

## Testing

The pull request...

- [x] has unit tests
- [x] has integration tests
