### PR TITLE
feat(nlp): main points to lib/index.js

### DIFF
--- a/packages/botonic-nlp/package.json
+++ b/packages/botonic-nlp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@botonic/nlp",
   "version": "0.19.0-alpha.9",
+  "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
     "build": "rm -rf lib && ../../node_modules/.bin/tsc",

--- a/packages/botonic-nlp/package.json
+++ b/packages/botonic-nlp/package.json
@@ -3,6 +3,12 @@
   "version": "0.19.0-alpha.9",
   "main": "lib/index.js",
   "license": "MIT",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib/**",
+    "src/**",
+    "README.md"
+  ],
   "scripts": {
     "build": "rm -rf lib && ../../node_modules/.bin/tsc",
     "lint": "npm run lint_core -- --fix",


### PR DESCRIPTION
## Description
NLP package main points to lib/index.js so we can use it like:

```typescript
import { Preprocessor, Dataset, BotonicNer } from '@botonic/nlp'
```