### PR TITLE
chore(contentful): escape-string-regexp 5.0 needs transpilation

### DIFF
--- a/packages/botonic-plugin-contentful/jest.config.js
+++ b/packages/botonic-plugin-contentful/jest.config.js
@@ -14,7 +14,9 @@ module.exports = {
   testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.(ts|tsx)$',
   testPathIgnorePatterns: ['lib', '.*.d.ts', 'tests/helpers', '.*.helper.ts'],
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
-  transformIgnorePatterns: ['node_modules/(?!@botonic).+\\.(js|jsx)$'],
+  transformIgnorePatterns: [
+    'node_modules/(?!@botonic|escape-string-regexp).+\\.(js|jsx)$',
+  ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   snapshotSerializers: [],
   setupFilesAfterEnv: [


### PR DESCRIPTION
## Description

Transpile escape-string-regexp 5.0 when run from jest

## Context

After upgrading from escape-string-regexp 4.0 to 5.0, we got this error when running tests: 
```
2021-04-28T14:35:50.2003261Z   ● Test suite failed to run
2021-04-28T14:35:50.2003929Z 
2021-04-28T14:35:50.2004617Z     Jest encountered an unexpected token
2021-04-28T14:35:50.2005114Z 
2021-04-28T14:35:50.2006246Z     This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.
2021-04-28T14:35:50.2006967Z 
2021-04-28T14:35:50.2007817Z     By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".
2021-04-28T14:35:50.2008852Z 
2021-04-28T14:35:50.2009817Z     Here's what you can do:
2021-04-28T14:35:50.2011521Z      • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/en/ecmascript-modules for how to enable it.
2021-04-28T14:35:50.2014213Z      • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
2021-04-28T14:35:50.2015793Z      • If you need a custom transformation specify a "transform" option in your config.
2021-04-28T14:35:50.2017491Z      • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.
2021-04-28T14:35:50.2018285Z 
2021-04-28T14:35:50.2019231Z     You'll find more details and examples of these config options in the docs:
2021-04-28T14:35:50.2020170Z     https://jestjs.io/docs/en/configuration.html
2021-04-28T14:35:50.2020730Z 
2021-04-28T14:35:50.2021241Z     Details:
2021-04-28T14:35:50.2021631Z 

/home/runner/work/botonic/botonic/packages/botonic-plugin-contentful/node_modules/escape-string-regexp/index.js:1
2021-04-28T14:35:50.2026390Z     ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){export default function escapeStringRegexp(string) {
```
Because version 5.0 uses syntax:
`
export default function escapeStringRegexp(string) 
`
whereas previous 4.0 version used syntax:
```
module.exports = string => {
	if (typeof string !== 'string') {
....
```

## Approach taken / Explain the design

Configure jest to transpile escape-string-regexp

## To document / Usage example

Not sure if we need to document it for bots which use this plugin

## Testing

The pull request...

- has unit tests
