### PR TITLE
Chore/publish abort

### DIFF
--- a/packages/botonic-plugin-dashbot/package.json
+++ b/packages/botonic-plugin-dashbot/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
+    "build": "echo Nothing to build",
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",

--- a/packages/botonic-plugin-dialogflow/package.json
+++ b/packages/botonic-plugin-dialogflow/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
+    "build": "echo Nothing to build",
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",

--- a/packages/botonic-plugin-google-analytics/package.json
+++ b/packages/botonic-plugin-google-analytics/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
+    "build": "echo Nothing to build",
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",

--- a/packages/botonic-plugin-inbenta/package.json
+++ b/packages/botonic-plugin-inbenta/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
+    "build": "echo Nothing to build",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",

--- a/packages/botonic-plugin-luis/package.json
+++ b/packages/botonic-plugin-luis/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
+    "build": "echo Nothing to build",
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",

--- a/packages/botonic-plugin-segment/package.json
+++ b/packages/botonic-plugin-segment/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
+    "build": "echo Nothing to build",
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",

--- a/packages/botonic-plugin-watson/package.json
+++ b/packages/botonic-plugin-watson/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
+    "build": "echo Nothing to build",
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_core -- --fix",

--- a/preinstall.js
+++ b/preinstall.js
@@ -1,5 +1,8 @@
 var child_process = require('child_process');
 var npm_args = JSON.parse(process.env.npm_config_argv)["cooked"]
+if (process.env.BOTONIC_NO_INSTALL_ROOT_DEPENDENCIES) {
+  process.exit(0)
+}
 if (npm_args.includes("--save-dev")) {
   console.log("Installing common botonic development dependencies:")
   process.chdir(__dirname)

--- a/scripts/ci/publish.ts
+++ b/scripts/ci/publish.ts
@@ -17,11 +17,14 @@ import {
 process.chdir('..')
 const packagesDir = join(process.cwd(), C.PACKAGES_DIRNAME)
 const packagesList = sortPackagesByPreference(packagesDir)
+const rootDir = join(packagesDir, "..")
 
 ;(async () => {
   const { version, confirmation } = await getVersionAndConfirmation()
   if (!confirmation) return
   console.log(blue(`Publishing new Botonic ${version} version:`))
+
+  await installDeps('common development')
 
   for (const pkg of packagesList) {
     const packagePath = join(packagesDir, pkg)
@@ -29,7 +32,7 @@ const packagesList = sortPackagesByPreference(packagesDir)
     console.log(`Preparing ${pkg}...`)
     console.log('====================================')
     await clean()
-    await installDeps()
+    await installDeps(pkg)
     await build()
     const bumpedVersion = await bumpVersion(version, packagePath)
     const botonicDepsVersion =

--- a/scripts/ci/utils.ts
+++ b/scripts/ci/utils.ts
@@ -54,8 +54,9 @@ export const spawnProcess = async (
     log?.onSuccess()
   } catch (e) {
     console.log(
-      red(`   Failed on running commmand ${command} ${args.join(' ')}\n`)
+      red(`   Failed on running command ${command} ${args.join(' ')}:\n${e.stderr.toString()}`)
     )
+    process.exit(1)
   }
 }
 

--- a/scripts/ci/utils.ts
+++ b/scripts/ci/utils.ts
@@ -111,8 +111,8 @@ export const changeBotonicDeps = async (packagePath, withVersion) => {
   }
 }
 
-export const installDeps = async () => {
-  console.log(' - Installing dependencies...')
+export const installDeps = async (project: string) => {
+  console.log(` - Installing ${project} dependencies...`)
   await spawnProcess('npm', ['install', '-D'], {
     onSuccess: () => console.log(green('   Installed successfully.\n')),
   })

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,7 @@
     "cloc-all": "./qa/cloc-all-packages.sh",
     "lint-all": "./qa/lint-all-packages.sh",
     "prepare-all": "./ci/prepare-package.sh",
-    "publish-all": "ts-node ./ci/publish.ts"
+    "publish-all": "BOTONIC_NO_INSTALL_ROOT_DEPENDENCIES=1 ts-node ./ci/publish.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Two improvements in our script to publish all packages:
###     install common dependencies once during publish
    The script to publish all packages called "npm i -D" on each package, which causes to reinstall the common dependencies at the root folder multiple times.
    Now there's a flag to disable this feature, and the common dependencies are installed only once

###     publish to abort when st fails
Before, when "npm run build" failed, there was a generic error message, and the script continued. Now, the script logs the stderror of the command that failed and the process abort. I added NOP build scripts for JS packages to avoid that "npm run build" fails for them.