### PR TITLE
chore(eslint-config): turn jest/no-conditional-expect to warn

### DIFF
--- a/packages/botonic-eslint-config/index.js
+++ b/packages/botonic-eslint-config/index.js
@@ -61,6 +61,7 @@ module.exports = {
     'jest/no-export': 'warn',
     // https://github.com/jest-community/eslint-plugin-jest/issues/657
     'jest/no-jasmine-globals': 'warn',
+    'jest/no-conditional-expect': 'warn',
     'no-empty': 'warn',
     'prefer-const': ['error', { destructuring: 'all' }],
     'simple-import-sort/imports': 'error',

--- a/packages/botonic-eslint-config/package.json
+++ b/packages/botonic-eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/eslint-config",
-  "version": "0.19.0-alpha.0",
+  "version": "0.19.0-alpha.1",
   "description": "Eslint config for botonic packages",
   "main": "index.js",
   "scripts": {},
@@ -14,18 +14,18 @@
     "typescript"
   ],
   "dependencies": {
-    "@typescript-eslint/parser": "~4.19.0"
+    "@typescript-eslint/parser": "~4.22.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "~4.19.0",
+    "@typescript-eslint/eslint-plugin": "~4.22.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.3.2",
+    "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.1.4",
-    "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-react": "^7.22.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-promise": "^4.3.1",
+    "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-simple-import-sort": "^7.0.0"
   },


### PR DESCRIPTION
## Description
Avoid eslint errors in expect asserts within conditionals or lambda callbacks

## Context

#1488 caused jest/no-conditional-expect due to upgrade to latest eslint-plugin-jest


## Approach taken / Explain the design

Turn jest/no-conditional-expect eslint error to warn

