### PR TITLE
refactor(plugin-ner): Codifier replaced by LabelEncoder

### DIFF
--- a/packages/botonic-nlp/package-lock.json
+++ b/packages/botonic-nlp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/nlp",
-  "version": "0.19.0-alpha.0",
+  "version": "0.19.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-nlp/package.json
+++ b/packages/botonic-nlp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/nlp",
-  "version": "0.19.0-alpha.0",
+  "version": "0.19.0-alpha.1",
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/botonic-plugin-ner/package-lock.json
+++ b/packages/botonic-plugin-ner/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "@botonic/nlp": {
-      "version": "0.19.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@botonic/nlp/-/nlp-0.19.0-alpha.0.tgz",
-      "integrity": "sha512-8FkRa4K2Z91YpJ+sVzPo+au+/Bmzoj6+2AKDwxGUaUPEaRGNvZUuDdUEIhvEAeYgpVTAj36GajB84EnSyuGDRA==",
+      "version": "0.19.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@botonic/nlp/-/nlp-0.19.0-alpha.1.tgz",
+      "integrity": "sha512-b8mcIwdXzMnWNpzjKNPpbM6el42R6Bs8NF5Gz5o8luVgYUtaAgK4YecRFz2Bi3t9YftX0niBpsVQhPlU6ehU6g==",
       "requires": {
         "@nlpjs/lang-en-min": "^4.19.1",
         "@nlpjs/lang-es": "^4.19.1",

--- a/packages/botonic-plugin-ner/package.json
+++ b/packages/botonic-plugin-ner/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@botonic/core": "~0.18.0",
-    "@botonic/nlp": "^0.19.0-alpha.0",
+    "@botonic/nlp": "^0.19.0-alpha.1",
     "@tensorflow/tfjs": "^2.7.0",
     "axios": "^0.21.1",
     "franc": "^5.0.0",

--- a/packages/botonic-plugin-ner/src/process/text-processor.ts
+++ b/packages/botonic-plugin-ner/src/process/text-processor.ts
@@ -1,4 +1,4 @@
-import { Codifier } from '@botonic/nlp/lib/preprocess/codifier'
+import { LabelEncoder } from '@botonic/nlp/lib/encode/label-encoder'
 import {
   PADDING_TOKEN,
   UNKNOWN_TOKEN,
@@ -35,7 +35,7 @@ export class TextProcessor {
   }
 
   private encodeSequence(sequence: string[]): number[] {
-    const codifier = new Codifier(this.vocabulary, { isCategorical: false })
-    return codifier.encode(sequence) as number[]
+    const codifier = new LabelEncoder(this.vocabulary)
+    return codifier.encode(sequence)
   }
 }

--- a/packages/botonic-plugin-ner/tests/helper/tools-helper.ts
+++ b/packages/botonic-plugin-ner/tests/helper/tools-helper.ts
@@ -1,7 +1,5 @@
-import { Codifier } from '@botonic/nlp/lib/preprocess/codifier'
 import { Preprocessor } from '@botonic/nlp/lib/preprocess/preprocessor'
 
-import { LOCALE, MAX_LENGTH, VOCABULARY } from './constants-helper'
+import { LOCALE, MAX_LENGTH } from './constants-helper'
 
 export const preprocessor = new Preprocessor(LOCALE, MAX_LENGTH)
-export const tokenCodifier = new Codifier(VOCABULARY, { isCategorical: false })


### PR DESCRIPTION
## Description
Due to the Codifier refactor previously done, all Codifier instances should be replaced by their corresponding encoder in `plugin-ner`.
