### PR TITLE
fix(plugin-text-classification): Minor Fixes

### DIFF
--- a/packages/botonic-plugin-text-classification/src/index.ts
+++ b/packages/botonic-plugin-text-classification/src/index.ts
@@ -17,9 +17,9 @@ export default class BotonicPluginTextClassification implements Plugin {
       if (request.input.type == INPUT.TEXT && !request.input.payload) {
         const inputText = request.input.data
         const detectedLocale = detectLocale(inputText, this.options.locales)
-        const ner = (await this.modelsSelector).select(detectedLocale)
-        const entities = ner.classify(inputText)
-        Object.assign(request.input, { entities })
+        const classifier = (await this.modelsSelector).select(detectedLocale)
+        const intents = classifier.classify(inputText)
+        Object.assign(request.input, { intent: intents[0].label, intents })
       }
     } catch (e) {
       console.error(`Cannot classify the input: ${request.input}`, e)

--- a/packages/botonic-plugin-text-classification/src/model/model-selector.ts
+++ b/packages/botonic-plugin-text-classification/src/model/model-selector.ts
@@ -13,7 +13,7 @@ export class ModelSelector {
     const selector = new ModelSelector(locales)
     const modelsInfo = selector.loadModelsInfo()
     await selector.loadModels(modelsInfo)
-    return new ModelSelector(locales)
+    return selector
   }
 
   select(locale: Locale): TextClassifier {


### PR DESCRIPTION
## Description
Some fixes have been resolved:
- Variable correctly renamed.
- `build` method from ModelSelector returned an incorrect new instance. 

## Context
The build method generated an error on the chatbot when trying to get the correct model for predicting the intent of the user's input message.