### PR TITLE
Chore/hybrid-js-ts-project-setup

### DIFF
--- a/packages/botonic-core/jest.config.js
+++ b/packages/botonic-core/jest.config.js
@@ -9,11 +9,14 @@ module.exports = {
     '.*.helper.js',
     'tests/__mocks__',
   ],
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
-  transformIgnorePatterns: [
-    'node_modules/(?!@botonic|react-children-utilities).+\\.(js|jsx)$',
-  ],
-  moduleFileExtensions: ['js', 'jsx', 'json'],
+  transform: {
+    '\\.js?$': 'babel-jest',
+    '\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: ['src/**/*.{js,ts}', '!/node_modules/'],
+  transformIgnorePatterns: ['node_modules/(?!@botonic).+\\.(ts|js)$'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  coveragePathIgnorePatterns: ['.d.ts'],
   snapshotSerializers: [],
   modulePaths: ['node_modules', 'src'],
   moduleNameMapper: {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -9,7 +9,7 @@
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_ci -- --fix",
     "lint_ci": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' '*.js' 'src/**/*.js*' 'src/**/*.d.ts'",
-    "build": "rm -rf lib && babel src --out-dir lib --source-maps --copy-files",
+    "build": "rm -rf lib && ../../node_modules/.bin/tsc;",
     "cloc": "../../scripts/qa/cloc-package.sh ."
   },
   "repository": {
@@ -32,10 +32,12 @@
   "devDependencies": {
     "@babel/cli": "^7.11.5",
     "@babel/core": "^7.11.6",
-    "@babel/plugin-proposal-object-rest-spread": "^7.9.6",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-proposal-object-rest-spread": "^7.9.6",
     "@babel/plugin-transform-runtime": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
+    "@types/axios": "^0.14.0",
+    "@types/pusher-js": "^4.2.2",
     "babel-plugin-add-module-exports": "^1.0.2"
   },
   "homepage": "https://github.com/hubtype/botonic#readme",
@@ -48,6 +50,5 @@
     "conversational-app",
     "conversational-ui",
     "javascript"
-  ],
-  "types": "./src/types"
+  ]
 }

--- a/packages/botonic-core/tsconfig.json
+++ b/packages/botonic-core/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*.d.ts"],
+  "include": ["src/"],
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "allowJs": true,
+    "declaration": true,
+    "outDir": "./lib"
   }
 }


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

Part 2 of `@botonic/core` migration to TypeScript.

## Description
* Setup project to allow project to have `.js` and `.ts` files and build them with TypeScript compiler.

## Context
~**Part 1**:  [Add types to @botonic/core](https://github.com/hubtype/botonic/pull/1333)~
~**Part 2**:  Setup Hybrid project (.js and .ts files).~
**Part 3**: Migrate one file to TypeScript.
**Part 4**:  Add unit tests --> Pass tests --> Migrate iteratively files to `.ts`.

