### PR TITLE
chore(eslint-config): shareable eslint config package

### DIFF
--- a/packages/botonic-core/README.md
+++ b/packages/botonic-core/README.md
@@ -2,7 +2,7 @@
 
 `@botonic/core` set the basis for Botonic. This package contains all the essential definitions and utilities that are used to coordinate the different packages of the framework.
 
-It is the main responsible of:
+It is the main responsible for:
 
 - Processing the inputs and map them into bot responses or actions
 - Supporting internationalization (i18n)

--- a/packages/botonic-eslint-config/README.md
+++ b/packages/botonic-eslint-config/README.md
@@ -1,0 +1,12 @@
+# Botonic eslint config
+
+Shareable eslint config as per the
+[official documentation](https://eslint.org/docs/developer-guide/shareable-configs)
+
+For a project to use this [eslint](https://eslint.org/) configuration, you'll need to:
+* Add `extends: '@botonic/eslint-config/index.js',` to your .eslintrc.js
+* If you can afford eslint to be slower (eg from your CI pipeline) to detect more issues, add '@botonic/eslint-config/index-ci.js'
+* Add this script to your package.json: ` "lint": "eslint_d --fix --quiet 'src/**/*.js*' 'src/**/*.ts' "`.
+* Execute `npm run lint`
+  
+Please check the [eslint user guide](https://eslint.org/docs/user-guide/) for adapting this configuration to your needs.

--- a/packages/botonic-eslint-config/index-ci.js
+++ b/packages/botonic-eslint-config/index-ci.js
@@ -1,0 +1,28 @@
+// Eslint configuration for CI (slower but detects more issues)
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const base = require('./index.js')
+base.parserOptions.project = './tsconfig.eslint.json'
+
+base.rules['@typescript-eslint/no-floating-promises'] = 'error' // see https://github.com/xjamundx/eslint-plugin-promise/issues/151
+base.rules['@typescript-eslint/no-misused-promises'] = 'error'
+base.rules['@typescript-eslint/require-await'] = 'error'
+
+// rules which are slower because they require type checking
+//https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.json
+base.extends.push(
+  'plugin:@typescript-eslint/recommended-requiring-type-checking'
+)
+base.rules['@typescript-eslint/unbound-method'] = [
+  'error',
+  { ignoreStatic: true },
+]
+base.rules['@typescript-eslint/no-for-in-array'] = 'warn' // sometimes index is necessary
+base.rules['@typescript-eslint/no-unnecessary-type-assertion'] = 'warn' //it has false positives
+
+base.rules['@typescript-eslint/no-unsafe-member-access'] = 'warn'
+base.rules['@typescript-eslint/no-unsafe-assignment'] = 'warn'
+base.rules['@typescript-eslint/no-unsafe-return'] = 'warn'
+base.rules['@typescript-eslint/no-unsafe-call'] = 'warn'
+
+module.exports = base

--- a/packages/botonic-eslint-config/index.js
+++ b/packages/botonic-eslint-config/index.js
@@ -1,0 +1,135 @@
+// Default eslint configuration
+
+module.exports = {
+  parser: '@typescript-eslint/parser', // Specifies the ESLint parser
+  extends: [
+    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'eslint:recommended',
+    'plugin:jest/recommended',
+    'plugin:node/recommended',
+    'plugin:import/recommended',
+    'plugin:promise/recommended',
+    // typescript
+    'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    'plugin:@typescript-eslint/eslint-recommended',
+    'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+  ],
+  plugins: [
+    '@typescript-eslint',
+    'filenames',
+    'import',
+    'jest',
+    'no-null',
+    'promise',
+    'simple-import-sort',
+  ],
+  parserOptions: {
+    ecmaVersion: 2017, // async is from ecma2017. Supported in node >=7.10
+    sourceType: 'module', // Allows for the use of imports
+    ecmaFeatures: {
+      jsx: true, // Allows for the parsing of JSX
+    },
+  },
+  settings: {
+    'import/parsers': {
+      '@typescript-eslint/parser': ['.ts', '.tsx', '.d.ts'],
+    },
+    'import/resolver': {
+      typescript: {
+        alwaysTryTypes: true, // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
+      },
+    },
+  },
+  // npm run lint runs eslint with --quiet --fix so that only errors are fixed
+  rules: {
+    // style. Soon a precommit githook will fix prettier errors
+    'prettier/prettier': 'error',
+    'filenames/match-regex': ['error', '^[a-z-.]+$', true],
+
+    complexity: ['error', { max: 18 }],
+
+    // In typescript we must use obj.field when we have the types, and obj['field'] when we don't
+    // Not set to warn because Webstorm cannot fix eslint rules with --quiet https://youtrack.jetbrains.com/issue/WEB-39246
+    'dot-notation': 'off',
+    'no-console': 'off',
+    // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
+    // e.g. "@typescript-eslint/explicit-function-return-type": "off",
+    'node/no-unsupported-features/es-syntax': 'off', //babel will take care of ES compatibility
+    'unicorn/no-abusive-eslint-disable': 'off',
+    '@typescript-eslint/naming-convention': 'warn',
+    'consistent-return': 'error',
+    'jest/no-export': 'warn',
+    // https://github.com/jest-community/eslint-plugin-jest/issues/657
+    'jest/no-jasmine-globals': 'warn',
+    'no-empty': 'warn',
+    'prefer-const': ['error', { destructuring: 'all' }],
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
+    // import rules
+    'node/no-missing-import': [
+      'error',
+      {
+        tryExtensions: ['.ts', '.tsx', '.js', '.jsx', '.d.ts'],
+      },
+    ],
+    'import/no-unresolved': 'error',
+    'import/default': 'warn', // syntax "export = xxxx" is not supported
+    'node/no-extraneous-import': 'warn', // otherwise it does not find ts-mockito if only defined in parent project
+    'array-callback-return': 'error',
+    // special for TYPESCRIPT
+    '@typescript-eslint/ban-ts-comment': 'warn',
+    '@typescript-eslint/explicit-function-return-type': 'off', // annoying for tests
+    '@typescript-eslint/explicit-member-accessibility': 'off', //we think defaulting to public is a good default
+    '@typescript-eslint/no-empty-function': 'warn',
+    '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }], // to encapsulate types in namespace with same name as Class
+    '@typescript-eslint/no-non-null-assertion': 'warn', // specially useful in tests, and "when you know what you're doing"
+    '@typescript-eslint/no-parameter-properties': 'off', // opinionated: parameter properties make data classes shorter
+    // allow public functions/classes to call private functions/classes declared below.
+    // otoh, variables (typically constants) should be declared at the top
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      { variables: true, functions: false, classes: false },
+    ],
+    '@typescript-eslint/no-useless-constructor': 'warn',
+    'no-empty-pattern': 'off',
+    // 'no-null/no-null': 'warn', // fields declared with ? are undefined, not null (be aware that React uses null)
+    'unicorn/prevent-abbreviations': 'off', // the plugin removes removes type annotations from typescript code :-(
+    'unicorn/filename-case': 'off', // React convention is in CamelCase
+    'valid-jsdoc': 'off', // function comments hide code complexity (and typescript already have type specifications),
+  },
+  overrides: [
+    {
+      files: [
+        '**/*.js', // to be able to skip required fields when not used in a particular test
+        '**/*.jsx',
+      ],
+      rules: {
+        // pending to mark unused vars with _...
+        //'no-unused-vars': ['error', { 'varsIgnorePattern': '^_' }],
+      },
+    },
+    {
+      files: [
+        '**/*.ts', // to be able to skip required fields when not used in a particular test
+      ],
+      rules: {
+        'import/namespace': 'off',
+        // pending to mark unused vars with _...
+        //'@typescript-eslint/no-unused-vars': ['error', { 'varsIgnorePattern': '^_' }],
+      },
+    },
+  ],
+  env: {
+    jest: true,
+    'jest/globals': true,
+    es6: true,
+    // browser/node to prevent "'console' is not defined  no-undef"
+    browser: true,
+    node: true,
+  },
+}
+// eslint-disable-next-line no-undef
+if (typeof AVOID_IMPORT_CRASH !== 'undefined' && AVOID_IMPORT_CRASH) {
+  // avoid eslint-plugin-import crash https://github.com/benmosher/eslint-plugin-import/issues/1818#issuecomment-651547125
+  delete module.exports['settings']['import/parsers']
+}

--- a/packages/botonic-eslint-config/package.json
+++ b/packages/botonic-eslint-config/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@botonic/eslint-config",
+  "version": "0.19.0-alpha.0",
+  "description": "Eslint config for botonic packages",
+  "main": "index.js",
+  "scripts": {},
+  "author": "",
+  "license": "MIT",
+  "keywords": [
+    "bot-framework",
+    "eslint",
+    "eslintconfig",
+    "javascript",
+    "typescript"
+  ],
+  "dependencies": {
+    "@typescript-eslint/parser": "~4.19.0"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "~4.19.0",
+    "eslint-plugin-filenames": "^1.3.2",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jest": "^24.3.2",
+    "eslint-plugin-no-null": "^1.0.2",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-react": "^7.22.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0"
+  },
+  "files": [
+    "index.js",
+    "index-ci.js",
+    "README.md"
+  ]
+}


### PR DESCRIPTION
## Description

Eslint shareable configuration package.

## Context
Unifying the eslint configuration will simplify the eslint configuration of new botonic projects, specially those outside the "packages" folder (which at least inherit the eslint dependencies from the root folder). 


## Approach taken / Explain the design

As specified in the [official documentation](https://eslint.org/docs/developer-guide/shareable-configs)

## To document / Usage example

For a project to use this [eslint](https://eslint.org/) configuration, you'll need to:
* Add `extends: '@botonic/eslint-config/index.js',` to your .eslintrc.js
* If you can afford eslint to be slower (eg from your CI pipeline) to detect more issues, add '@botonic/eslint-config/index-ci.js'
* Add this script to your package.json: ` "lint": "eslint_d --fix --quiet 'src/**/*.js*' 'src/**/*.ts' "`.
* Execute `npm run lint`
Please check the [official user guide](https://eslint.org/docs/user-guide/) for adapting this configuration to your needs.

## Testing

It's being tested in projects outside the botonic repository.