### PR TITLE
Fix(plugin-ner, plugin-intent-classification): fix imports to work with serve mode

### DIFF
--- a/packages/botonic-nlp/package.json
+++ b/packages/botonic-nlp/package.json
@@ -2,7 +2,6 @@
   "name": "@botonic/nlp",
   "version": "0.19.0-alpha.4",
   "license": "MIT",
-  "main": "lib/index.js",
   "scripts": {
     "build": "rm -rf lib && ../../node_modules/.bin/tsc",
     "lint": "npm run lint_core -- --fix",

--- a/packages/botonic-plugin-intent-classification/src/model/intent-classifier.ts
+++ b/packages/botonic-plugin-intent-classification/src/model/intent-classifier.ts
@@ -1,6 +1,6 @@
-import { Preprocessor } from '@botonic/nlp/lib/preprocess'
-import { Intent } from '@botonic/nlp/lib/tasks/intent-classification/process'
-import type { IntentClassificationConfig } from '@botonic/nlp/lib/tasks/intent-classification/storage'
+import { Preprocessor } from '@botonic/nlp/lib/preprocess/preprocessor'
+import { Intent } from '@botonic/nlp/lib/tasks/intent-classification/process/prediction-processor'
+import type { IntentClassificationConfig } from '@botonic/nlp/lib/tasks/intent-classification/storage/types'
 import type { Tensor2D } from '@tensorflow/tfjs'
 import { LayersModel } from '@tensorflow/tfjs'
 

--- a/packages/botonic-plugin-intent-classification/src/process/prediction-processor.ts
+++ b/packages/botonic-plugin-intent-classification/src/process/prediction-processor.ts
@@ -1,4 +1,4 @@
-import { Intent } from '@botonic/nlp/lib/tasks/intent-classification/process'
+import { Intent } from '@botonic/nlp/lib/tasks/intent-classification/process/prediction-processor'
 import type { Tensor2D } from '@tensorflow/tfjs'
 
 export class PredictionProcessor {

--- a/packages/botonic-plugin-intent-classification/src/process/text-processor.ts
+++ b/packages/botonic-plugin-intent-classification/src/process/text-processor.ts
@@ -1,9 +1,10 @@
-import { IndexedItems, LabelEncoder } from '@botonic/nlp/lib/encode'
+import { IndexedItems } from '@botonic/nlp/lib/encode/indexed-items'
+import { LabelEncoder } from '@botonic/nlp/lib/encode/label-encoder'
 import {
   PADDING_TOKEN,
-  Preprocessor,
   UNKNOWN_TOKEN,
-} from '@botonic/nlp/lib/preprocess'
+} from '@botonic/nlp/lib/preprocess/constants'
+import { Preprocessor } from '@botonic/nlp/lib/preprocess/preprocessor'
 import { Tensor2D, tensor2d } from '@tensorflow/tfjs'
 
 export class TextProcessor {

--- a/packages/botonic-plugin-intent-classification/src/utils/environment-utils.ts
+++ b/packages/botonic-plugin-intent-classification/src/utils/environment-utils.ts
@@ -18,14 +18,14 @@ export function getModelUri(locale: Locale): string {
 
 function getEnvironmentDomain(): string {
   if (getEnvironment() == Environment.DEPLOYED) {
-    return process.env.STATIC_URL
+    return typeof process !== 'undefined' && process.env.STATIC_URL
   } else {
     return window.location.href
   }
 }
 
 function getEnvironment(): Environment {
-  if (process.env.STATIC_URL !== undefined) {
+  if (typeof process !== 'undefined' && process.env.STATIC_URL !== undefined) {
     return Environment.DEPLOYED
   } else {
     return Environment.LOCAL

--- a/packages/botonic-plugin-ner/src/process/prediction-processor.ts
+++ b/packages/botonic-plugin-ner/src/process/prediction-processor.ts
@@ -1,9 +1,6 @@
-import { PADDING_TOKEN } from '@botonic/nlp/lib/preprocess'
-import {
-  Entity,
-  NEUTRAL_ENTITY,
-  Prediction,
-} from '@botonic/nlp/lib/tasks/ner/process'
+import { PADDING_TOKEN } from '@botonic/nlp/lib/preprocess/constants'
+import { NEUTRAL_ENTITY } from '@botonic/nlp/lib/tasks/ner/process/constants'
+import { Entity, Prediction } from '@botonic/nlp/lib/tasks/ner/process/types'
 import { Tensor3D } from '@tensorflow/tfjs'
 export class PredictionProcessor {
   constructor(private readonly entities: string[]) {}

--- a/packages/botonic-plugin-ner/src/process/text-processor.ts
+++ b/packages/botonic-plugin-ner/src/process/text-processor.ts
@@ -1,9 +1,10 @@
-import { IndexedItems, LabelEncoder } from '@botonic/nlp/lib/encode'
+import { IndexedItems } from '@botonic/nlp/lib/encode/indexed-items'
+import { LabelEncoder } from '@botonic/nlp/lib/encode/label-encoder'
 import {
   PADDING_TOKEN,
-  Preprocessor,
   UNKNOWN_TOKEN,
-} from '@botonic/nlp/lib/preprocess'
+} from '@botonic/nlp/lib/preprocess/constants'
+import { Preprocessor } from '@botonic/nlp/lib/preprocess/preprocessor'
 import { tensor, Tensor2D } from '@tensorflow/tfjs'
 
 export class TextProcessor {

--- a/packages/botonic-plugin-ner/src/utils/environment-utils.ts
+++ b/packages/botonic-plugin-ner/src/utils/environment-utils.ts
@@ -8,7 +8,7 @@ export enum ENVIRONMENT {
 }
 
 export function getEnvironment(): ENVIRONMENT {
-  if (process.env.STATIC_URL !== undefined) {
+  if (typeof process !== 'undefined' && process.env.STATIC_URL !== undefined) {
     return ENVIRONMENT.DEPLOYED
   } else {
     return ENVIRONMENT.LOCAL
@@ -17,7 +17,7 @@ export function getEnvironment(): ENVIRONMENT {
 
 export function getDomain(): string {
   if (getEnvironment() == ENVIRONMENT.DEPLOYED) {
-    return process.env.STATIC_URL
+    return typeof process !== 'undefined' && process.env.STATIC_URL
   } else {
     return window.location.href
   }


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Remove imports pointing to modules (this makes the bundle to include Node deps). This is an implementation detail that has to be taken into account when developing nlp plugins.
     * Done for plugin-intent-classification
     * Done for plugin-ner 
* Safe check for process env (not included anymore in Webpack5 unless it is defined with external plugins)


## Context
Plugin intent classification and ner were not working when run in serve mode.
