### PR TITLE
refactor(nlp): rename input class field to intent BOT-400

### DIFF
--- a/packages/botonic-nlp/src/dataset/dataset.ts
+++ b/packages/botonic-nlp/src/dataset/dataset.ts
@@ -6,17 +6,17 @@ import { InputDataReader } from './input-data-reader'
 
 export class Dataset {
   private constructor(
-    readonly classes: string[],
+    readonly intents: string[],
     readonly entities: string[],
     readonly samples: Sample[]
   ) {}
 
   static load(path: string): Dataset {
     const inputData = new InputDataReader(path).read()
-    const { classes, entities, samples } = new InputDataParser().parse(
+    const { intents, entities, samples } = new InputDataParser().parse(
       inputData
     )
-    return new Dataset(classes, entities, samples)
+    return new Dataset(intents, entities, samples)
   }
 
   split(
@@ -30,8 +30,8 @@ export class Dataset {
     const trainSamples = samples.slice(testProportion * samples.length)
     const testSamples = samples.slice(0, testProportion * samples.length)
     return {
-      trainSet: new Dataset(this.classes, this.entities, trainSamples),
-      testSet: new Dataset(this.classes, this.entities, testSamples),
+      trainSet: new Dataset(this.intents, this.entities, trainSamples),
+      testSet: new Dataset(this.intents, this.entities, testSamples),
     }
   }
 

--- a/packages/botonic-nlp/src/dataset/input-data-parser.ts
+++ b/packages/botonic-nlp/src/dataset/input-data-parser.ts
@@ -2,37 +2,37 @@ import { AugmenterMap, DataAugmenter } from './data-augmenter'
 import { DefinedEntity, EntitiesParser } from './entities-parser'
 import { InputData } from './input-data-reader'
 
-export type Sample = { text: string; class: string; entities: DefinedEntity[] }
+export type Sample = { text: string; intent: string; entities: DefinedEntity[] }
 
 export type ParsedData = {
-  classes: string[]
+  intents: string[]
   entities: string[]
   samples: Sample[]
 }
 
 export class InputDataParser {
   parse(inputData: InputData[]): ParsedData {
-    const classes: Set<string> = new Set()
+    const intents: Set<string> = new Set()
     const entities: Set<string> = new Set()
     const samples: Set<Sample> = new Set()
 
     inputData.forEach(data => {
       const parsedData = this.parseInputData(data)
-      parsedData.classes.forEach(c => classes.add(c))
+      parsedData.intents.forEach(i => intents.add(i))
       parsedData.entities.forEach(e => entities.add(e))
       parsedData.samples.forEach(s => samples.add(s))
     })
 
     return {
-      classes: Array.from(classes),
+      intents: Array.from(intents),
       entities: Array.from(entities),
       samples: Array.from(samples),
     }
   }
 
   private parseInputData(inputData: InputData): ParsedData {
-    const className: string = inputData.class ?? ''
-    const classes: string[] = inputData.class ? [inputData.class] : []
+    const intent: string = inputData.intent ?? ''
+    const intents: string[] = inputData.intent ? [inputData.intent] : []
     const entities: string[] = inputData.entities ?? []
     const augmenterMap: AugmenterMap = inputData['data-augmentation'] ?? {}
 
@@ -43,8 +43,8 @@ export class InputDataParser {
       sentences = augmenter.augment(sentences)
     }
 
-    let samples = sentences.map(text => {
-      return { text, class: className, entities: [] }
+    let samples: Sample[] = sentences.map(text => {
+      return { text, intent, entities: [] }
     })
 
     if (entities.length !== 0) {
@@ -57,6 +57,6 @@ export class InputDataParser {
       })
     }
 
-    return { classes, entities, samples }
+    return { intents, entities, samples }
   }
 }

--- a/packages/botonic-nlp/src/dataset/input-data-reader.ts
+++ b/packages/botonic-nlp/src/dataset/input-data-reader.ts
@@ -5,7 +5,7 @@ import { extname, join } from 'path'
 import { AugmenterMap } from './data-augmenter'
 
 export type InputData = {
-  class?: string
+  intent?: string
   entities?: string[]
   'data-augmentation'?: AugmenterMap
   samples: string[]

--- a/packages/botonic-nlp/src/tasks/intent-classification/botonic-intent-classifier.ts
+++ b/packages/botonic-nlp/src/tasks/intent-classification/botonic-intent-classifier.ts
@@ -21,7 +21,7 @@ import { Intent, PredictionProcessor, Processor } from './process'
 import { IntentClassificationConfigStorage } from './storage'
 
 export class BotonicIntentClassifier {
-  readonly classes: string[]
+  readonly intents: string[]
   private processor: Processor
   private predictionProcessor: PredictionProcessor
   private modelManager: ModelManager
@@ -29,17 +29,17 @@ export class BotonicIntentClassifier {
   constructor(
     readonly locale: Locale,
     readonly maxLength: number,
-    classes: string[],
+    intents: string[],
     readonly vocabulary: string[],
     private readonly preprocessor: Preprocessor
   ) {
-    this.classes = unique(classes)
+    this.intents = unique(intents)
     this.processor = new Processor(
       this.preprocessor,
       new LabelEncoder(new IndexedItems(this.vocabulary)),
-      new OneHotEncoder(new IndexedItems(this.classes))
+      new OneHotEncoder(new IndexedItems(this.intents))
     )
-    this.predictionProcessor = new PredictionProcessor(this.classes)
+    this.predictionProcessor = new PredictionProcessor(this.intents)
   }
 
   static async load(
@@ -50,7 +50,7 @@ export class BotonicIntentClassifier {
     const classifier = new BotonicIntentClassifier(
       config.locale,
       config.maxLength,
-      config.classes,
+      config.intents,
       config.vocabulary,
       preprocessor
     )
@@ -73,7 +73,7 @@ export class BotonicIntentClassifier {
       case INTENT_CLASSIFIER_TEMPLATE.SIMPLE_NN:
         return createSimpleNN(
           this.maxLength,
-          this.classes.length,
+          this.intents.length,
           embeddingsMatrix,
           params
         )
@@ -113,7 +113,7 @@ export class BotonicIntentClassifier {
       locale: this.locale,
       maxLength: this.maxLength,
       vocabulary: this.vocabulary,
-      classes: this.classes,
+      intents: this.intents,
     }
     new IntentClassificationConfigStorage().save(path, config)
     await this.modelManager.save(path)

--- a/packages/botonic-nlp/src/tasks/intent-classification/models/simple-nn.ts
+++ b/packages/botonic-nlp/src/tasks/intent-classification/models/simple-nn.ts
@@ -18,7 +18,7 @@ const DEFAULT_LEARNING_RATE = 0.001
 
 export function createSimpleNN(
   maxLength: number,
-  numClasses: number,
+  numIntents: number,
   embeddingsMatrix: Tensor2D,
   params: IntentClassifierParameters = {
     dropout: DEFAULT_DROPOUT,
@@ -46,7 +46,7 @@ export function createSimpleNN(
 
   const denseLayer = layers.dense({
     name: `${MODEL_NAME}_DenseLayer`,
-    units: numClasses,
+    units: numIntents,
     activation: 'softmax',
   })
 

--- a/packages/botonic-nlp/src/tasks/intent-classification/process/prediction-processor.ts
+++ b/packages/botonic-nlp/src/tasks/intent-classification/process/prediction-processor.ts
@@ -5,7 +5,7 @@ export class Intent {
 }
 
 export class PredictionProcessor {
-  constructor(private readonly classes: string[]) {}
+  constructor(private readonly intents: string[]) {}
 
   process(prediction: OutputData): Intent[] {
     const confidences = prediction.arraySync()[0]
@@ -15,7 +15,7 @@ export class PredictionProcessor {
 
   private createIntents(confidences: number[]): Intent[] {
     return confidences.map(
-      (confidence, idx) => new Intent(this.classes[idx], confidence)
+      (confidence, idx) => new Intent(this.intents[idx], confidence)
     )
   }
 

--- a/packages/botonic-nlp/src/tasks/intent-classification/process/processor.ts
+++ b/packages/botonic-nlp/src/tasks/intent-classification/process/processor.ts
@@ -11,14 +11,14 @@ export class Processor {
   constructor(
     readonly preprocessor: Preprocessor,
     readonly tokensEncoder: LabelEncoder,
-    readonly classEncoder: OneHotEncoder
+    readonly intentEncoder: OneHotEncoder
   ) {}
 
   processSamples(samples: Sample[]): { x: InputData; y: OutputData } {
     const texts = samples.map(sample => sample.text)
-    const classes = samples.map(sample => sample.class)
+    const intents = samples.map(sample => sample.intent)
 
-    return { x: this.processTexts(texts), y: this.generateOutput(classes) }
+    return { x: this.processTexts(texts), y: this.generateOutput(intents) }
   }
 
   processTexts(texts: string[]): InputData {
@@ -42,7 +42,7 @@ export class Processor {
   }
 
   //TODO: modify encoders to just encode one token (not sequences).
-  private generateOutput(classes: string[]): OutputData {
-    return tensor(this.classEncoder.encode(classes))
+  private generateOutput(intents: string[]): OutputData {
+    return tensor(this.intentEncoder.encode(intents))
   }
 }

--- a/packages/botonic-nlp/src/tasks/intent-classification/storage/types.ts
+++ b/packages/botonic-nlp/src/tasks/intent-classification/storage/types.ts
@@ -1,3 +1,3 @@
 import { NlpConfig } from '../../../storage/types'
 
-export type IntentClassificationConfig = NlpConfig & { classes: string[] }
+export type IntentClassificationConfig = NlpConfig & { intents: string[] }

--- a/packages/botonic-nlp/tests/dataset/dataset.test.ts
+++ b/packages/botonic-nlp/tests/dataset/dataset.test.ts
@@ -1,14 +1,14 @@
 import { Dataset } from '../../src/dataset/dataset'
 import { PADDING_TOKEN, UNKNOWN_TOKEN } from '../../src/preprocess/constants'
-import * as constantssHelper from '../helpers/constants-helper'
+import * as constantsHelper from '../helpers/constants-helper'
 import * as toolsHelper from '../helpers/tools-helper'
 
 describe('Dataset', () => {
-  const sut = Dataset.load(constantssHelper.DATA_DIR_PATH)
+  const sut = Dataset.load(constantsHelper.DATA_DIR_PATH)
 
   test('Load Dataset', () => {
-    expect(sut.classes).toEqual(['BuyProduct', 'ReturnProduct'])
-    expect(sut.entities).toEqual(['product', 'color', 'size'])
+    expect(sut.intents.sort()).toEqual(constantsHelper.INTENTS.sort())
+    expect(sut.entities.sort()).toEqual(constantsHelper.ENTITIES.sort())
     expect(sut.samples.length).toEqual(180)
   })
 

--- a/packages/botonic-nlp/tests/dataset/input-data-parser.test.ts
+++ b/packages/botonic-nlp/tests/dataset/input-data-parser.test.ts
@@ -8,9 +8,9 @@ describe('Input Data Parser', () => {
 
     const sut = new InputDataParser()
 
-    const { classes, entities, samples } = sut.parse(inputData)
-    expect(classes).toEqual(['BuyProduct', 'ReturnProduct'])
-    expect(entities).toEqual(['product', 'color', 'size'])
+    const { intents, entities, samples } = sut.parse(inputData)
+    expect(intents.sort()).toEqual(helper.INTENTS.sort())
+    expect(entities.sort()).toEqual(helper.ENTITIES.sort())
     expect(samples.length).toEqual(180)
   })
 })

--- a/packages/botonic-nlp/tests/dataset/input-data-reader.test.ts
+++ b/packages/botonic-nlp/tests/dataset/input-data-reader.test.ts
@@ -6,12 +6,12 @@ describe('Input Data Reader', () => {
     const sut = new InputDataReader(helper.DATA_DIR_PATH)
     const inputData = sut.read()
     expect(inputData.length).toEqual(2)
-    expect(inputData.map(i => i.class).sort()).toEqual(helper.CLASSES.sort())
+    expect(inputData.map(i => i.intent).sort()).toEqual(helper.INTENTS.sort())
     expect(inputData.map(i => i.entities).sort()).toEqual(
-      Array(helper.CLASSES.length).fill(helper.ENTITIES).sort()
+      Array(helper.INTENTS.length).fill(helper.ENTITIES).sort()
     )
     expect(
-      inputData.filter(i => i.class == 'BuyProduct').map(i => i.samples.length)
+      inputData.filter(i => i.intent == 'BuyProduct').map(i => i.samples.length)
     ).toEqual([5])
   })
 })

--- a/packages/botonic-nlp/tests/helpers/constants-helper.ts
+++ b/packages/botonic-nlp/tests/helpers/constants-helper.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 export const LOCALE = 'en'
 export const MAX_SEQUENCE_LENGTH = 12
 
-export const CLASSES = ['BuyProduct', 'ReturnProduct']
+export const INTENTS = ['BuyProduct', 'ReturnProduct']
 export const ENTITIES = ['product', 'color', 'size']
 
 export const VOCABULARY = [

--- a/packages/botonic-nlp/tests/helpers/data/buy-product.yaml
+++ b/packages/botonic-nlp/tests/helpers/data/buy-product.yaml
@@ -1,4 +1,4 @@
-class: BuyProduct
+intent: BuyProduct
 
 entities:
   - product

--- a/packages/botonic-nlp/tests/helpers/data/return-product.yaml
+++ b/packages/botonic-nlp/tests/helpers/data/return-product.yaml
@@ -1,4 +1,4 @@
-class: ReturnProduct
+intent: ReturnProduct
 
 entities:
   - product

--- a/packages/botonic-nlp/tests/helpers/models/intent-classification/en/config.json
+++ b/packages/botonic-nlp/tests/helpers/models/intent-classification/en/config.json
@@ -33,5 +33,5 @@
     "t-shirt",
     "white"
   ],
-  "classes": ["BuyProduct", "ReturnProduct"]
+  "intents": ["BuyProduct", "ReturnProduct"]
 }

--- a/packages/botonic-nlp/tests/helpers/tools-helper.ts
+++ b/packages/botonic-nlp/tests/helpers/tools-helper.ts
@@ -8,10 +8,10 @@ import { Preprocessor } from '../../src/preprocess'
 import { NEUTRAL_ENTITY } from '../../src/tasks/ner/process/constants'
 import { Processor as NerProcessor } from '../../src/tasks/ner/process/processor'
 import {
-  CLASSES,
   DATA_DIR_PATH,
   EMBEDDINGS_DIMENSION,
   ENTITIES,
+  INTENTS,
   LOCALE,
   MAX_SEQUENCE_LENGTH,
   VOCABULARY,
@@ -22,7 +22,7 @@ export const dataset = Dataset.load(DATA_DIR_PATH)
 export const preprocessor = new Preprocessor(LOCALE, MAX_SEQUENCE_LENGTH)
 
 export const tokenEncoder = new LabelEncoder(new IndexedItems(VOCABULARY))
-export const classEncoder = new OneHotEncoder(new IndexedItems(CLASSES))
+export const intentEncoder = new OneHotEncoder(new IndexedItems(INTENTS))
 export const entitiesEncoder = new OneHotEncoder(
   new IndexedItems([NEUTRAL_ENTITY].concat(ENTITIES))
 )

--- a/packages/botonic-nlp/tests/tasks/intent-classification/botonic-intent-classifier.test.ts
+++ b/packages/botonic-nlp/tests/tasks/intent-classification/botonic-intent-classifier.test.ts
@@ -13,7 +13,7 @@ describe('Botonic Intent Classifier', () => {
   const sut = new BotonicIntentClassifier(
     constantsHelper.LOCALE,
     constantsHelper.MAX_SEQUENCE_LENGTH,
-    constantsHelper.CLASSES,
+    constantsHelper.INTENTS,
     vocabulary,
     toolsHelper.preprocessor
   )

--- a/packages/botonic-nlp/tests/tasks/intent-classification/models/simple-nn.test.ts
+++ b/packages/botonic-nlp/tests/tasks/intent-classification/models/simple-nn.test.ts
@@ -5,7 +5,7 @@ describe('Simple NN Model', () => {
   test('Model Creation', () => {
     const model = createSimpleNN(
       helper.MAX_SEQUENCE_LENGTH,
-      helper.CLASSES.length,
+      helper.INTENTS.length,
       helper.EMBEDDINGS_MATRIX,
       { units: 64, dropout: 0.2, learningRate: 0.1 }
     )

--- a/packages/botonic-nlp/tests/tasks/intent-classification/process/prediction-processor.test.ts
+++ b/packages/botonic-nlp/tests/tasks/intent-classification/process/prediction-processor.test.ts
@@ -7,9 +7,9 @@ import * as helper from '../../../helpers/constants-helper'
 describe('Prediction Processor', () => {
   test('Process Prediction', () => {
     const prediction = tensor([[0.3, 0.7]]) as OutputData
-    const sut = new PredictionProcessor(helper.CLASSES)
+    const sut = new PredictionProcessor(helper.INTENTS)
     const intents = sut.process(prediction)
-    expect(intents.length).toEqual(helper.CLASSES.length)
-    expect(intents[0].label).toEqual(helper.CLASSES[1])
+    expect(intents.length).toEqual(helper.INTENTS.length)
+    expect(intents[0].label).toEqual(helper.INTENTS[1])
   })
 })

--- a/packages/botonic-nlp/tests/tasks/intent-classification/process/processor.test.ts
+++ b/packages/botonic-nlp/tests/tasks/intent-classification/process/processor.test.ts
@@ -11,18 +11,18 @@ describe('Intent Classification Processor', () => {
   const sut = new Processor(
     toolsHelper.preprocessor,
     toolsHelper.tokenEncoder,
-    toolsHelper.classEncoder
+    toolsHelper.intentEncoder
   )
 
   test('Process samples', () => {
     const { x, y } = sut.processSamples([
       {
-        class: 'BuyProduct',
+        intent: 'BuyProduct',
         entities: [{ start: 27, end: 32, label: 'product' }],
         text: SHORT_TEXT,
       },
       {
-        class: 'BuyProduct',
+        intent: 'BuyProduct',
         entities: [{ start: 27, end: 32, label: 'product' }],
         text: LONG_TEXT,
       },
@@ -32,7 +32,7 @@ describe('Intent Classification Processor', () => {
       [6, 7, 9, 1, 1, 0, 0, 0, 0, 0, 0, 0],
       [6, 7, 9, 1, 1, 28, 27, 6, 7, 1, 1, 21],
     ])
-    expect(y.shape).toEqual([2, constantsHelper.CLASSES.length])
+    expect(y.shape).toEqual([2, constantsHelper.INTENTS.length])
     expect(y.arraySync()).toEqual([
       [1, 0],
       [1, 0],

--- a/packages/botonic-nlp/tests/tasks/intent-classification/storage/config-storage.test.ts
+++ b/packages/botonic-nlp/tests/tasks/intent-classification/storage/config-storage.test.ts
@@ -12,7 +12,7 @@ describe('Config handler', () => {
     expect(config.locale).toEqual(helper.LOCALE)
     expect(config.maxLength).toEqual(helper.MAX_SEQUENCE_LENGTH)
     expect(config.vocabulary).toEqual(helper.VOCABULARY)
-    expect(config.classes).toEqual(helper.CLASSES)
+    expect(config.intents).toEqual(helper.INTENTS)
   })
 
   test('Save config', () => {
@@ -21,7 +21,7 @@ describe('Config handler', () => {
       locale: helper.LOCALE,
       maxLength: helper.MAX_SEQUENCE_LENGTH,
       vocabulary: helper.VOCABULARY,
-      classes: helper.CLASSES,
+      intents: helper.INTENTS,
     })
     expect(existsSync(join(path, storer.CONFIG_FILENAME))).toBeTruthy()
     rmdirSync(path, { recursive: true })

--- a/packages/botonic-nlp/tests/tasks/ner/process/processor.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/process/processor.test.ts
@@ -17,12 +17,12 @@ describe('NER Processor', () => {
   test('Process samples', () => {
     const { x, y } = sut.process([
       {
-        class: 'BuyProduct',
+        intent: 'BuyProduct',
         entities: [{ start: 27, end: 32, label: 'product' }],
         text: SHORT_TEXT,
       },
       {
-        class: 'BuyProduct',
+        intent: 'BuyProduct',
         entities: [{ start: 27, end: 32, label: 'product' }],
         text: LONG_TEXT,
       },


### PR DESCRIPTION
## Description
- In the input file, we had a field named class which has been replaced for intent.
- `InputData` and `ParsedData` had a `classes` field that has been renamed to `intent`.
- `Sample` class field has been renamed to intent.
- Some parameters named class or classes have been renamed to intent or intents respectively.
(Usages of all fields that have been renamed have also been renamed)

## Testing
The pull request...
- [x] has unit tests
- [x] has integration tests
