### PR TITLE
refactor(cli): text-classification task renamed to intent-classification #BOT-399

### DIFF
--- a/packages/botonic-cli/src/commands/train.ts
+++ b/packages/botonic-cli/src/commands/train.ts
@@ -41,7 +41,7 @@ class Task {
 export class Tasks {
   static tasks = {
     ner: new Task('ner'),
-    'text-classification': new Task('text-classification'),
+    'intent-classification': new Task('intent-classification'),
   }
 
   static getAll(): Task[] {


### PR DESCRIPTION
## Description
Task flag in train command renamed from `text-classification` to `intent-classification`. 
