### PR TITLE
style(core): remove RouteRequest type replace it with BotRequest

### DIFF
--- a/packages/botonic-core/src/types/index.d.ts
+++ b/packages/botonic-core/src/types/index.d.ts
@@ -170,8 +170,7 @@ export interface Route {
   type?: StringMatcher
 }
 
-export type RouteRequest = { input: Input; session: Session }
-export type Routes<R = Route> = R[] | ((_: RouteRequest) => R[])
+export type Routes<R = Route> = R[] | ((_: BotRequest) => R[])
 
 // Desk
 


### PR DESCRIPTION
## Description
Remove `RouteRequest` type in favour of using `BotRequest` instead in `Routes` type.

## Context
As you can see [here](https://github.com/hubtype/botonic/blob/master/packages/botonic-core/src/core-bot.js#L62), `CoreBot` is passing all 3 attributes declared in `BotRequest` type (`input`, `session` and `lastRoutePath`) in the `routes` function so having `RouteRequest` as the argument's type for the `routes` function was no correct.

## Approach taken / Explain the design


## To document / Usage example

## Testing

The pull request has no tests.