### PR TITLE
feat(cli): task flag in botonic train command

### DIFF
--- a/packages/botonic-cli/src/commands/train.ts
+++ b/packages/botonic-cli/src/commands/train.ts
@@ -29,22 +29,12 @@ class Task {
   }
 
   private logTaskPluginNotInstalled(): void {
-    console.error(
+    console.log(
       colors.red(
         `Training process has been stopped because you don't have @botonic/plugin-${this.name} installed.\nPlease, install it with the following command:`
       )
     )
     console.log(colors.bold(`$ npm install @botonic/plugin-${this.name}`))
-  }
-}
-
-class InvalidTaskError extends Error {
-  constructor(taskName: string, availableTasks: string[]) {
-    super(
-      `Unsupported task '${taskName}'. Available tasks: '${availableTasks.join(
-        "', '"
-      )}'.`
-    )
   }
 }
 
@@ -56,7 +46,11 @@ export class Tasks {
 
   static getByName(taskName: string): Task {
     if (!this.isValidTask(taskName)) {
-      throw new InvalidTaskError(taskName, Object.keys(this.tasks))
+      throw new Error(
+        `Unsupported task '${taskName}'. Available tasks: '${Object.keys(
+          this.tasks
+        ).join("', '")}'.`
+      )
     }
     return this.tasks[taskName]
   }

--- a/packages/botonic-cli/src/commands/train.ts
+++ b/packages/botonic-cli/src/commands/train.ts
@@ -48,7 +48,7 @@ class InvalidTaskError extends Error {
   }
 }
 
-class Tasks {
+export class Tasks {
   static tasks = {
     ner: new Task('ner'),
     'text-classification': new Task('text-classification'),

--- a/packages/botonic-cli/src/commands/train.ts
+++ b/packages/botonic-cli/src/commands/train.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 
 import { Telemetry } from '../analytics/telemetry'
+import { BOTONIC_NPM_NAMESPACE, BOTONIC_PROJECT_PATH } from '../constants'
 import { spawnNpmScript } from '../util/system'
 
 class Task {
@@ -11,7 +12,6 @@ class Task {
 
   run(): void {
     if (this.isTaskPluginInstalled()) {
-      track(`Trained with Botonic train:${this.name}`)
       spawnNpmScript(`train:${this.name}`, () => `Finished training `)
     } else {
       this.logTaskPluginNotInstalled()
@@ -20,9 +20,9 @@ class Task {
 
   private isTaskPluginInstalled(): boolean {
     const path = join(
-      process.cwd(),
+      BOTONIC_PROJECT_PATH,
       'node_modules',
-      '@botonic',
+      BOTONIC_NPM_NAMESPACE,
       `plugin-${this.name}`
     )
     return existsSync(path)
@@ -58,6 +58,7 @@ export default class Run extends Command {
   private telemetry = new Telemetry()
 
   async run(): Promise<void> {
+    this.telemetry.trackTrain()
     const { flags } = this.parse(Run)
     flags.task ? this.runSpecificTask(flags.task) : this.runAllTasks()
   }

--- a/packages/botonic-cli/src/commands/train.ts
+++ b/packages/botonic-cli/src/commands/train.ts
@@ -44,6 +44,10 @@ export class Tasks {
     'text-classification': new Task('text-classification'),
   }
 
+  static getAll(): Task[] {
+    return Object.values(this.tasks)
+  }
+
   static getByName(taskName: string): Task {
     if (!this.isValidTask(taskName)) {
       throw new Error(
@@ -81,14 +85,10 @@ export default class Run extends Command {
     try {
       this.telemetry.trackTrain()
       const { flags } = this.parse(Run)
-      const tasks = this.getTasks(flags.task)
+      const tasks = flags.task ? [Tasks.getByName(flags.task)] : Tasks.getAll()
       tasks.forEach(task => task.run())
     } catch (e) {
       console.error(e)
     }
-  }
-
-  private getTasks(taskName: string | undefined): Task[] {
-    return taskName ? [Tasks.getByName(taskName)] : Object.values(Tasks.tasks)
   }
 }

--- a/packages/botonic-cli/src/commands/train.ts
+++ b/packages/botonic-cli/src/commands/train.ts
@@ -1,21 +1,27 @@
 import { Command, flags } from '@oclif/command'
 import colors from 'colors'
-import * as path from 'path'
+import { existsSync } from 'fs'
+import { join } from 'path'
 
 import { Telemetry } from '../analytics/telemetry'
 import { spawnNpmScript } from '../util/system'
 
+enum TASKS {
+  NER = 'ner',
+  TEXT_CLASSIFICATION = 'text-classification',
+}
+
 export default class Run extends Command {
-  static description = 'Train your bot with NLU'
+  static description = 'Train your bot with NLP'
 
   static examples = [
-    `$ botonic train
-    TRAINING MODEL FOR {LANGUAGE}...
+    `$ botonic train [--task=<${Object.values(TASKS).join('|')}>]
+    TRAINING MODEL...
     `,
   ]
 
   static flags = {
-    lang: flags.string(),
+    task: flags.string(),
   }
 
   static args = []
@@ -23,27 +29,79 @@ export default class Run extends Command {
   private telemetry = new Telemetry()
 
   async run(): Promise<void> {
-    this.telemetry.trackTrain()
-    const botonicNLUPath: string = path.join(
+    const { flags } = this.parse(Run)
+    const task = flags.task
+    if (task) {
+      this.runSpecificTask(task)
+    } else {
+      this.runAllTasks()
+    }
+  }
+
+  private runAllTasks(): void {
+    this.runNerTask()
+    this.runTextClassificationTask()
+  }
+
+  private runSpecificTask(task: string): void {
+    switch (task) {
+      case TASKS.NER:
+        this.runNerTask()
+        break
+      case TASKS.TEXT_CLASSIFICATION:
+        this.runTextClassificationTask()
+        break
+      default:
+        this.logInvalidTask(task)
+        break
+    }
+  }
+
+  private runNerTask(): void {
+    if (this.isPackageInstalled(`plugin-${TASKS.NER}`)) {
+      track(`Trained with Botonic train:${TASKS.NER}`)
+      spawnNpmScript(`train:${TASKS.NER}`, () => `Finished training `)
+    }
+  }
+
+  private runTextClassificationTask(): void {
+    if (this.isPackageInstalled(`plugin-${TASKS.TEXT_CLASSIFICATION}`)) {
+      track(`Trained with Botonic train:${TASKS.TEXT_CLASSIFICATION}`)
+      spawnNpmScript(
+        `train:${TASKS.TEXT_CLASSIFICATION}`,
+        () => `Finished training `
+      )
+    }
+  }
+
+  private logInvalidTask(task: string): void {
+    console.log(
+      colors.red(
+        `Unsupported task '${task}'. Available tasks: '${Object.values(
+          TASKS
+        ).join("', '")}'.`
+      )
+    )
+  }
+
+  private isPackageInstalled(packageName: string): boolean {
+    const path = join(
       process.cwd(),
       'node_modules',
       '@botonic',
-      'nlu'
+      packageName,
+      'dist'
     )
-    try {
-      await import(botonicNLUPath)
-    } catch (e) {
-      const error = String(e)
-      this.telemetry.trackError(`Running botonic train: ${error}`)
-      console.log(e)
+    if (existsSync(path)) {
+      return true
+    } else {
       console.log(
         colors.red(
-          `You don't have @botonic/plugin-nlu installed.\nPlease, install it with the following command:`
+          `Training process has been stopped because you don't have @botonic/${packageName} installed.\nPlease, install it with the following command:`
         )
       )
-      console.log(`$ npm install @botonic/plugin-nlu`)
-      return
+      console.log(`$ npm install @botonic/${packageName}`)
+      return false
     }
-    spawnNpmScript('train', () => 'Finished training')
   }
 }

--- a/packages/botonic-cli/src/commands/train.ts
+++ b/packages/botonic-cli/src/commands/train.ts
@@ -55,14 +55,14 @@ export class Tasks {
   }
 
   static getByName(taskName: string): Task {
-    if (this.isInvalidTask(taskName)) {
+    if (!this.isValidTask(taskName)) {
       throw new InvalidTaskError(taskName, Object.keys(this.tasks))
     }
     return this.tasks[taskName]
   }
 
-  private static isInvalidTask(taskName: string): boolean {
-    return !Object.keys(this.tasks).includes(taskName)
+  private static isValidTask(taskName: string): boolean {
+    return Object.keys(this.tasks).includes(taskName)
   }
 }
 

--- a/packages/botonic-cli/src/commands/train.ts
+++ b/packages/botonic-cli/src/commands/train.ts
@@ -58,19 +58,25 @@ export default class Run extends Command {
   }
 
   private runNerTask(): void {
-    if (this.isPackageInstalled(`plugin-${TASKS.NER}`)) {
+    const packageName = `plugin-${TASKS.NER}`
+    if (this.isPackageInstalled(packageName)) {
       track(`Trained with Botonic train:${TASKS.NER}`)
       spawnNpmScript(`train:${TASKS.NER}`, () => `Finished training `)
+    } else {
+      this.logPackageNotInstalled(packageName)
     }
   }
 
   private runTextClassificationTask(): void {
-    if (this.isPackageInstalled(`plugin-${TASKS.TEXT_CLASSIFICATION}`)) {
+    const packageName = `plugin-${TASKS.TEXT_CLASSIFICATION}`
+    if (this.isPackageInstalled(packageName)) {
       track(`Trained with Botonic train:${TASKS.TEXT_CLASSIFICATION}`)
       spawnNpmScript(
         `train:${TASKS.TEXT_CLASSIFICATION}`,
         () => `Finished training `
       )
+    } else {
+      this.logPackageNotInstalled(packageName)
     }
   }
 
@@ -85,23 +91,16 @@ export default class Run extends Command {
   }
 
   private isPackageInstalled(packageName: string): boolean {
-    const path = join(
-      process.cwd(),
-      'node_modules',
-      '@botonic',
-      packageName,
-      'dist'
-    )
-    if (existsSync(path)) {
-      return true
-    } else {
-      console.log(
-        colors.red(
-          `Training process has been stopped because you don't have @botonic/${packageName} installed.\nPlease, install it with the following command:`
-        )
+    const path = join(process.cwd(), 'node_modules', '@botonic', packageName)
+    return existsSync(path)
+  }
+
+  private logPackageNotInstalled(packageName: string): void {
+    console.log(
+      colors.red(
+        `Training process has been stopped because you don't have @botonic/${packageName} installed.\nPlease, install it with the following command:`
       )
-      console.log(`$ npm install @botonic/${packageName}`)
-      return false
-    }
+    )
+    console.log(`$ npm install @botonic/${packageName}`)
   }
 }

--- a/packages/botonic-cli/src/commands/train.ts
+++ b/packages/botonic-cli/src/commands/train.ts
@@ -38,6 +38,16 @@ class Task {
   }
 }
 
+class InvalidTaskError extends Error {
+  constructor(taskName: string, availableTasks: string[]) {
+    super(
+      `Unsupported task '${taskName}'. Available tasks: '${availableTasks.join(
+        "', '"
+      )}'.`
+    )
+  }
+}
+
 class Tasks {
   static tasks = {
     ner: new Task('ner'),
@@ -46,19 +56,13 @@ class Tasks {
 
   static getByName(taskName: string): Task {
     if (this.isInvalidTask(taskName)) {
-      throw new Error(this.getInvalidTaskMessage(taskName))
+      throw new InvalidTaskError(taskName, Object.keys(this.tasks))
     }
     return this.tasks[taskName]
   }
 
   private static isInvalidTask(taskName: string): boolean {
     return !Object.keys(this.tasks).includes(taskName)
-  }
-
-  private static getInvalidTaskMessage(taskName: string): string {
-    return `Unsupported task '${taskName}'. Available tasks: '${Object.keys(
-      this.tasks
-    ).join("', '")}'.`
   }
 }
 

--- a/packages/botonic-cli/tests/commands/train.test.ts
+++ b/packages/botonic-cli/tests/commands/train.test.ts
@@ -1,0 +1,21 @@
+import { Config } from '@oclif/config'
+
+import { default as TrainCommand, Tasks } from '../../src/commands/train'
+
+describe('Tasks', () => {
+  test('Invalid task name', () => {
+    expect(() => {
+      Tasks.getByName('test')
+    }).toThrowError()
+  })
+
+  test('Get task by name', () => {
+    const sut = Tasks.getByName('ner')
+    expect(sut.name).toEqual('ner')
+  })
+})
+
+//TODO: find a way of run the command in the test
+describe('Train Command', () => {
+  const trainCommand = new TrainCommand(process.argv, new Config({ root: '' }))
+})


### PR DESCRIPTION
## Description
Botonic now has two different NLP task:

1.  Text Classification
2. Named Entity Recognition

The `botonic train` command needs a way to let the user decide the desired task for training the model. Or whether train a model for each of the possible tasks.
 
## Context
This PR gives to the user the option of selecting the task(s) of the training process.

## Approach taken / Explain the design
The `train` command now has a `task` flag where the user can define the desired task. If no flag is defined, a model for each of the tasks is trained. 

By now, the only task flag values allowed are:
 - `ner`
 - `text-classification`

Examples:
- `botonic train` : Trains a **Named Entity Recognition** model and also a **Text Classifier** model (all possible Botonic tasks).
- `botonic train --task=ner` : Only a **Named Entity Recognition** model is trained.

:warning:  **The Plugin of the selected task is required. If not installed, no model would be trained for this specific task.** :warning: 