### PR TITLE
chore: set codecov github action version to v1 #PLA-499

### DIFF
--- a/.github/workflows/botonic-cli-tests.yml
+++ b/.github/workflows/botonic-cli-tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: (cd ./packages/$PACKAGE && npm run lint_ci)
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1.4.1
+        uses: codecov/codecov-action@v1
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-core-tests.yml
+++ b/.github/workflows/botonic-core-tests.yml
@@ -40,7 +40,7 @@ jobs:
       run: scripts/qa/lint-d-ts.sh packages/$PACKAGE
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1.4.1
+      uses: codecov/codecov-action@v1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-nlu-tests.yml
+++ b/.github/workflows/botonic-nlu-tests.yml
@@ -1,5 +1,5 @@
 name: Botonic nlu tests
- 
+
 on:
   push:
     paths:
@@ -7,7 +7,7 @@ on:
       - 'packages/*'
       - 'packages/botonic-nlu/**'
       - '.github/workflows/botonic-nlu-tests.yml'
- 
+
 jobs:
   botonic-plugin-nlu-tests:
     name: Botonic nlu tests
@@ -15,7 +15,7 @@ jobs:
     env:
       PACKAGE: botonic-nlu
     steps:
-    - name: Checking out to current branch 
+    - name: Checking out to current branch
       uses: actions/checkout@v2
     - name: Setting up node
       uses: actions/setup-node@v2-beta
@@ -28,23 +28,23 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - name: Install dev dependencies 
+    - name: Install dev dependencies
       run: (cd ./packages/$PACKAGE && npm install -D)
-    - name: Build botonic-nlu 
+    - name: Build botonic-nlu
       run: (cd ./packages/$PACKAGE && npm run build)
-      
-    - name: Run tests 
+
+    - name: Run tests
       run: (cd ./packages/$PACKAGE && npm run test_ci)
-    
+
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1.6
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         files: ./packages/${{env.PACKAGE}}/junit.xml
-    
+
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1.4.1
+      uses: codecov/codecov-action@v1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -53,5 +53,5 @@ jobs:
         name: ${{env.PACKAGE}}
         env_vars: ${{env.PACKAGE}}
 
-    - name: Verify lint botonic-nlu 
+    - name: Verify lint botonic-nlu
       run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-contentful-tests.yml
+++ b/.github/workflows/botonic-plugin-contentful-tests.yml
@@ -42,7 +42,7 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1.4.1
+      uses: codecov/codecov-action@v1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-dialogflow-tests.yml
+++ b/.github/workflows/botonic-plugin-dialogflow-tests.yml
@@ -1,5 +1,5 @@
 name: Botonic plugin-dialogflow tests
- 
+
 on:
   push:
     paths:
@@ -7,7 +7,7 @@ on:
       - 'packages/*'
       - 'packages/botonic-plugin-dialogflow/**'
       - '.github/workflows/botonic-plugin-dialogflow-tests.yml'
- 
+
 jobs:
   botonic-plugin-dialogflow:
     name: Botonic plugin-dialogflow tests
@@ -15,7 +15,7 @@ jobs:
     env:
       PACKAGE: botonic-plugin-dialogflow
     steps:
-    - name: Checking out to current branch 
+    - name: Checking out to current branch
       uses: actions/checkout@v2
     - name: Setting up node
       uses: actions/setup-node@v2-beta
@@ -28,23 +28,23 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - name: Install dev dependencies 
+    - name: Install dev dependencies
       run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Build botonic-plugin-dialogflow
       run: (cd ./packages/$PACKAGE && npm run build)
-      
-    - name: Run tests 
+
+    - name: Run tests
       run: (cd ./packages/$PACKAGE && npm run test_ci)
-    
+
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1.9
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         files: ./packages/${{env.PACKAGE}}/junit.xml
-    
+
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1.4.1
+      uses: codecov/codecov-action@v1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -54,5 +54,5 @@ jobs:
         env_vars: ${{env.PACKAGE}}
         network_filter: packages/${{env.PACKAGE}}/
 
-    - name: Verify lint botonic-dialogflow 
+    - name: Verify lint botonic-dialogflow
       run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-plugin-dynamo-tests.yml
+++ b/.github/workflows/botonic-plugin-dynamo-tests.yml
@@ -41,7 +41,7 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1.4.1
+      uses: codecov/codecov-action@v1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-intent-classification-tests.yml
+++ b/.github/workflows/botonic-plugin-intent-classification-tests.yml
@@ -44,7 +44,7 @@ jobs:
           files: ./packages/${{env.PACKAGE}}/junit.xml
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1.4.1
+        uses: codecov/codecov-action@v1
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -1,5 +1,5 @@
 name: Botonic plugin-nlu tests
- 
+
 on:
   push:
     paths:
@@ -7,7 +7,7 @@ on:
       - 'packages/*'
       - 'packages/botonic-plugin-nlu/**'
       - '.github/workflows/botonic-plugin-nlu-tests.yml'
- 
+
 jobs:
   botonic-plugin-nlu-tests:
     name: Botonic plugin-nlu tests
@@ -15,7 +15,7 @@ jobs:
     env:
       PACKAGE: botonic-plugin-nlu
     steps:
-    - name: Checking out to current branch 
+    - name: Checking out to current branch
       uses: actions/checkout@v2
     - name: Setting up node
       uses: actions/setup-node@v2-beta
@@ -28,23 +28,23 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-    - name: Install dev dependencies 
+    - name: Install dev dependencies
       run: (cd ./packages/$PACKAGE && npm install -D)
     - name: Build botonic-plugin-nlu
       run: (cd ./packages/$PACKAGE && npm run build)
-      
-    - name: Run tests 
+
+    - name: Run tests
       run: (cd ./packages/$PACKAGE && npm run test_ci)
-    
+
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1.9
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         files: ./packages/${{env.PACKAGE}}/junit.xml
-    
+
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1.4.1
+      uses: codecov/codecov-action@v1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -53,5 +53,5 @@ jobs:
         name: ${{env.PACKAGE}}
         env_vars: ${{env.PACKAGE}}
 
-    - name: Verify lint botonic-nlu 
+    - name: Verify lint botonic-nlu
       run: (cd ./packages/$PACKAGE && npm run lint_ci)

--- a/.github/workflows/botonic-react-tests.yml
+++ b/.github/workflows/botonic-react-tests.yml
@@ -38,9 +38,9 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
     - name: Verify index.d.ts
       run: scripts/qa/lint-d-ts.sh ./packages/$PACKAGE
-    
+
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1.4.1
+      uses: codecov/codecov-action@v1
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description
Configure codecov action to use latest @v1 version available as https://github.com/codecov/codecov-action#usage recommends
 
## Context
After experimenting some security issues and following suggestion by @dpinol, we will use codecov's latest @v1 version. 

## Approach taken / Explain the design


## Checklist

The pull request...

- [x] has the Linear issue number in the title so the issue and the PR are linked
- [ ] adds the entry in the CHANGELOG.md (with the link to the Linear issue)
  - no because the modified file is only used in ci
- [ ] has tests
  - has unit tests
  - has integration tests

- [ ] creates new component and includes specific selectors to help with integration tests
