### PR TITLE
feat(ner-plugin): Postprocess implemented

### DIFF
--- a/packages/botonic-plugin-ner/src/postprocess/prediction-processor.ts
+++ b/packages/botonic-plugin-ner/src/postprocess/prediction-processor.ts
@@ -1,0 +1,28 @@
+import { PADDING_TOKEN } from '@botonic/nlp/dist/preprocess/constants'
+import { Entity, Prediction } from '@botonic/nlp/dist/tasks/ner/process/types'
+import { Tensor3D } from '@tensorflow/tfjs-core/dist/tensor'
+
+export class PredictionProcessor {
+  constructor(private readonly entities: string[]) {}
+
+  process(sequence: string[], prediction: Tensor3D): Entity[] {
+    const confidences = prediction.arraySync()[0]
+    const entities = sequence.map((token, idx) => {
+      return this.getEntity(token, confidences[idx])
+    })
+    return entities.filter(e => e.text != PADDING_TOKEN)
+  }
+
+  private getEntity(token: string, confidences: number[]): Entity {
+    const confidence = Math.max(...confidences)
+    const label = this.entities[confidences.indexOf(confidence)]
+    const predictions = this.getPredictions(confidences)
+    return { text: token, label, confidence, predictions }
+  }
+
+  private getPredictions(confidences: number[]): Prediction[] {
+    return confidences.map((c, i) => {
+      return { label: this.entities[i], confidence: c }
+    })
+  }
+}

--- a/packages/botonic-plugin-ner/src/postprocess/prediction-processor.ts
+++ b/packages/botonic-plugin-ner/src/postprocess/prediction-processor.ts
@@ -1,6 +1,6 @@
 import { PADDING_TOKEN } from '@botonic/nlp/dist/preprocess/constants'
 import { Entity, Prediction } from '@botonic/nlp/dist/tasks/ner/process/types'
-import { Tensor3D } from '@tensorflow/tfjs-core/dist/tensor'
+import { Tensor3D } from '@tensorflow/tfjs'
 
 export class PredictionProcessor {
   constructor(private readonly entities: string[]) {}

--- a/packages/botonic-plugin-ner/src/postprocess/prediction-processor.ts
+++ b/packages/botonic-plugin-ner/src/postprocess/prediction-processor.ts
@@ -7,9 +7,9 @@ export class PredictionProcessor {
 
   process(sequence: string[], prediction: Tensor3D): Entity[] {
     const confidences = prediction.arraySync()[0]
-    const entities = sequence.map((token, idx) => {
-      return this.getEntity(token, confidences[idx])
-    })
+    const entities = sequence.map((token, idx) =>
+      this.getEntity(token, confidences[idx])
+    )
     return entities.filter(e => e.text != PADDING_TOKEN)
   }
 

--- a/packages/botonic-plugin-ner/tests/postprocess/prediction-processor.test.ts
+++ b/packages/botonic-plugin-ner/tests/postprocess/prediction-processor.test.ts
@@ -1,0 +1,13 @@
+import { PredictionProcessor } from '../../src/postprocess/prediction-processor'
+import * as constantsHelper from '../helper/constants-helper'
+
+describe('Prediction processor', () => {
+  test('process prediction', () => {
+    const processor = new PredictionProcessor(constantsHelper.ENTITIES)
+    const sut = processor.process(
+      constantsHelper.SEQUENCE,
+      constantsHelper.PREDICTION
+    )
+    expect(sut.map(entity => entity.label)).toEqual(['O', 'O', 'product'])
+  })
+})


### PR DESCRIPTION
**Depends on #1393.** Please, review it first. :warning: 

## Description
A `PredictionProcessor` has been implemented to process the output tensor generated by the model prediction.

## Context
The `PredictionProcessor` takes the sequence and the output tensor of the model to generate an array that contains the recognized entities.

## Approach taken / Explain the design
The `PredictionProcessor` maps the sequence with the output tensor to get the recognized entities and the corresponding confidences for all possible entity labels.

## Testing

The pull request...

- [x] has unit tests
