### PR TITLE
Core & React: Fix types

### DIFF
--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
-  "types": "./index.d.ts",
+  "types": "./src/types",
   "scripts": {
     "test": "../../node_modules/.bin/jest --coverage",
     "prepare": "node ../../preinstall.js",
@@ -50,6 +50,5 @@
     "conversational-app",
     "conversational-ui",
     "javascript"
-  ],
-  "types": "./src/types"
+  ]
 }

--- a/packages/botonic-core/src/types/index.d.ts
+++ b/packages/botonic-core/src/types/index.d.ts
@@ -167,6 +167,7 @@ export interface Route {
   request?: RequestMatcher
   session?: SessionMatcher
   text?: StringMatcher
+  data?: StringMatcher
   type?: StringMatcher
 }
 

--- a/packages/botonic-react/src/components/index.d.ts
+++ b/packages/botonic-react/src/components/index.d.ts
@@ -50,6 +50,9 @@ export interface ButtonProps {
   url?: string
   webview?: Webview
   onClick?: () => void
+  autodisable?: boolean
+  disabled?: boolean
+  disabledstyle?: boolean
 }
 
 export const Button: React.FunctionComponent<ButtonProps>

--- a/packages/botonic-react/src/index.d.ts
+++ b/packages/botonic-react/src/index.d.ts
@@ -195,7 +195,7 @@ export class WebchatApp {
     appId: string
     visibility: () => boolean
   }): Promise<boolean>
-  setTyping(typing: number): void
+  setTyping(enable: boolean): void
   toggle(): void
   toggleCoverComponent(): void
   updateMessageInfo(msgId: string, messageInfo: MessageInfo): void
@@ -216,10 +216,7 @@ export interface WebchatContextProps {
   updateLatestInput: (input: core.Input) => void
   closeWebview: () => void
   toggleWebchat: () => void
-  getThemeProperty: (
-    property: string,
-    defaultValue?: string
-  ) => string | undefined
+  getThemeProperty: (property: string, defaultValue?: string) => any
   resolveCase: () => void
   theme: ThemeProps
   webchatState: WebchatState

--- a/packages/botonic-react/src/index.d.ts
+++ b/packages/botonic-react/src/index.d.ts
@@ -20,8 +20,8 @@ export interface BotResponse extends core.BotRequest {
 }
 
 export interface Route extends core.Route {
-  action?: typeof React.Component
-  retryAction?: typeof React.Component
+  action?: React.ComponentType<any>
+  retryAction?: React.ComponentType<any>
 }
 type Routes = core.Routes<Route>
 


### PR DESCRIPTION
## Description
Fix types:
- @botonic/core:
  - Add `data` as a possible matcher attribute in `Route` interface.
- @botonic/react:
  - Add autodisable props in `ButtonProps` interface.
  - Fix `setTyping` argument type and `getThemeProperty` returned value type.
  - Fix type for `action` and `retryAction` in Route to allow both class and functional components in routes.

Also, remove duplicated entry (`types`) in `package.json` file.

## Context
Improve typings

## Approach taken / Explain the design
- @botonic/core:
  - Since [all Input attributes](https://github.com/hubtype/botonic/blob/master/packages/botonic-core/src/router.js#L237) can be set as matchers, `data` was the one missing.
- @botonic/react:
  - Since the theme props can be of different types, I've changed the type of the returned value of `getThemeProperty` to `any`.

## To document / Usage example

## Testing

The pull request has no tests.