### PR TITLE
refactor(nlp): Ner and Text Classification model layers renamed #BOT-381

### DIFF
--- a/packages/botonic-nlp/src/tasks/ner/models/bilstm-model.ts
+++ b/packages/botonic-nlp/src/tasks/ner/models/bilstm-model.ts
@@ -11,6 +11,8 @@ import {
 
 import { NerModelParameters } from './types'
 
+const MODEL_NAME = 'BiLstmNerModel'
+
 const DEFAULT_DROPOUT = 0.1
 const DEFAULT_UNITS = 128
 const DEFAULT_LEARNING_RATE = 0.001
@@ -25,10 +27,10 @@ export function createBiLstmModel(
     learningRate: DEFAULT_LEARNING_RATE,
   }
 ): LayersModel {
-  const inputs = input({ name: 'InputLayer', shape: [maxLength] })
+  const inputs = input({ name: `${MODEL_NAME}_InputLayer`, shape: [maxLength] })
 
   const embeddingsLayer = layers.embedding({
-    name: 'EmbeddingsLayer',
+    name: `${MODEL_NAME}_EmbeddingsLayer`,
     inputDim: embeddingsMatrix.shape[0] as number,
     outputDim: embeddingsMatrix.shape[1] as number,
     inputLength: maxLength,
@@ -37,12 +39,12 @@ export function createBiLstmModel(
   })
 
   const dropoutLayer = layers.dropout({
-    name: 'DropoutLayer',
+    name: `${MODEL_NAME}_DropoutLayer`,
     rate: params.dropout ?? DEFAULT_DROPOUT,
   })
 
   const bidirectionalLSTM = layers.bidirectional({
-    name: 'BidirectionalLayer',
+    name: `${MODEL_NAME}_BidirectionalLayer`,
     layer: layers.lstm({
       units: params.units ?? DEFAULT_UNITS,
       returnSequences: true,
@@ -51,7 +53,7 @@ export function createBiLstmModel(
   })
 
   const timeDistributedLayer = layers.timeDistributed({
-    name: 'TimeDistributedLayer',
+    name: `${MODEL_NAME}_TimeDistributedLayer`,
     layer: layers.dense({
       units: entities.length,
       activation: 'softmax',
@@ -62,7 +64,7 @@ export function createBiLstmModel(
     bidirectionalLSTM.apply(dropoutLayer.apply(embeddingsLayer.apply(inputs)))
   ) as SymbolicTensor
 
-  const nerModel = model({ name: 'BiLstmNerModel', inputs, outputs })
+  const nerModel = model({ name: MODEL_NAME, inputs, outputs })
   nerModel.compile({
     optimizer: train.adam(params.learningRate ?? DEFAULT_LEARNING_RATE),
     loss: 'categoricalCrossentropy',

--- a/packages/botonic-nlp/src/tasks/text-classification/models/constants.ts
+++ b/packages/botonic-nlp/src/tasks/text-classification/models/constants.ts
@@ -1,3 +1,0 @@
-export const DEFAULT_DROPOUT = 0.3
-export const DEFAULT_UNITS = 128
-export const DEFAULT_LEARNING_RATE = 0.001

--- a/packages/botonic-nlp/src/tasks/text-classification/models/simple-nn.ts
+++ b/packages/botonic-nlp/src/tasks/text-classification/models/simple-nn.ts
@@ -8,12 +8,13 @@ import {
   train,
 } from '@tensorflow/tfjs-node'
 
-import {
-  DEFAULT_DROPOUT,
-  DEFAULT_LEARNING_RATE,
-  DEFAULT_UNITS,
-} from './constants'
 import { TextClassifierParameters } from './types'
+
+const MODEL_NAME = 'SimpleTextClassifier'
+
+const DEFAULT_DROPOUT = 0.3
+const DEFAULT_UNITS = 128
+const DEFAULT_LEARNING_RATE = 0.001
 
 export function createSimpleNN(
   maxLength: number,
@@ -25,10 +26,10 @@ export function createSimpleNN(
     learningRate: DEFAULT_LEARNING_RATE,
   }
 ): LayersModel {
-  const inputs = input({ name: 'InputLayer', shape: [maxLength] })
+  const inputs = input({ name: `${MODEL_NAME}_InputLayer`, shape: [maxLength] })
 
   const embeddingsLayer = layers.embedding({
-    name: 'EmbeddingsLayer',
+    name: `${MODEL_NAME}_EmbeddingsLayer`,
     inputDim: embeddingsMatrix.shape[0],
     outputDim: embeddingsMatrix.shape[1],
     inputLength: maxLength,
@@ -37,14 +38,14 @@ export function createSimpleNN(
   })
 
   const lstmLayer = layers.lstm({
-    name: 'LSTMLayer',
+    name: `${MODEL_NAME}_LSTMLayer`,
     units: params.units ?? DEFAULT_UNITS,
     dropout: params.dropout ?? DEFAULT_DROPOUT,
     recurrentDropout: 0.3,
   })
 
   const denseLayer = layers.dense({
-    name: 'DenseLayer',
+    name: `${MODEL_NAME}_DenseLayer`,
     units: numClasses,
     activation: 'softmax',
   })
@@ -54,7 +55,7 @@ export function createSimpleNN(
   ) as SymbolicTensor
 
   const textClassifierModel = model({
-    name: 'SimpleTextClassifier',
+    name: MODEL_NAME,
     inputs,
     outputs,
   })


### PR DESCRIPTION
## Description
When creating a bot with plugins for Text Classification and NER tasks we get an error.
This error is caused because models used for both tasks have the same names for some layers.

**Solution**: Renaming the model layers to have different names for each task.