### PR TITLE
Contentful/test robutstness

### DIFF
--- a/packages/botonic-plugin-contentful/src/util/backoff.ts
+++ b/packages/botonic-plugin-contentful/src/util/backoff.ts
@@ -27,8 +27,11 @@ export async function repeatWithBackoff<T>(
     try {
       return await func()
     } catch (e) {
+      const stack = e.stack ? `\nat:\n${e.stack}` : ' (no stack available)'
       logger(
-        `Retrying after exception at ${new Date().toString()}: ${String(e)}`
+        `Retrying after exception at ${new Date().toISOString()}: ${String(
+          e
+        )}` + stack
       )
       await backoff.backoff()
     }

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
@@ -13,6 +13,8 @@ function ctxt(ctx: Partial<ManageContext>): ManageContext {
   return { ...ctx, preview: false } as ManageContext
 }
 
+const TEST_TIMEOUT = 50000
+
 // Since the tests modify contentful contents, they might fail if executed
 // more than once simultaneously (eg from 2 different branches from CI)
 describe('ManageContentful fields', () => {
@@ -32,18 +34,30 @@ describe('ManageContentful fields', () => {
     )
   })
 
-  test('TEST: updateFields with empty ("") value does not fallback', async () => {
-    await updateEmptyField('', '')
-  }, 400000)
+  test(
+    'TEST: updateFields with empty ("") value does not fallback',
+    async () => {
+      await updateEmptyField('', '')
+    },
+    TEST_TIMEOUT
+  )
 
-  test('TEST: updateFields with undefined value falls back to other locale', async () => {
-    await updateEmptyField(undefined, fallbackLocaleContent.text)
-  }, 40000)
+  test(
+    'TEST: updateFields with undefined value falls back to other locale',
+    async () => {
+      await updateEmptyField(undefined, fallbackLocaleContent.text)
+    },
+    TEST_TIMEOUT
+  )
 
-  test('TEST: updateFields non empty', async () => {
-    const newValue = rndStr()
-    await updateEmptyField(newValue, newValue)
-  }, 40000)
+  test(
+    'TEST: updateFields non empty',
+    async () => {
+      const newValue = rndStr()
+      await updateEmptyField(newValue, newValue)
+    },
+    TEST_TIMEOUT
+  )
 
   async function updateEmptyField(
     newValue: string | undefined,
@@ -107,82 +121,90 @@ describe('ManageContentful fields', () => {
     })
   }
 
-  test('TEST: updateFields by default does not allow overwrites', async () => {
-    const sut = testManageContentful()
-    const newFields = { [ContentFieldType.TEXT]: rndStr() }
+  test(
+    'TEST: updateFields by default does not allow overwrites',
+    async () => {
+      const sut = testManageContentful()
+      const newFields = { [ContentFieldType.TEXT]: rndStr() }
 
-    try {
-      expect.assertions(4)
-      await sut.updateFields(
-        ctxt({ locale: TEST_DEFAULT_LOCALE }),
-        TEST_CONTENT_ID,
-        newFields
-      )
-    } catch (e) {
-      // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
-      expect(e).toBeInstanceOf(CmsException)
-      if (e instanceof CmsException) {
-        // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
-        expect(e.message).toInclude(
-          "Error calling ManageCms.updateFields with locale 'en' on 'text' with id '627QkyJrFo3grJryj0vu6L' " +
-            `with args '${JSON.stringify(newFields)}'. ` +
-            "Cannot overwrite field 'text' of entry '627QkyJrFo3grJryj0vu6L'"
+      try {
+        expect.assertions(4)
+        await sut.updateFields(
+          ctxt({ locale: TEST_DEFAULT_LOCALE }),
+          TEST_CONTENT_ID,
+          newFields
         )
+      } catch (e) {
         // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
-        expect(e.message).toInclude(
-          'because ManageContext.allowOverwrites is false'
-        )
+        expect(e).toBeInstanceOf(CmsException)
+        if (e instanceof CmsException) {
+          // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
+          expect(e.message).toInclude(
+            "Error calling ManageCms.updateFields with locale 'en' on 'text' with id '627QkyJrFo3grJryj0vu6L' " +
+              `with args '${JSON.stringify(newFields)}'. ` +
+              "Cannot overwrite field 'text' of entry '627QkyJrFo3grJryj0vu6L'"
+          )
+          // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
+          expect(e.message).toInclude(
+            'because ManageContext.allowOverwrites is false'
+          )
 
-        // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
-        expect(e.reason.message).toInclude('Cannot overwrite')
+          // eslint-disable-next-line jest/no-try-expect,jest/no-conditional-expect
+          expect(e.reason.message).toInclude('Cannot overwrite')
+        }
       }
-    }
-  }, 40000)
+    },
+    TEST_TIMEOUT
+  )
 
-  test('TEST: copyField buttons', async () => {
-    const contentful = testContentful({ disableCache: true })
-    const oldContent = await contentful.text(TEST_CONTENT_ID.id)
-    const sut = testManageContentful()
-    const FROM_LOCALE = ENGLISH
-    const TO_LOCALE = SPANISH
+  test(
+    'TEST: copyField buttons',
+    async () => {
+      const contentful = testContentful({ disableCache: true })
+      const oldContent = await contentful.text(TEST_CONTENT_ID.id)
+      const sut = testManageContentful()
+      const FROM_LOCALE = ENGLISH
+      const TO_LOCALE = SPANISH
 
-    const fromButtons = (
-      await contentful.text(oldContent.id, {
-        locale: FROM_LOCALE,
-      })
-    ).buttons
-    expect(fromButtons.length).toBeGreaterThan(0)
-
-    try {
-      // ACT
-      await sut.copyField(
-        ctxt({ locale: TO_LOCALE }),
-        oldContent.contentId,
-        ContentFieldType.BUTTONS,
-        FROM_LOCALE,
-        false
-      )
-      // wait until CDNs provide the new value
-      await repeatWithBackoff(async () => {
-        const newContent = await contentful.text(oldContent.id, {
-          locale: TO_LOCALE,
+      const fromButtons = (
+        await contentful.text(oldContent.id, {
+          locale: FROM_LOCALE,
         })
-        expect(newContent.buttons.length).toEqual(fromButtons.length)
-      })
-    } finally {
-      // RESTORE
-      await sut.updateFields(
-        ctxt({ locale: TO_LOCALE, allowOverwrites: true }),
-        oldContent.contentId,
-        { [ContentFieldType.BUTTONS]: [] }
-      )
-      await repeatWithBackoff(async () => {
-        const restored = await contentful.text(oldContent.id, {
-          locale: TO_LOCALE,
-          ignoreFallbackLocale: true,
+      ).buttons
+      expect(fromButtons.length).toBeGreaterThan(0)
+
+      try {
+        // ACT
+        await sut.copyField(
+          ctxt({ locale: TO_LOCALE }),
+          oldContent.contentId,
+          ContentFieldType.BUTTONS,
+          FROM_LOCALE,
+          false
+        )
+        // wait until CDNs provide the new value
+        await repeatWithBackoff(async () => {
+          const newContent = await contentful.text(oldContent.id, {
+            locale: TO_LOCALE,
+          })
+          expect(newContent.buttons.length).toEqual(fromButtons.length)
         })
-        expect(restored.buttons).toEqual([])
-      })
-    }
-  }, 40000)
+      } finally {
+        // RESTORE
+        await sut.updateFields(
+          ctxt({ locale: TO_LOCALE, allowOverwrites: true }),
+          oldContent.contentId,
+          { [ContentFieldType.BUTTONS]: [] }
+        )
+        await repeatWithBackoff(async () => {
+          const restored = await contentful.text(oldContent.id, {
+            locale: TO_LOCALE,
+            ignoreFallbackLocale: true,
+          })
+          expect(restored.buttons).toEqual([])
+        })
+      }
+    },
+    TEST_TIMEOUT
+  )
 })

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
@@ -71,8 +71,12 @@ describe('ManageContentful fields', () => {
         )
       }
       // ACT
-      await sut.updateFields(ctxt({ locale: SPANISH }), TEST_CONTENT_ID, {
-        [ContentFieldType.TEXT]: newValue,
+      // Despite the check of oldTextValue, it's possible that the content is externally updated
+      // in the interim
+      await repeatWithBackoff(async () => {
+        await sut.updateFields(ctxt({ locale: SPANISH }), TEST_CONTENT_ID, {
+          [ContentFieldType.TEXT]: newValue,
+        })
       })
       await repeatWithBackoff(async () => {
         const newContent = await contentful.text(TEST_CONTENT_ID.id, {
@@ -87,6 +91,9 @@ describe('ManageContentful fields', () => {
   }
 
   async function restoreValue(manage: ManageCms) {
+    contentful.text(TEST_CONTENT_ID.id, {
+      locale: SPANISH,
+    })
     await manage.updateFields(
       ctxt({ locale: SPANISH, allowOverwrites: true }),
       TEST_CONTENT_ID,


### PR DESCRIPTION
* Make contentful manage (update) tests a bit more robust to simultaneous updates of contents
* Make contentful manage (update) tests a bit more robust by extending timeout
* Improve backoff: log shorter timestamp and show stacktrace