### PR TITLE
Contentful/asset info

### DIFF
--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -144,7 +144,14 @@ export class DummyCMS implements CMS {
   }
 
   asset(id: string, context?: Context): Promise<Asset> {
-    return Promise.resolve(new Asset(id, `name for ${id}`, `http://url.${id}`))
+    return Promise.resolve(
+      new Asset(id, `http://url.${id}`, {
+        name: `${id} title`,
+        fileName: `${id} fileName`,
+        description: `${id} description`,
+        type: `${id} type`,
+      })
+    )
   }
 
   dateRange(id: string, context?: Context): Promise<DateRangeContent> {

--- a/packages/botonic-plugin-contentful/src/cms/contents.ts
+++ b/packages/botonic-plugin-contentful/src/cms/contents.ts
@@ -9,17 +9,25 @@ export enum ButtonStyle {
   QUICK_REPLY = 1,
 }
 
+/**
+ * @param type eg. image/jpeg
+ */
+export interface AssetInfo {
+  readonly name: string
+  readonly fileName?: string
+  readonly type?: string
+  readonly description?: string
+}
+
 /** Not a Content because it cannot have custom fields */
 export class Asset {
   /**
-   * @param type eg. image/jpeg
    * @param details depends on the type. eg the image size
    */
   constructor(
     readonly id: string,
-    readonly name: string,
     readonly url: string,
-    readonly type?: string,
+    readonly info: AssetInfo,
     readonly details?: any
   ) {}
 }

--- a/packages/botonic-plugin-contentful/src/contentful/contents/asset.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/asset.ts
@@ -11,11 +11,16 @@ export class AssetDelivery extends ResourceDelivery {
 
   private fromEntry(asset: Asset) {
     const url = this.urlFromAssetRequired(asset)
+    const fields = asset.fields
     return new cms.Asset(
       asset.sys.id,
-      asset.fields.title,
       url,
-      asset.fields.file.contentType,
+      {
+        fileName: fields.file.fileName,
+        name: fields.title,
+        type: fields.file.contentType,
+        description: fields.description,
+      },
       asset.fields.file.details
     )
   }

--- a/packages/botonic-plugin-contentful/src/contentful/manage/manage-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/manage/manage-contentful.ts
@@ -3,8 +3,9 @@ import { createClient } from 'contentful-management'
 import { ClientAPI } from 'contentful-management/dist/typings/create-contentful-api'
 // eslint-disable-next-line node/no-missing-import
 import { Environment } from 'contentful-management/dist/typings/entities/environment'
+import { Stream } from 'stream'
 
-import { AssetId, ContentId, ContentType } from '../../cms'
+import { AssetId, AssetInfo, ContentId, ContentType } from '../../cms'
 import { ContentFieldType } from '../../manage-cms/fields'
 import { ManageCms } from '../../manage-cms/manage-cms'
 import { ManageContext } from '../../manage-cms/manage-context'
@@ -105,20 +106,10 @@ export class ManageContentful implements ManageCms {
 
   async createAsset(
     context: ManageContext,
-    title: string,
-    fileName: string,
-    contentType: string,
-    file: any,
-    description?: string
+    file: string | ArrayBuffer | Stream,
+    info: AssetInfo
   ): Promise<{ id: string; url?: string }> {
-    return this.manageAsset.createAsset(
-      context,
-      title,
-      fileName,
-      contentType,
-      file,
-      description
-    )
+    return this.manageAsset.createAsset(context, file, info)
   }
 
   async removeAsset(context: ManageContext, assetId: AssetId): Promise<void> {

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms-error.ts
@@ -1,5 +1,8 @@
+import { Stream } from 'stream'
+
 import {
   AssetId,
+  AssetInfo,
   ContentfulExceptionWrapper,
   ContentId,
   ContentType,
@@ -104,14 +107,11 @@ export class ErrorReportingManageCms implements ManageCms {
 
   createAsset(
     context: ManageContext,
-    title: string,
-    fileName: string,
-    contentType: string,
-    file: any,
-    description?: string
+    file: string | ArrayBuffer | Stream,
+    info: AssetInfo
   ): Promise<{ id: string; url?: string }> {
     return this.manageCms
-      .createAsset(context, title, fileName, contentType, file, description)
+      .createAsset(context, file, info)
       .catch(this.handleError('createAsset', undefined, undefined, {}))
   }
 

--- a/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
+++ b/packages/botonic-plugin-contentful/src/manage-cms/manage-cms.ts
@@ -1,4 +1,6 @@
-import { AssetId, ContentId, ContentType } from '../cms'
+import { Stream } from 'stream'
+
+import { AssetId, AssetInfo, ContentId, ContentType } from '../cms'
 import * as nlp from '../nlp'
 import { ContentFieldType } from './fields'
 import { ManageContext } from './manage-context'
@@ -55,13 +57,13 @@ export interface ManageCms {
 
   removeAssetFile(context: ManageContext, assetId: AssetId): Promise<void>
 
+  /**
+   * file: use a string to specify the contents of a text file
+   */
   createAsset(
     context: ManageContext,
-    title: string,
-    fileName: string,
-    contentType: string,
-    file: any,
-    description?: string
+    file: string | ArrayBuffer | Stream,
+    info: AssetInfo
   ): Promise<{ id: string; url?: string }>
 
   removeAsset(context: ManageContext, assetId: AssetId): Promise<void>

--- a/packages/botonic-plugin-contentful/tests/contentful/contentful.helper.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/contentful.helper.ts
@@ -4,11 +4,17 @@ import { CmsInfo } from '../../src/cms/cms-info'
 import { createCms, createCmsInfo } from '../../src/contentful/factories'
 
 export function testSpaceId(): string {
-  return process.env.CONTENTFUL_TEST_SPACE_ID!
+  if (!process.env.CONTENTFUL_TEST_SPACE_ID) {
+    throw new Error('You need to set env var CONTENTFUL_TEST_SPACE_ID')
+  }
+  return process.env.CONTENTFUL_TEST_SPACE_ID
 }
 
 export function testAccessToken(): string {
-  return process.env.CONTENTFUL_TEST_TOKEN!
+  if (!process.env.CONTENTFUL_TEST_TOKEN) {
+    throw new Error('You need to set env var CONTENTFUL_TEST_TOKEN')
+  }
+  return process.env.CONTENTFUL_TEST_TOKEN
 }
 
 export function testContentful(

--- a/packages/botonic-plugin-contentful/tests/contentful/contents/asset.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/contents/asset.test.ts
@@ -1,3 +1,4 @@
+import { Asset } from '../../../src/cms/contents'
 import { testContentful } from '../contentful.helper'
 import { expectImgUrlIs } from './image.test'
 
@@ -7,11 +8,7 @@ test('TEST: contentful asset', async () => {
   const sut = testContentful()
 
   const asset = await sut.asset(TEST_ASSET_ID)
-
-  expectImgUrlIs(asset.url, 'red.jpg')
-  expect(asset.type).toEqual('image/jpeg')
-  expect(asset.id).toEqual(TEST_ASSET_ID)
-  expect(asset.details.size).toEqual(2253)
+  expectRedAsset(asset)
 })
 
 test('TEST: contentful assets', async () => {
@@ -20,4 +17,15 @@ test('TEST: contentful assets', async () => {
   const assets = await sut.assets()
   expect(assets.length).toBeGreaterThanOrEqual(3)
   expect(assets.map(a => a.id)).toContain(TEST_ASSET_ID)
+  expectRedAsset(assets.filter(a => a.id == TEST_ASSET_ID)[0])
 })
+
+function expectRedAsset(asset: Asset) {
+  expectImgUrlIs(asset.url, 'red.jpg')
+  expect(asset.info.description).toEqual('red background')
+  expect(asset.info.name).toEqual('red')
+  expect(asset.info.type).toEqual('image/jpeg')
+  expect(asset.info.fileName).toEqual('red.jpg')
+  expect(asset.id).toEqual(TEST_ASSET_ID)
+  expect(asset.details.size).toEqual(2253)
+}

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-asset.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-asset.test.ts
@@ -28,20 +28,20 @@ describe('ManageContentful assets', () => {
     let assetId: string
     const file = JSON.stringify({ a: rndStr(), b: rndStr() })
     const fileName = rndStr()
+    const info = {
+      description: `${fileName} description`,
+      fileName: `${fileName}.json`,
+      name: fileName,
+      type: 'application/json',
+    }
     try {
       // ACT
-      const { id, url } = await sut.createAsset(
-        context,
-        fileName,
-        `${fileName}.json`,
-        'application/json',
-        file
-      )
+      const { id, url } = await sut.createAsset(context, file, info)
       assetId = id
       await repeatWithBackoff(async () => {
         const newContent = await contentful.asset(assetId, context)
         expect(newContent.id).toEqual(assetId)
-        expect(newContent.name).toEqual(fileName)
+        expect(newContent.info).toEqual(info)
         expect(newContent.url).toEqual(`https:${url}`)
       })
     } finally {

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.helper.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.helper.ts
@@ -4,10 +4,13 @@ import { ManageContext } from '../../../src/manage-cms'
 import { testContentfulOptions } from '../contentful.helper'
 
 export function testManageContentful(options: Partial<ContentfulOptions> = {}) {
+  if (!process.env.CONTENTFUL_TEST_MANAGE_TOKEN) {
+    throw new Error('You need to set env var CONTENTFUL_TEST_MANAGE_TOKEN')
+  }
   return createManageCms(
     testContentfulOptions({
       ...options,
-      accessToken: process.env.CONTENTFUL_TEST_MANAGE_TOKEN!,
+      accessToken: process.env.CONTENTFUL_TEST_MANAGE_TOKEN,
     })
   )
 }

--- a/packages/botonic-plugin-contentful/tests/tools/l10n/import-updater.test.ts
+++ b/packages/botonic-plugin-contentful/tests/tools/l10n/import-updater.test.ts
@@ -1,7 +1,8 @@
+import { Stream } from 'stream'
 import { anything, capture, instance, mock, when } from 'ts-mockito'
 
 import * as cms from '../../../src/cms'
-import { AssetId, ContentId, ContentType } from '../../../src/cms'
+import { AssetId, AssetInfo, ContentId, ContentType } from '../../../src/cms'
 import {
   ContentFieldType,
   ManageCms,
@@ -215,10 +216,8 @@ test('TEST: ContentUpdater', async () => {
 
     createAsset(
       context: ManageContext,
-      title: string,
-      fileName: string,
-      contentType: string,
-      file: any
+      file: string | ArrayBuffer | Stream,
+      info: AssetInfo
     ): Promise<{ id: string; url?: string }> {
       fail("shouldn't be called")
     }


### PR DESCRIPTION
Depends on #1571. 

## Description

Create a new AssetInfo interface to reduce the number of parameters when creating an Asset (both in delivery and management areas)

## Context

createAsset had too many fields, which made code error prone and difficult to read.

## Approach taken / Explain the design

now both Asset and createAsset use AssetInfo interface.
createAsset title argument has been renamed to "name" to be consistent with Content name field.

## To document / Usage example

:warning:  Breaking change: Asset fields name and type are now available under Asset.info field

## Testing

The pull request...

- has integration tests
