### PR TITLE
refactor(nlp, plugin-ner): Filter Neutral Entities #BOT-341

### DIFF
--- a/packages/botonic-nlp/src/tasks/ner/process/prediction-processor.ts
+++ b/packages/botonic-nlp/src/tasks/ner/process/prediction-processor.ts
@@ -1,6 +1,7 @@
 import { Tensor3D } from '@tensorflow/tfjs-node'
 
 import { PADDING_TOKEN } from '../../../preprocess/constants'
+import { NEUTRAL_ENTITY } from './constants'
 import { Entity, Prediction } from './types'
 
 export class PredictionProcessor {
@@ -11,7 +12,9 @@ export class PredictionProcessor {
     const entities = sequence.map((token, idx) => {
       return this.getEntity(token, confidences[idx])
     })
-    return entities.filter(e => e.text != PADDING_TOKEN)
+    return entities.filter(
+      e => e.text != PADDING_TOKEN && e.label != NEUTRAL_ENTITY
+    )
   }
 
   private getEntity(token, confidences): Entity {

--- a/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
@@ -58,25 +58,15 @@ describe('Botonic NER', () => {
 
   test('Recognize entities', async () => {
     // arrange
-    const sut = BotonicNer.with(
-      constantsHelper.LOCALE,
-      constantsHelper.MAX_SEQUENCE_LENGTH,
-      constantsHelper.ENTITIES
-    )
-    const { trainSet } = toolsHelper.dataset.split()
-    sut.generateVocabulary(trainSet)
+    const sut = await BotonicNer.load(constantsHelper.NER_MODEL_DIR_PATH)
     sut.compile()
-    const model = await sut.createModel(
-      NER_TEMPLATE.BILSTM,
-      toolsHelper.wordEmbeddingStorage
-    )
-    sut.setModel(model)
-    await sut.train(trainSet, 4, 8)
 
     // act
-    const entities = sut.recognizeEntities('I love this tshirt')
+    const entities = sut.recognizeEntities('I want to return this jacket')
 
     // assert
-    expect(entities.length).toEqual(3)
+    expect(entities.length).toEqual(1)
+    expect(entities.map(e => e.label)).toEqual(['product'])
+    expect(entities.map(e => e.text)).toEqual(['jacket'])
   })
 })

--- a/packages/botonic-nlp/tests/tasks/ner/process/prediction-processor.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/process/prediction-processor.test.ts
@@ -2,6 +2,7 @@ import { Tensor3D } from '@tensorflow/tfjs-node'
 
 import { ModelManager } from '../../../../src/model/manager'
 import { ModelStorage } from '../../../../src/storage/model-storage'
+import { NEUTRAL_ENTITY } from '../../../../src/tasks/ner/process/constants'
 import { PredictionProcessor } from '../../../../src/tasks/ner/process/prediction-processor'
 import * as constantsHelper from '../../../helpers/constants-helper'
 import * as toolsHelper from '../../../helpers/tools-helper'
@@ -15,8 +16,13 @@ describe('Prediction processor', () => {
       'I want to return this jacket'
     )
     const prediction = manager.predict(input) as Tensor3D
-    const sut = new PredictionProcessor(constantsHelper.ENTITIES)
+    const sut = new PredictionProcessor(
+      [NEUTRAL_ENTITY].concat(constantsHelper.ENTITIES)
+    )
     const entities = sut.process(sequence, prediction)
-    expect(entities.length).toEqual(4)
+    expect(entities.length).toEqual(1)
+    expect(entities.map(e => e.label)).toEqual(['product'])
+    expect(entities.map(e => e.text)).toEqual(['jacket'])
+    expect(entities.some(e => e.label === NEUTRAL_ENTITY)).toBeFalsy()
   })
 })

--- a/packages/botonic-plugin-ner/src/process/prediction-processor.ts
+++ b/packages/botonic-plugin-ner/src/process/prediction-processor.ts
@@ -1,7 +1,7 @@
 import { PADDING_TOKEN } from '@botonic/nlp/lib/preprocess/constants'
+import { NEUTRAL_ENTITY } from '@botonic/nlp/lib/tasks/ner/process/constants'
 import { Entity, Prediction } from '@botonic/nlp/lib/tasks/ner/process/types'
 import { Tensor3D } from '@tensorflow/tfjs'
-
 export class PredictionProcessor {
   constructor(private readonly entities: string[]) {}
 
@@ -31,6 +31,8 @@ export class PredictionProcessor {
   }
 
   private filterEntities(entities: Entity[]): Entity[] {
-    return entities.filter(entity => entity.text != PADDING_TOKEN)
+    return entities.filter(
+      entity => entity.text != PADDING_TOKEN && entity.label != NEUTRAL_ENTITY
+    )
   }
 }

--- a/packages/botonic-plugin-ner/tests/process/prediction-processor.test.ts
+++ b/packages/botonic-plugin-ner/tests/process/prediction-processor.test.ts
@@ -1,13 +1,16 @@
+import { NEUTRAL_ENTITY } from '@botonic/nlp/lib/tasks/ner/process/constants'
+
 import { PredictionProcessor } from '../../src/process/prediction-processor'
 import * as constantsHelper from '../helper/constants-helper'
 
 describe('Prediction processor', () => {
   test('process prediction', () => {
-    const processor = new PredictionProcessor(constantsHelper.ENTITIES)
-    const sut = processor.process(
+    const sut = new PredictionProcessor(constantsHelper.ENTITIES)
+    const entities = sut.process(
       constantsHelper.SEQUENCE,
       constantsHelper.PREDICTION
     )
-    expect(sut.map(entity => entity.label)).toEqual(['O', 'O', 'product'])
+    expect(entities.map(entity => entity.label)).toEqual(['product'])
+    expect(entities.some(entity => entity.label === NEUTRAL_ENTITY)).toBeFalsy()
   })
 })


### PR DESCRIPTION
## Description
Filter the entities recognized as `NEUTRAL` because these ones must not be returned to the user.

## Context
The `NEUTRAL` label is used for labeling tokens that are not entities.

## Testing

The pull request...

- [x] has unit tests
- [x] has integration tests
