### PR TITLE
refactor(nlp): Default Engines implementation

### DIFF
--- a/packages/botonic-nlp/src/preprocess/engines/en/normalizer-en.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/en/normalizer-en.ts
@@ -1,4 +1,4 @@
-import { Normalizer } from '../../types'
+import { Normalizer } from '../types'
 
 export class NormalizerEn implements Normalizer {
   readonly locale = 'en'

--- a/packages/botonic-nlp/src/preprocess/engines/en/stemmer-en.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/en/stemmer-en.ts
@@ -1,4 +1,4 @@
-import { Stemmer } from '../../types'
+import { Stemmer } from '../types'
 
 export class StemmerEn implements Stemmer {
   readonly locale = 'en'

--- a/packages/botonic-nlp/src/preprocess/engines/en/tokenizer-en.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/en/tokenizer-en.ts
@@ -1,4 +1,4 @@
-import { Tokenizer } from '../../types'
+import { Tokenizer } from '../types'
 
 export class TokenizerEn implements Tokenizer {
   readonly locale = 'en'

--- a/packages/botonic-nlp/src/preprocess/engines/es/normalizer-es.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/es/normalizer-es.ts
@@ -1,4 +1,4 @@
-import { Normalizer } from '../../types'
+import { Normalizer } from '../types'
 
 export class NormalizerEs implements Normalizer {
   readonly locale = 'es'

--- a/packages/botonic-nlp/src/preprocess/engines/es/stemmer-es.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/es/stemmer-es.ts
@@ -1,4 +1,4 @@
-import { Stemmer } from '../../types'
+import { Stemmer } from '../types'
 
 export class StemmerEs implements Stemmer {
   readonly locale = 'es'

--- a/packages/botonic-nlp/src/preprocess/engines/es/tokenizer-es.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/es/tokenizer-es.ts
@@ -1,4 +1,4 @@
-import { Tokenizer } from '../../types'
+import { Tokenizer } from '../types'
 
 export class TokenizerEs implements Tokenizer {
   readonly locale = 'en'

--- a/packages/botonic-nlp/src/preprocess/engines/normalizer.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/normalizer.ts
@@ -1,7 +1,7 @@
 import { Locale } from '../../types'
-import { Normalizer } from '../types'
 import { NormalizerEn } from './en/normalizer-en'
 import { NormalizerEs } from './es/normalizer-es'
+import { Normalizer } from './types'
 
 const NORMALIZERS = {
   en: new NormalizerEn(),

--- a/packages/botonic-nlp/src/preprocess/engines/stemmer.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/stemmer.ts
@@ -1,7 +1,7 @@
 import { Locale } from '../../types'
-import { Stemmer } from '../types'
 import { StemmerEn } from './en/stemmer-en'
 import { StemmerEs } from './es/stemmer-es'
+import { Stemmer } from './types'
 
 const STEMMERS = {
   en: new StemmerEn(),

--- a/packages/botonic-nlp/src/preprocess/engines/stopwords.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/stopwords.ts
@@ -1,7 +1,7 @@
 import { Locale } from '../../types'
-import { Stopwords } from '../types'
 import { STOPWORDS_EN } from './en/stopwords-en'
 import { STOPWORDS_ES } from './es/stopwords-es'
+import { Stopwords } from './types'
 
 const STOPWORDS = {
   en: STOPWORDS_EN,

--- a/packages/botonic-nlp/src/preprocess/engines/tokenizer.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/tokenizer.ts
@@ -1,7 +1,7 @@
 import { Locale } from '../../types'
-import { Tokenizer } from '../types'
 import { TokenizerEn } from './en/tokenizer-en'
 import { TokenizerEs } from './es/tokenizer-es'
+import { Tokenizer } from './types'
 
 const TOKENIZERS = {
   en: new TokenizerEn(),

--- a/packages/botonic-nlp/src/preprocess/engines/types.ts
+++ b/packages/botonic-nlp/src/preprocess/engines/types.ts
@@ -1,4 +1,4 @@
-import { Locale } from '../types'
+import { Locale } from '../../types'
 
 export interface Normalizer {
   readonly locale: Locale

--- a/packages/botonic-nlp/src/preprocess/preprocessor.ts
+++ b/packages/botonic-nlp/src/preprocess/preprocessor.ts
@@ -3,7 +3,7 @@ import { getNormalizer } from './engines/normalizer'
 // import { getStemmer } from './engines/stemmer'
 import { getStopwords } from './engines/stopwords'
 import { getTokenizer } from './engines/tokenizer'
-import { Normalizer, Stemmer, Stopwords, Tokenizer } from './types'
+import { Normalizer, Stemmer, Stopwords, Tokenizer } from './engines/types'
 
 export enum SEQUENCE_POSITION {
   PRE,

--- a/packages/botonic-nlp/src/preprocess/preprocessor.ts
+++ b/packages/botonic-nlp/src/preprocess/preprocessor.ts
@@ -3,14 +3,22 @@ import { getNormalizer } from './engines/normalizer'
 // import { getStemmer } from './engines/stemmer'
 import { getStopwords } from './engines/stopwords'
 import { getTokenizer } from './engines/tokenizer'
-import { PreprocessEngines } from './types'
+import { Normalizer, Stemmer, Stopwords, Tokenizer } from './types'
 
 export enum SEQUENCE_POSITION {
   PRE,
   POST,
 }
+
+export type Engines = {
+  normalizer?: Normalizer
+  tokenizer?: Tokenizer
+  stopwords?: Stopwords
+  stemmer?: Stemmer
+}
+
 export class Preprocessor {
-  engines: PreprocessEngines = {}
+  engines: Engines = {}
 
   constructor(readonly locale: Locale, readonly maxLength: number) {
     this.loadEngines()

--- a/packages/botonic-nlp/src/preprocess/types.ts
+++ b/packages/botonic-nlp/src/preprocess/types.ts
@@ -16,10 +16,3 @@ export interface Tokenizer {
 }
 
 export type Stopwords = string[]
-
-export type PreprocessEngines = {
-  normalizer?: Normalizer
-  tokenizer?: Tokenizer
-  stopwords?: Stopwords
-  stemmer?: Stemmer
-}

--- a/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
+++ b/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
@@ -9,13 +9,13 @@ import { OneHotEncoder } from '../../encode/one-hot-encoder'
 import { ModelManager } from '../../model/manager'
 import { ModelEvaluation } from '../../model/types'
 import { PADDING_TOKEN, UNKNOWN_TOKEN } from '../../preprocess/constants'
-import { Preprocessor } from '../../preprocess/preprocessor'
 import {
   Normalizer,
   Stemmer,
   Stopwords,
   Tokenizer,
-} from '../../preprocess/types'
+} from '../../preprocess/engines/types'
+import { Preprocessor } from '../../preprocess/preprocessor'
 import { VocabularyGenerator } from '../../preprocess/vocabulary-generator'
 import { ModelStorage } from '../../storage/model-storage'
 import { Locale } from '../../types'

--- a/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
+++ b/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
@@ -9,13 +9,13 @@ import { OneHotEncoder } from '../../encode/one-hot-encoder'
 import { ModelManager } from '../../model/manager'
 import { ModelEvaluation } from '../../model/types'
 import { PADDING_TOKEN, UNKNOWN_TOKEN } from '../../preprocess/constants'
-import { Preprocessor } from '../../preprocess/preprocessor'
 import {
   Normalizer,
   Stemmer,
   Stopwords,
   Tokenizer,
-} from '../../preprocess/types'
+} from '../../preprocess/engines/types'
+import { Preprocessor } from '../../preprocess/preprocessor'
 import { VocabularyGenerator } from '../../preprocess/vocabulary-generator'
 import { ModelStorage } from '../../storage/model-storage'
 import { Locale } from '../../types'


### PR DESCRIPTION
## Description
A set of default preprocessing engines has been added to make `Preprocessor` easier by defining it directly with the desired engines.

## Context
- Now, `Preprocessor` is created with specific engines.
- Added one set of default preprocessing engines.

## To document / Usage example
```typescript
const engines = {
    tokenizer: new TokenizerEn(),
    stemmer: new StemmerEn(),
    normalizer: new NormalizerEn(),
    stopwords: STOPWORDS_EN,
}

const preprocessor = new Preprocessor(locale, maxLength, engines)
```
<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- [x] has unit tests
- [x] has integration tests
