### PR TITLE
refactor(nlp): remove compile fron BotonicNer and BotonicTextClassifier #BOT-337

### DIFF
--- a/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
+++ b/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
@@ -41,6 +41,12 @@ export class BotonicNer {
     private readonly preprocessor: Preprocessor
   ) {
     this.entities = unique([NEUTRAL_ENTITY].concat(entities))
+    this.processor = new Processor(
+      this.preprocessor,
+      new LabelEncoder(new IndexedItems(this.vocabulary)),
+      new OneHotEncoder(new IndexedItems(this.entities))
+    )
+    this.predictionProcessor = new PredictionProcessor(this.entities)
   }
 
   static async load(
@@ -57,15 +63,6 @@ export class BotonicNer {
     )
     ner.modelManager = new ModelManager(await ModelStorage.load(path))
     return ner
-  }
-
-  compile(): void {
-    this.processor = new Processor(
-      this.preprocessor,
-      new LabelEncoder(new IndexedItems(this.vocabulary)),
-      new OneHotEncoder(new IndexedItems(this.entities))
-    )
-    this.predictionProcessor = new PredictionProcessor(this.entities)
   }
 
   async createModel(

--- a/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
+++ b/packages/botonic-nlp/src/tasks/text-classification/botonic-text-classifier.ts
@@ -10,12 +10,6 @@ import { OneHotEncoder } from '../../encode/one-hot-encoder'
 import { ModelManager } from '../../model/manager'
 import { ModelEvaluation } from '../../model/types'
 import { Preprocessor } from '../../preprocess/preprocessor'
-import {
-  Normalizer,
-  Stemmer,
-  Stopwords,
-  Tokenizer,
-} from '../../preprocess/types'
 import { ModelStorage } from '../../storage/model-storage'
 import { Locale } from '../../types'
 import { unique } from '../../utils/array-utils'
@@ -45,6 +39,12 @@ export class BotonicTextClassifier {
     private readonly preprocessor: Preprocessor
   ) {
     this.classes = unique(classes)
+    this.processor = new Processor(
+      this.preprocessor,
+      new LabelEncoder(new IndexedItems(this.vocabulary)),
+      new OneHotEncoder(new IndexedItems(this.classes))
+    )
+    this.predictionProcessor = new PredictionProcessor(this.classes)
   }
 
   static async load(
@@ -63,15 +63,6 @@ export class BotonicTextClassifier {
       await ModelStorage.load(path)
     )
     return textClassification
-  }
-
-  compile(): void {
-    this.processor = new Processor(
-      this.preprocessor,
-      new LabelEncoder(new IndexedItems(this.vocabulary)),
-      new OneHotEncoder(new IndexedItems(this.classes))
-    )
-    this.predictionProcessor = new PredictionProcessor(this.classes)
   }
 
   // TODO: set embeddings as optional

--- a/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
@@ -14,7 +14,6 @@ describe('Botonic NER', () => {
     vocabulary,
     toolsHelper.preprocessor
   )
-  sut.compile()
 
   test('Evaluate model', async () => {
     // arrange
@@ -39,7 +38,6 @@ describe('Botonic NER', () => {
       constantsHelper.NER_MODEL_DIR_PATH,
       toolsHelper.preprocessor
     )
-    sut.compile()
 
     // act
     const entities = sut.recognizeEntities('I want to return this jacket')

--- a/packages/botonic-nlp/tests/tasks/text-classification/botonic-text-classifier.test.ts
+++ b/packages/botonic-nlp/tests/tasks/text-classification/botonic-text-classifier.test.ts
@@ -17,7 +17,6 @@ describe('Botonic Text Classifier', () => {
     vocabulary,
     toolsHelper.preprocessor
   )
-  sut.compile()
 
   test('Train and Evaluate model', async () => {
     const model = await sut.createModel(


### PR DESCRIPTION
## Description
The `compile` method from `BotonicNer` and `BotonicTextClassifier` was unnecessary because its content could be moved inside the constructor.

## Context
The simpler these classes are the better for the final user.

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests