### PR TITLE
Upgrade typescript from 4.2.x to 4.3.x

### DIFF
--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -49,6 +49,6 @@
     "@types/markdown-it": "^10.0.3",
     "@types/node": "^14.14.6",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "devDependencies": {
     "@types/jest": "^26.0.23",
-    "@types/node": "^15.3.0",
+    "@types/node": "^15.12.1",
     "@types/rimraf": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
@@ -21,7 +21,7 @@
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "eslint_d": "^10.1.2",
+    "eslint_d": "^10.1.3",
     "jest": "^26.6.3",
     "jest-each": "^26.6.2",
     "jest-expect-message": "^1.0.2",
@@ -32,7 +32,7 @@
     "ts-mockito": "^2.6.1",
     "ts-node": "^9.1.1",
     "tslib": "^2.2.0",
-    "typescript": "^4.2.4"
+    "typescript": "^4.3.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/packages/botonic-dx/package.json
+++ b/packages/botonic-dx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx",
-  "version": "0.19.0-alpha.16",
+  "version": "0.19.0-alpha.17",
   "description": "Continuous integration for botonic packages",
   "scripts": {},
   "author": "",
@@ -45,7 +45,7 @@
     "ts-mockito": "^2.6.1",
     "ts-node": "^9.1.1",
     "tslib": "^2.2.0",
-    "typescript": "^4.2.4"
+    "typescript": "^4.3.2"
   },
   "engines": {
     "npm": ">=17.13.0"

--- a/packages/botonic-plugin-nlu/package-lock.json
+++ b/packages/botonic-plugin-nlu/package-lock.json
@@ -5094,9 +5094,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw=="
     },
     "underscore": {
       "version": "1.13.1",

--- a/packages/botonic-plugin-nlu/package.json
+++ b/packages/botonic-plugin-nlu/package.json
@@ -25,7 +25,7 @@
     "langs": "^2.0.0",
     "node-fetch": "^2.6.1",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.3"
+    "typescript": "^4.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",


### PR DESCRIPTION
* typescript 4.3 introduces a new [check](https://devblogs.microsoft.com/typescript/announcing-typescript-4-3-rc/#always-truthy-promise-checks) to detect missing awaits 
