### PR TITLE
chore: update codecov's action version #PLA-442

### DIFF
--- a/.github/workflows/botonic-cli-tests.yml
+++ b/.github/workflows/botonic-cli-tests.yml
@@ -48,7 +48,8 @@ jobs:
         run: (cd ./packages/$PACKAGE && npm run lint_ci)
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.4.1
+        if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-core-tests.yml
+++ b/.github/workflows/botonic-core-tests.yml
@@ -40,7 +40,8 @@ jobs:
       run: scripts/qa/lint-d-ts.sh packages/$PACKAGE
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.4.1
+      if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-nlu-tests.yml
+++ b/.github/workflows/botonic-nlu-tests.yml
@@ -44,7 +44,7 @@ jobs:
         files: ./packages/${{env.PACKAGE}}/junit.xml
     
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.4.1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-contentful-tests.yml
+++ b/.github/workflows/botonic-plugin-contentful-tests.yml
@@ -42,7 +42,8 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.4.1
+      if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-plugin-dialogflow-tests.yml
+++ b/.github/workflows/botonic-plugin-dialogflow-tests.yml
@@ -44,7 +44,7 @@ jobs:
         files: ./packages/${{env.PACKAGE}}/junit.xml
     
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1.3.1
+      uses: codecov/codecov-action@v1.4.1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-dynamo-tests.yml
+++ b/.github/workflows/botonic-plugin-dynamo-tests.yml
@@ -41,7 +41,8 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.4.1
+      if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -44,7 +44,7 @@ jobs:
         files: ./packages/${{env.PACKAGE}}/junit.xml
     
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.4.1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-react-tests.yml
+++ b/.github/workflows/botonic-react-tests.yml
@@ -40,7 +40,8 @@ jobs:
       run: scripts/qa/lint-d-ts.sh ./packages/$PACKAGE
     
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1.4.1
+      if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{env.PACKAGE}}


### PR DESCRIPTION
## Description
Due to https://about.codecov.io/security-update/, we need to update codecov's action to https://github.com/codecov/codecov-action/releases/tag/v1.4.1



## Checklist

The pull request...

- [ ] has the Linear issue number in the title so the issue and the PR are linked
- [ ] adds the entry in the CHANGELOG.md (with the link to the Linear issue)
  - no because... it is just a change in our ci pipeline
- [ ] has tests
  - has unit tests
  - has integration tests
  - doesn't need tests because...  it is just a change in our ci pipeline
