### PR TITLE
Refactor(nlp): NLP Tasks constructors refactored #BOT-329

### DIFF
--- a/packages/botonic-nlp/src/tasks/index.ts
+++ b/packages/botonic-nlp/src/tasks/index.ts
@@ -1,0 +1,1 @@
+export * from './nlp-task-config'

--- a/packages/botonic-nlp/src/tasks/intent-classification/botonic-intent-classifier.ts
+++ b/packages/botonic-nlp/src/tasks/intent-classification/botonic-intent-classifier.ts
@@ -30,8 +30,8 @@ export class BotonicIntentClassifier {
   readonly maxLength: number
   readonly vocabulary: string[]
   readonly intents: string[]
-  private processor: Processor
-  private predictionProcessor: PredictionProcessor
+  private readonly processor: Processor
+  private readonly predictionProcessor: PredictionProcessor
   private modelManager: ModelManager
 
   constructor(config: IntentClassifierConfig) {

--- a/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
+++ b/packages/botonic-nlp/src/tasks/ner/botonic-ner.ts
@@ -31,8 +31,8 @@ export class BotonicNer {
   readonly maxLength: number
   readonly vocabulary: string[]
   readonly entities: string[]
-  private processor: Processor
-  private predictionProcessor: PredictionProcessor
+  private readonly processor: Processor
+  private readonly predictionProcessor: PredictionProcessor
   private modelManager: ModelManager
 
   constructor(config: EntityRecognizerConfig) {

--- a/packages/botonic-nlp/src/tasks/nlp-task-config.ts
+++ b/packages/botonic-nlp/src/tasks/nlp-task-config.ts
@@ -1,0 +1,9 @@
+import { Preprocessor } from '../preprocess'
+import { Locale } from '../types'
+
+export interface NlpTaskConfig {
+  locale: Locale
+  maxLength: number
+  vocabulary: string[]
+  preprocessor: Preprocessor
+}

--- a/packages/botonic-nlp/tests/tasks/intent-classification/botonic-intent-classifier.test.ts
+++ b/packages/botonic-nlp/tests/tasks/intent-classification/botonic-intent-classifier.test.ts
@@ -10,13 +10,13 @@ import * as toolsHelper from '../../helpers/tools-helper'
 describe('Botonic Intent Classifier', () => {
   const { trainSet, testSet } = toolsHelper.dataset.split()
   const vocabulary = trainSet.extractVocabulary(toolsHelper.preprocessor)
-  const sut = new BotonicIntentClassifier(
-    constantsHelper.LOCALE,
-    constantsHelper.MAX_SEQUENCE_LENGTH,
-    constantsHelper.INTENTS,
-    vocabulary,
-    toolsHelper.preprocessor
-  )
+  const sut = new BotonicIntentClassifier({
+    locale: constantsHelper.LOCALE,
+    maxLength: constantsHelper.MAX_SEQUENCE_LENGTH,
+    vocabulary: vocabulary,
+    intents: constantsHelper.INTENTS,
+    preprocessor: toolsHelper.preprocessor,
+  })
 
   test('Train and Evaluate model', async () => {
     const model = await sut.createModel(

--- a/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
+++ b/packages/botonic-nlp/tests/tasks/ner/botonic-ner.test.ts
@@ -7,13 +7,13 @@ import * as toolsHelper from '../../helpers/tools-helper'
 describe('Botonic NER', () => {
   const { trainSet, testSet } = toolsHelper.dataset.split()
   const vocabulary = trainSet.extractVocabulary(toolsHelper.preprocessor)
-  const sut = new BotonicNer(
-    constantsHelper.LOCALE,
-    constantsHelper.MAX_SEQUENCE_LENGTH,
-    constantsHelper.ENTITIES,
-    vocabulary,
-    toolsHelper.preprocessor
-  )
+  const sut = new BotonicNer({
+    locale: constantsHelper.LOCALE,
+    maxLength: constantsHelper.MAX_SEQUENCE_LENGTH,
+    vocabulary: vocabulary,
+    entities: constantsHelper.ENTITIES,
+    preprocessor: toolsHelper.preprocessor,
+  })
 
   test('Evaluate model', async () => {
     // arrange


### PR DESCRIPTION
## Description
`BotonicIntentClassifier` and `BotonicNer` constructors have been updated. Now they need a config interface to be initialized.

## Context
We want to simplify the main NLP classes by using a configuration interface.  

## Testing

The pull request...

- [x] has unit tests
- [x] has integration tests
