### PR TITLE
Contentful/Make acronyms agnostic to dots #CUS-271

### DIFF
--- a/packages/botonic-plugin-contentful/src/nlp/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/keywords.ts
@@ -7,6 +7,7 @@ import { SimilarWordFinder, SimilarWordResult } from './similar-words'
  * TODO consider storing as a list of new Token class instances', each with a raw and stem fields
  */
 export class Keyword {
+  /** Lowercase raw keyword */
   readonly raw: string
   /**
    * If hasOnlyStopWords == false, the stems of the non stopWords (eg. buy a shirt => buy shirt)

--- a/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
@@ -70,6 +70,7 @@ export class NormalizedUtterance {
    * @param onlyStopWords: true iff all tokens are stop words
    */
   constructor(
+    /** raw is actually lowercased and trimmed*/
     readonly raw: string,
     readonly words: Word[],
     private readonly onlyStopWords = false

--- a/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
+++ b/packages/botonic-plugin-contentful/src/nlp/normalizer.ts
@@ -3,10 +3,12 @@ import { equalArrays } from '../util/arrays'
 import { Locale } from './locales'
 import { stemmerFor } from './stemmer'
 import {
+  DEFAULT_SEPARATORS,
   DEFAULT_SEPARATORS_REGEX,
   stopWordsFor,
   tokenizerPerLocale,
 } from './tokens'
+import { replaceAll } from './util/strings'
 
 /**
  * Both tokens and stem will be converted to the <code>stem</code>
@@ -35,7 +37,7 @@ export class StemmingBlackList {
 
 export class Word {
   /**
-   * @param token lowercase, with i18n characters converted to ascii
+   * @param token lowercase, with i18n characters converted to ascii and after executing Preprocessor
    * @param stem lowercase, stemmed. Same as token for stopwords
    */
   constructor(
@@ -91,17 +93,94 @@ export class NormalizedUtterance {
   }
 }
 
+export abstract class Preprocessor {
+  abstract preprocess(txt: string): string
+}
+
+export class NopPreprocessor {
+  preprocess(txt: string): string {
+    return txt
+  }
+}
+
+/**
+ * Removes dots within acronyms, even if missing last dot,
+ * or immediately followed by a different separator
+ */
+export class AcronymPreprocessor implements Preprocessor {
+  private static readonly DOT = '.'
+  private SEPS_NO_DOT: string
+  constructor(separators: string) {
+    this.SEPS_NO_DOT = separators.replace(AcronymPreprocessor.DOT, '')
+  }
+
+  preprocess(txt: string): string {
+    if (!txt.includes(AcronymPreprocessor.DOT)) return txt
+    const wordsAndSeparators = this.splitWordsAndSeparators(txt)
+    txt = ''
+    for (const wOrSep of wordsAndSeparators) {
+      const isSeparator = wOrSep.includes(this.SEPS_NO_DOT)
+      if (!isSeparator) {
+        txt = txt + this.preprocessWord(wOrSep)
+      } else {
+        txt = txt + wOrSep
+      }
+    }
+    return txt
+  }
+
+  private splitWordsAndSeparators(txt: string): string[] {
+    let word = ''
+    const ret: string[] = []
+    const pushWord = () => {
+      if (word) {
+        ret.push(word)
+        word = ''
+      }
+    }
+    for (const l of txt) {
+      if (this.SEPS_NO_DOT.includes(l)) {
+        pushWord()
+        ret.push(l)
+      } else {
+        word += l
+      }
+    }
+    pushWord()
+    return ret
+  }
+
+  private preprocessWord(w: string): string {
+    if (w.length <= 2) {
+      return w
+    }
+    let mustBeDot = false
+    for (const l of w) {
+      const isDot = l == AcronymPreprocessor.DOT
+      if (isDot !== mustBeDot) {
+        return w
+      }
+      mustBeDot = !mustBeDot
+    }
+    return replaceAll(w, AcronymPreprocessor.DOT, '')
+  }
+}
+
 export class Normalizer {
   private stopWordsPerLocale: DynamicSingletonMap<string[]>
   private stemmingBlackListPerLocale: DynamicSingletonMap<StemmingBlackList[]>
 
+  /**
+   * preprocessor: Applied before tokenizing. Applied also to separators and stem words
+   */
   constructor(
     stemmingBlackListPerLocale: {
       [locale: string]: StemmingBlackList[]
     } = {},
     stopWordsForLocale = stopWordsFor,
     private readonly tokenizer = tokenizerPerLocale,
-    private readonly separatorsRegex = DEFAULT_SEPARATORS_REGEX
+    private readonly separatorsRegex = DEFAULT_SEPARATORS_REGEX,
+    private readonly preprocessor = new AcronymPreprocessor(DEFAULT_SEPARATORS)
   ) {
     this.stopWordsPerLocale = new DynamicSingletonMap<string[]>(locale =>
       stopWordsForLocale(locale).map(w => this.normalizeWord(locale, w))
@@ -119,9 +198,10 @@ export class Normalizer {
    * @throws EmptyTextException if the text is empty or only contains separators
    */
   normalize(locale: Locale, raw: string): NormalizedUtterance {
-    let txt = raw.replace(this.separatorsRegex, ' ')
-    txt = txt.trim().toLowerCase() // TODO use preprocess without normalization? move to NormalizedUtterance constructor?
-    if (!txt) {
+    raw = raw.trim().toLowerCase() // TODO use preprocess without normalization? move to NormalizedUtterance constructor?
+    let txt = this.preprocessor.preprocess(raw)
+    txt = txt.replace(this.separatorsRegex, ' ')
+    if (!txt.trim()) {
       throw new EmptyTextException(raw)
     }
 
@@ -146,13 +226,12 @@ export class Normalizer {
       const tokenStems = stemmer.stem([token])
       words = words.concat(tokenStems.map(stem => new Word(token, stem)))
     }
-    return new NormalizedUtterance(txt, words, numStopWords == tokens.length)
+    return new NormalizedUtterance(raw, words, numStopWords == tokens.length)
   }
 
-  private normalizeWord(locale: Locale, stopWord: string): string {
-    return this.tokenizer(locale)
-      .tokenize(stopWord.toLowerCase(), true)
-      .join(' ')
+  private normalizeWord(locale: Locale, word: string): string {
+    word = this.preprocessor.preprocess(word)
+    return this.tokenizer(locale).tokenize(word.toLowerCase(), true).join(' ')
   }
 
   private getBlackListStem(locale: Locale, word: string): string | undefined {

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
@@ -100,9 +100,6 @@ describe('ManageContentful fields', () => {
   }
 
   async function restoreValue(manage: ManageCms) {
-    contentful.text(TEST_CONTENT_ID.id, {
-      locale: SPANISH,
-    })
     await manage.updateFields(
       ctxt({ locale: SPANISH, allowOverwrites: true }),
       TEST_CONTENT_ID,

--- a/packages/botonic-plugin-contentful/tests/nlp/keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/keywords.test.ts
@@ -143,6 +143,11 @@ test.each<any>([
 )
 
 test.each<any>([
+  // acronyms
+  ['o.k.', { OK: ['o.k.'] }, ['OK']],
+  ['ok', { OK: ['o.k.'] }, ['OK']],
+  ['o.k.', { OK: ['ok'] }, ['OK']],
+
   // found with multiword keyword
   ['k w A', { A: ['k w A', 'kwB'] }, ['A']],
 

--- a/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
@@ -1,4 +1,6 @@
 import {
+  AcronymPreprocessor,
+  DEFAULT_SEPARATORS,
   DEFAULT_STOP_WORDS,
   EmptyTextException,
   Locale,
@@ -8,6 +10,28 @@ import {
   SUPPORTED_LOCALES,
   Word,
 } from '../../src/nlp'
+
+test.each<any>([
+  //acronyms
+  ['o.k.', 'ok'],
+  ['o.k', 'ok'],
+  ['o.k ', 'ok '],
+  ['o.k ', 'ok '],
+  ['U.S.A', 'USA'],
+  ['o.k, vale', 'ok, vale'],
+  //not acronyms
+  ['.a.', '.a.'],
+  ['U..A', 'U..A'],
+  ['a. opcion', 'a. opcion'],
+  ['no separators', 'no separators'],
+  ['final dot.', 'final dot.'],
+])(
+  'TEST: AcronymPreprocessor removes acronyms (%s=>%s)',
+  (from: string, to: string) => {
+    const sut = new AcronymPreprocessor(DEFAULT_SEPARATORS)
+    expect(sut.preprocess(from)).toEqual(to)
+  }
+)
 
 test.each<any>(SUPPORTED_LOCALES)(
   'TEST: consecutive separators %s are removed',
@@ -255,6 +279,14 @@ test('TEST: Normalizer does not stem blacklisted tokens', () => {
     'perro',
     'perro',
   ])
+})
+
+test.each<any>([
+  ['o.k.', new NormalizedUtterance('o.k.', [new Word('ok', 'ok')])],
+])('TEST: sut.normalize acronyms', (from: string, to: string) => {
+  const loc = 'es'
+  const sut = new Normalizer()
+  expect(sut.normalize(loc, from)).toEqual(to)
 })
 
 function replaceI18nChars(word: string, locale: string): string {

--- a/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
+++ b/packages/botonic-plugin-contentful/tests/nlp/normalizer.test.ts
@@ -20,6 +20,7 @@ test.each<any>([
   ['U.S.A', 'USA'],
   ['o.k, vale', 'ok, vale'],
   //not acronyms
+  ['longerThan1Char.k', 'longerThan1Char.k'],
   ['.a.', '.a.'],
   ['U..A', 'U..A'],
   ['a. opcion', 'a. opcion'],


### PR DESCRIPTION
## Description

Now Normalizer will remove the dots only when an acronym is detected.

## Context

Tokenizer splits acronyms in several words and it makes difficult to match "ok" with "o.k"

## Approach taken / Explain the design

 An AcronymPreprocessor is now executed as first step of our Normalizer so that we do this conversion. It will also be applied to stopwords, keywords,...
 ```
 //acronyms
  ['o.k.', 'ok'],
  ['o.k', 'ok'],
  ['o.k ', 'ok '],
  ['o.k ', 'ok '],
  ['U.S.A', 'USA'],
  ['o.k, vale', 'ok, vale'],
  //not acronyms
  ['.a.', '.a.'],
  ['U..A', 'U..A'],
  ['a. opcion', 'a. opcion'],
  ['no separators', 'no separators'],
  ['final dot.', 'final dot.'],

```
## To document / Usage example

Now Normalizer will remove the dots only when an acronym is detected. Works like "o.k.", "o.k" and "ok" will be normalized to the same stem.

## Testing

- has unit tests
