### PR TITLE
chore(core/react): fix types distribution

### DIFF
--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "test": "../../node_modules/.bin/jest --coverage",
     "prepare": "node ../../preinstall.js",
@@ -23,7 +24,8 @@
   "files": [
     "src/**",
     "lib/**",
-    "src/index.d.ts"
+    "index.d.ts",
+    "README.md"
   ],
   "dependencies": {
     "axios": "^0.21.0",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "test": "../../node_modules/.bin/jest --coverage",
     "cloc": "../../scripts/qa/cloc-package.sh .",
@@ -23,7 +24,8 @@
     "src/**",
     "lib/**",
     "index.d.ts",
-    "MIGRATION_GUIDE.md"
+    "MIGRATION_GUIDE.md",
+    "README.md"
   ],
   "dependencies": {
     "@botonic/core": "~0.18.0",


### PR DESCRIPTION
1.  Added README.md to core & react distribution
1. eslint import was not finding @botonic/core types from typescript projects
* root core index.d.ts was not distributed
* added "types" entry in package.json for core & react
