### PR TITLE
refactor(nlp): Remove Getters & Setters #BOT-330

### DIFF
--- a/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
+++ b/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
@@ -142,24 +142,4 @@ export class BotonicNer {
     NerConfigStorage.save(path, config)
     await this.modelManager.save(path)
   }
-
-  set normalizer(engine: Normalizer) {
-    this.preprocessor.engines.normalizer = engine
-  }
-
-  set tokenizer(engine: Tokenizer) {
-    this.preprocessor.engines.tokenizer = engine
-  }
-
-  set stopwords(engine: Stopwords) {
-    this.preprocessor.engines.stopwords = engine
-  }
-
-  get stopwords(): Stopwords {
-    return this.preprocessor.engines.stopwords
-  }
-
-  set stemmer(engine: Stemmer) {
-    this.preprocessor.engines.stemmer = engine
-  }
 }

--- a/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
+++ b/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
@@ -132,24 +132,4 @@ export class BotonicTextClassifier {
     new TextClassificationConfigStorage().save(path, config)
     await this.modelManager.save(path)
   }
-
-  set normalizer(engine: Normalizer) {
-    this.preprocessor.engines.normalizer = engine
-  }
-
-  set tokenizer(engine: Tokenizer) {
-    this.preprocessor.engines.tokenizer = engine
-  }
-
-  set stopwords(engine: Stopwords) {
-    this.preprocessor.engines.stopwords = engine
-  }
-
-  get stopwords(): Stopwords {
-    return this.preprocessor.engines.stopwords
-  }
-
-  set stemmer(engine: Stemmer) {
-    this.preprocessor.engines.stemmer = engine
-  }
 }

--- a/packages/botonic-nlp/tests/tasks/text-classification/botonic-text-classifier.test.ts
+++ b/packages/botonic-nlp/tests/tasks/text-classification/botonic-text-classifier.test.ts
@@ -3,7 +3,6 @@ import { join } from 'path'
 
 import { DatabaseStorage } from '../../../src/embeddings/database/storage'
 import { PADDING_TOKEN, UNKNOWN_TOKEN } from '../../../src/preprocess/constants'
-import { STOPWORDS_EN } from '../../../src/preprocess/engines/en/stopwords-en'
 import { BotonicTextClassifier } from '../../../src/tasks/text-classification/botonic-text-classifier'
 import { TEXT_CLASSIFIER_TEMPLATE } from '../../../src/tasks/text-classification/models/types'
 import * as constantsHelper from '../../helpers/constants-helper'
@@ -58,16 +57,5 @@ describe('Botonic Text Classifier', () => {
     expect(existsSync(path)).toBeTruthy()
     rmdirSync(path, { recursive: true })
     expect(existsSync(path)).toBeFalsy()
-  })
-
-  test('Get Stopwords', () => {
-    const stopwords = sut.stopwords
-    expect(stopwords).toEqual(STOPWORDS_EN)
-  })
-
-  test('Set Stopwords', () => {
-    sut.stopwords = ['this', 'is']
-    const stopwords = sut.stopwords
-    expect(stopwords).toEqual(['this', 'is'])
   })
 })


### PR DESCRIPTION
## Description
Remove getters and setters of preprocessing engines.

## Context
No need for getters and setters for preprocessing engines needed. If an engine modification is required, then it should be implemented directly into the `Preprocess` class. 
