### PR TITLE
feat(plugin-text-classification): Plugin Utils implementation #BOT-343

### DIFF
--- a/packages/botonic-plugin-text-classification/src/utils/environment-utils.ts
+++ b/packages/botonic-plugin-text-classification/src/utils/environment-utils.ts
@@ -2,20 +2,21 @@ import { Locale } from '@botonic/nlp/lib/types'
 
 import { ASSETS_DIR, MODELS_DIR, TEXT_CLASSIFICATION_DIR } from '../constants'
 
-export enum Environment {
+enum Environment {
   DEPLOYED,
   LOCAL,
 }
 
-export function getEnvironment(): Environment {
-  if (process.env.STATIC_URL !== undefined) {
-    return Environment.DEPLOYED
+export function getModelUri(locale: Locale): string {
+  const domain = getEnvironmentDomain()
+  if (getEnvironment() === Environment.DEPLOYED) {
+    return `${domain}/${ASSETS_DIR}/${MODELS_DIR}/${TEXT_CLASSIFICATION_DIR}/${locale}`
   } else {
-    return Environment.LOCAL
+    return `${domain}/${TEXT_CLASSIFICATION_DIR}/${MODELS_DIR}/${locale}`
   }
 }
 
-export function getDomain(): string {
+function getEnvironmentDomain(): string {
   if (getEnvironment() == Environment.DEPLOYED) {
     return process.env.STATIC_URL
   } else {
@@ -23,11 +24,10 @@ export function getDomain(): string {
   }
 }
 
-export function getUri(locale: Locale): string {
-  const domain = getDomain()
-  if (getEnvironment() === Environment.DEPLOYED) {
-    return `${domain}/${ASSETS_DIR}/${MODELS_DIR}/${TEXT_CLASSIFICATION_DIR}/${locale}`
+function getEnvironment(): Environment {
+  if (process.env.STATIC_URL !== undefined) {
+    return Environment.DEPLOYED
   } else {
-    return `${domain}/${TEXT_CLASSIFICATION_DIR}/${MODELS_DIR}/${locale}`
+    return Environment.LOCAL
   }
 }

--- a/packages/botonic-plugin-text-classification/src/utils/environment-utils.ts
+++ b/packages/botonic-plugin-text-classification/src/utils/environment-utils.ts
@@ -1,0 +1,33 @@
+import { Locale } from '@botonic/nlp/lib/types'
+
+import { ASSETS_DIR, MODELS_DIR, TEXT_CLASSIFICATION_DIR } from '../constants'
+
+export enum Environment {
+  DEPLOYED,
+  LOCAL,
+}
+
+export function getEnvironment(): Environment {
+  if (process.env.STATIC_URL !== undefined) {
+    return Environment.DEPLOYED
+  } else {
+    return Environment.LOCAL
+  }
+}
+
+export function getDomain(): string {
+  if (getEnvironment() == Environment.DEPLOYED) {
+    return process.env.STATIC_URL
+  } else {
+    return window.location.href
+  }
+}
+
+export function getUri(locale: Locale): string {
+  const domain = getDomain()
+  if (getEnvironment() === Environment.DEPLOYED) {
+    return `${domain}/${ASSETS_DIR}/${MODELS_DIR}/${TEXT_CLASSIFICATION_DIR}/${locale}`
+  } else {
+    return `${domain}/${TEXT_CLASSIFICATION_DIR}/${MODELS_DIR}/${locale}`
+  }
+}

--- a/packages/botonic-plugin-text-classification/src/utils/locale-utils.ts
+++ b/packages/botonic-plugin-text-classification/src/utils/locale-utils.ts
@@ -1,5 +1,11 @@
 import { Locale } from '@botonic/nlp/lib/types'
+import franc from 'franc'
+import langs from 'langs'
 
 export function detectLocale(input: string, locales: Locale[]): Locale {
-  return 'en'
+  const res = franc(input, {
+    whitelist: locales.map(locale => langs.where('1', locale)[3]),
+  })
+  if (res === 'und') return locales[0]
+  return langs.where('3', res)[1] as Locale
 }

--- a/packages/botonic-plugin-text-classification/tests/utils/locale-utils.test.ts
+++ b/packages/botonic-plugin-text-classification/tests/utils/locale-utils.test.ts
@@ -1,0 +1,12 @@
+import { detectLocale } from '../../src/utils/locale-utils'
+
+describe('Locale utils', () => {
+  test.each([
+    ['where is my order?', 'en'],
+    ["dov'è il mio ordine?", 'it'],
+    ['donde está mi pedido?', 'es'],
+    ['где мой заказ?', 'ru'],
+  ])('Locale detection', (input: string, locale: string) => {
+    expect(detectLocale(input, ['en', 'ru', 'es', 'it'])).toEqual(locale)
+  })
+})


### PR DESCRIPTION
**Depends on #1472 .** Please, review it first. ⚠️ 

## Description
Implementing the utils of the text-classification plugin.

## Context
Functions contained in `utils` will be used during the plugin's code.

## To document / Usage example
The `detectLocale` function needs from the text which we want to predict the locale and a whitelist of locales:
```typescript
const detectedLocale = detectLocale('Guess the locale of this sentence', ['en', 'es', 'it', 'ru'])
```

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests
