### PR TITLE
feat(ner): model stored by locale

### DIFF
--- a/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
+++ b/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
@@ -1,4 +1,5 @@
 import { Tensor3D } from '@tensorflow/tfjs-node'
+import { join } from 'path'
 
 import { DatasetLoader } from '../../dataset/loader'
 import { Dataset, Sample } from '../../dataset/types'
@@ -142,6 +143,7 @@ export class BotonicNer {
   }
 
   async saveModel(path: string): Promise<void> {
+    path = join(path, this.locale)
     const config = {
       locale: this.locale,
       maxLength: this.maxLength,


### PR DESCRIPTION
**Depends on #1379.** Please, review it first. :warning: 

## Description
Models need to be stored by their locale.

## Context
Since we want Botonic NLP to allow having different models for different locales, storing them by their locale is needed.
