### PR TITLE
chore: disable codecov's comments in PRs #PLA-387

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,9 @@ coverage:
       default:
         # if the coverage is under this value the Codecov GitHub check will fail
         threshold: 40%
+
+comment: false #https://docs.codecov.io/docs/pull-request-comments
+
 flags:
   botonic-cli:
     paths:


### PR DESCRIPTION
## Description
Disable codecov comments is PR's for all projects in this repo

## Context
Codecov's comments in PRs are noisy and not really helpful, so we agreed to remove them from the PRs

## Approach taken / Explain the design
Include `comment: false` in `codecov.yml` file


## To document / Usage example


## Testing
Created a mock PR to see comments do not appear anymore: https://github.com/hubtype/botonic/pull/1402

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
