### PR TITLE
feat(nlp): importModel method #BOT-336

### DIFF
--- a/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
+++ b/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
@@ -108,7 +108,7 @@ export class BotonicNer {
     }
   }
 
-  importModel(model: LayersModel): void {
+  setModel(model: LayersModel): void {
     this.modelManager = new ModelManager(model)
   }
 

--- a/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
+++ b/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
@@ -1,4 +1,4 @@
-import { Tensor3D } from '@tensorflow/tfjs-node'
+import { LayersModel, Tensor3D } from '@tensorflow/tfjs-node'
 import { join } from 'path'
 
 import { Dataset } from '../../dataset/dataset'
@@ -21,7 +21,7 @@ import { ModelStorage } from '../../storage/model-storage'
 import { Locale } from '../../types'
 import { unique } from '../../utils/array-utils'
 import { createBiLstmModel } from '../ner/models/bilstm-model'
-import { NerModelParameters, NerModelTemplate } from './models/types'
+import { NER_TEMPLATE, NerModelParameters } from './models/types'
 import { NEUTRAL_ENTITY } from './process/constants'
 import { PredictionProcessor } from './process/prediction-processor'
 import { Processor } from './process/processor'
@@ -85,10 +85,10 @@ export class BotonicNer {
   }
 
   async createModel(
-    template: NerModelTemplate,
+    template: NER_TEMPLATE,
     storage: WordEmbeddingStorage,
     params?: NerModelParameters
-  ): Promise<void> {
+  ): Promise<LayersModel> {
     // TODO: set embeddings as optional
     const embeddingsMatrix = await generateEmbeddingsMatrix(
       storage,
@@ -96,19 +96,20 @@ export class BotonicNer {
     )
 
     switch (template) {
-      case 'biLstm':
-        this.modelManager = new ModelManager(
-          createBiLstmModel(
-            this.maxLength,
-            this.entities,
-            embeddingsMatrix,
-            params
-          )
+      case NER_TEMPLATE.BILSTM:
+        return createBiLstmModel(
+          this.maxLength,
+          this.entities,
+          embeddingsMatrix,
+          params
         )
-        break
       default:
         throw new Error(`"${template}" is an invalid model template.`)
     }
+  }
+
+  importModel(model: LayersModel): void {
+    this.modelManager = new ModelManager(model)
   }
 
   async train(

--- a/packages/botonic-nlp/src/tasks/ner/models/types.ts
+++ b/packages/botonic-nlp/src/tasks/ner/models/types.ts
@@ -1,7 +1,9 @@
-export type NerModelTemplate = 'biLstm'
-
 export type NerModelParameters = {
   dropout?: number
   units?: number
   learningRate?: number
+}
+
+export enum NER_TEMPLATE {
+  BILSTM,
 }

--- a/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
+++ b/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
@@ -1,4 +1,4 @@
-import { Tensor2D } from '@tensorflow/tfjs-node'
+import { LayersModel, Tensor2D } from '@tensorflow/tfjs-node'
 import { join } from 'path'
 
 import { Dataset } from '../../dataset/dataset'
@@ -83,21 +83,27 @@ export class BotonicTextClassifier {
     template: TEXT_CLASSIFIER_TEMPLATE,
     storage: WordEmbeddingStorage,
     params?: TextClassifierParameters
-  ): Promise<void> {
+  ): Promise<LayersModel> {
     const embeddingsMatrix = await generateEmbeddingsMatrix(
       storage,
       this.vocabulary
     )
 
-    if (template == TEXT_CLASSIFIER_TEMPLATE.SIMPLE_NN) {
-      const model = createSimpleNN(
-        this.maxLength,
-        this.classes.length,
-        embeddingsMatrix,
-        params
-      )
-      this.modelManager = new ModelManager(model)
+    switch (template) {
+      case TEXT_CLASSIFIER_TEMPLATE.SIMPLE_NN:
+        return createSimpleNN(
+          this.maxLength,
+          this.classes.length,
+          embeddingsMatrix,
+          params
+        )
+      default:
+        throw new Error(`"${template}" is an invalid model template.`)
     }
+  }
+
+  importModel(model: LayersModel): void {
+    this.modelManager = new ModelManager(model)
   }
 
   async train(

--- a/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
+++ b/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
@@ -102,7 +102,7 @@ export class BotonicTextClassifier {
     }
   }
 
-  importModel(model: LayersModel): void {
+  setModel(model: LayersModel): void {
     this.modelManager = new ModelManager(model)
   }
 

--- a/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
@@ -45,7 +45,7 @@ describe('Botonic NER', () => {
       NER_TEMPLATE.BILSTM,
       toolsHelper.wordEmbeddingStorage
     )
-    sut.importModel(model)
+    sut.setModel(model)
     await sut.train(trainSet, 4, 8)
 
     // act
@@ -70,7 +70,7 @@ describe('Botonic NER', () => {
       NER_TEMPLATE.BILSTM,
       toolsHelper.wordEmbeddingStorage
     )
-    sut.importModel(model)
+    sut.setModel(model)
     await sut.train(trainSet, 4, 8)
 
     // act

--- a/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
@@ -1,5 +1,6 @@
 import { PADDING_TOKEN, UNKNOWN_TOKEN } from '../../../src/preprocess/constants'
 import { BotonicNer } from '../../../src/tasks/ner/botonic-ner'
+import { NER_TEMPLATE } from '../../../src/tasks/ner/models/types'
 import * as constantsHelper from '../../helpers/constants-helper'
 import * as toolsHelper from '../../helpers/tools-helper'
 
@@ -40,7 +41,11 @@ describe('Botonic NER', () => {
     const { trainSet, testSet } = toolsHelper.dataset.split()
     sut.generateVocabulary(trainSet)
     sut.compile()
-    await sut.createModel('biLstm', toolsHelper.wordEmbeddingStorage)
+    const model = await sut.createModel(
+      NER_TEMPLATE.BILSTM,
+      toolsHelper.wordEmbeddingStorage
+    )
+    sut.importModel(model)
     await sut.train(trainSet, 4, 8)
 
     // act
@@ -61,7 +66,11 @@ describe('Botonic NER', () => {
     const { trainSet } = toolsHelper.dataset.split()
     sut.generateVocabulary(trainSet)
     sut.compile()
-    await sut.createModel('biLstm', toolsHelper.wordEmbeddingStorage)
+    const model = await sut.createModel(
+      NER_TEMPLATE.BILSTM,
+      toolsHelper.wordEmbeddingStorage
+    )
+    sut.importModel(model)
     await sut.train(trainSet, 4, 8)
 
     // act

--- a/packages/botonic-nlp/tests/tasks/text-classification/botonic-text-classifier.test.ts
+++ b/packages/botonic-nlp/tests/tasks/text-classification/botonic-text-classifier.test.ts
@@ -27,7 +27,7 @@ describe('Botonic Text Classifier', () => {
     const { trainSet, testSet } = toolsHelper.dataset.split()
     sut.generateVocabulary(trainSet)
     sut.compile()
-    await sut.createModel(
+    const model = await sut.createModel(
       TEXT_CLASSIFIER_TEMPLATE.SIMPLE_NN,
       await DatabaseStorage.with(
         constantsHelper.LOCALE,
@@ -35,6 +35,7 @@ describe('Botonic Text Classifier', () => {
         constantsHelper.EMBEDDINGS_DIMENSION
       )
     )
+    sut.importModel(model)
     await sut.train(trainSet, 4, 8)
     const { accuracy, loss } = await sut.evaluate(testSet)
     expect(accuracy).toBeGreaterThan(0.01)
@@ -44,7 +45,7 @@ describe('Botonic Text Classifier', () => {
   test('Save Model', async () => {
     const { trainSet } = toolsHelper.dataset.split(0.5, false)
     sut.generateVocabulary(trainSet)
-    await sut.createModel(
+    const model = await sut.createModel(
       TEXT_CLASSIFIER_TEMPLATE.SIMPLE_NN,
       await DatabaseStorage.with(
         constantsHelper.LOCALE,
@@ -52,6 +53,7 @@ describe('Botonic Text Classifier', () => {
         constantsHelper.EMBEDDINGS_DIMENSION
       )
     )
+    sut.importModel(model)
     const path = join(constantsHelper.HELPER_DIR, 'tmp-botonic-text-classifier')
     await sut.saveModel(path)
     expect(existsSync(path)).toBeTruthy()

--- a/packages/botonic-nlp/tests/tasks/text-classification/botonic-text-classifier.test.ts
+++ b/packages/botonic-nlp/tests/tasks/text-classification/botonic-text-classifier.test.ts
@@ -35,7 +35,7 @@ describe('Botonic Text Classifier', () => {
         constantsHelper.EMBEDDINGS_DIMENSION
       )
     )
-    sut.importModel(model)
+    sut.setModel(model)
     await sut.train(trainSet, 4, 8)
     const { accuracy, loss } = await sut.evaluate(testSet)
     expect(accuracy).toBeGreaterThan(0.01)
@@ -53,7 +53,7 @@ describe('Botonic Text Classifier', () => {
         constantsHelper.EMBEDDINGS_DIMENSION
       )
     )
-    sut.importModel(model)
+    sut.setModel(model)
     const path = join(constantsHelper.HELPER_DIR, 'tmp-botonic-text-classifier')
     await sut.saveModel(path)
     expect(existsSync(path)).toBeTruthy()


### PR DESCRIPTION
## Description
The way the model is created has been split into two steps:
- `createModel()` method refactored to return the created model.
- `setModel()` method needs to be called to set the model we want to use for training, evaluation, and predictions.

## Context
In this way, a user can decide to directly import a custom model. Also, **in the future**, if Botonic's community develops models for NLP tasks, this would be easily imported this way.  

## To document / Usage example
If a user wants to use a template model from Botonic, the code would look something like:
```typescript

const embeddingsStorage = await DatabaseStorage.with(
  constantsHelper.LOCALE,
  constantsHelper.EMBEDDINGS_TYPE,
  constantsHelper.EMBEDDINGS_DIMENSION
)

const model = await classifier.createModel(
  TEXT_CLASSIFIER_TEMPLATE.SIMPLE_NN,
  embeddingsStorage
)
classifier.setModel(model)
```

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- [x] has unit tests
- [x] has integration tests
