### PR TITLE
Creation of botonic-plugin-google-translate #BOT-430

### DIFF
--- a/packages/botonic-plugin-google-translate/README.md
+++ b/packages/botonic-plugin-google-translate/README.md
@@ -1,0 +1,65 @@
+# Botonic Plugin Google Translate
+
+## What does this plugin do?
+This plugin uses [Google Cloud Translation API](https://cloud.google.com/translate) to detect the language of the user input text.
+
+## Setup
+
+### Install the plugin
+To install this plugin, you only need to execute the following command:
+
+```bash
+npm i @botonic/plugin-google-translate 
+```
+
+### Enable Cloud Translation API
+Before using this plugin, you need a project that has the Cloud Translation API enabled and its credentials. See [Cloud Translation Set Up Guide](https://cloud.google.com/translate/docs/setup).
+
+### Add the plugin
+
+To being able of using this plugin to detect the language of the user input text, you need to have it installed and added to your plugins.
+
+> **Note:** This is case-sensitive so make sure to correctly define your credentials.
+
+```js
+export const plugins = [
+    {
+        id: 'google-translate',
+        resolve: require('@botonic/plugin-google-translate'),
+        options: {
+            credentials: {
+                privateKeyId: '',
+                privateKey: '',
+                projectId: '',
+                clientEmail: '',
+            },
+        },
+    },
+]
+```
+
+You can also add a **whitelist** parameter to filter the detected languages:
+
+```js
+export const plugins = [
+    {
+        id: 'google-translate',
+        resolve: require('@botonic/plugin-google-translate'),
+        options: {
+            whitelist: ['en', 'es', 'it'],
+            credentials: {
+                privateKeyId: '',
+                privateKey: '',
+                projectId: '',
+                clientEmail: '',
+            },
+        },
+    },
+]
+```
+
+If this whitelist is defined and none of the specified languages match the detected ones, `'en'` will be set as default.
+
+## Use
+
+If you want to check the language of the user input text, you only need to take a look at the `__locale` variable of the current session.

--- a/packages/botonic-plugin-google-translate/jest.config.js
+++ b/packages/botonic-plugin-google-translate/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+}

--- a/packages/botonic-plugin-google-translate/package-lock.json
+++ b/packages/botonic-plugin-google-translate/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.5.tgz",
+      "integrity": "sha512-121rumjddw9c3NCQ55KGkyE1h/nzWhU/owjhw0l4mQrkzz4x9SGS1X8gFLraHwX7td3Yo4QTL+qj0NcIzN87BA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -20,12 +20,6 @@
         "axios": "^0.21.0",
         "pusher-js": "^5.1.1"
       }
-    },
-    "@types/webgl2": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.6.tgz",
-      "integrity": "sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ==",
-      "dev": true
     },
     "axios": {
       "version": "0.21.1",

--- a/packages/botonic-plugin-google-translate/package-lock.json
+++ b/packages/botonic-plugin-google-translate/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "@botonic/plugin-google-translate",
+  "version": "0.19.0-alpha.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/runtime": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@botonic/core": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.18.2.tgz",
+      "integrity": "sha512-7PczrGmOtV2YHbMBWSf9GScNc6rHj5j5Cds2cY9xqrzvGWq+iZAPfjVQLGbhSY8Y3UafdVi0t924G0CY0cIdYQ==",
+      "requires": {
+        "axios": "^0.21.0",
+        "pusher-js": "^5.1.1"
+      }
+    },
+    "@types/webgl2": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.6.tgz",
+      "integrity": "sha512-50GQhDVTq/herLMiqSQkdtRu+d5q/cWHn4VvKJtrj4DJAjo1MNkWYa2MA41BaBO1q1HgsUjuQvEOk0QHvlnAaQ==",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+    },
+    "jsrsasign": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.3.0.tgz",
+      "integrity": "sha512-irDIKKFW++EAELgP3fjFi5/Fn0XEyfuQTTgpbeFwCGkV6tRIYZl3uraRea2HTXWCstcSZuDaCbdAhU1n+075Bg=="
+    },
+    "pusher-js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-5.1.1.tgz",
+      "integrity": "sha512-f2tdoA7NvJQkU8Y/iCH25ZSNGxnwCXrVbwos38isX6gnjsSZ1aksWvyZddm2N0sHJWyl+oPBz/MzU5cevVDyEQ=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    }
+  }
+}

--- a/packages/botonic-plugin-google-translate/package.json
+++ b/packages/botonic-plugin-google-translate/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@botonic/plugin-google-translate",
+  "version": "0.19.0-alpha.0",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "scripts": {
+    "clean_install": "npm i && npm run-script build",
+    "cloc": "../../scripts/qa/cloc-package.sh .",
+    "build": "rm -rf lib && ../../node_modules/.bin/tsc",
+    "test": "../../node_modules/.bin/jest",
+    "test_ci": "../../node_modules/.bin/jest --coverage --ci --reporters=default --reporters=jest-junit",
+    "prepare": "node ../../preinstall.js",
+    "lint": "npm run lint_core -- --fix",
+    "lint_ci": "npm run lint_core -- -c ../.eslintrc_slow.js",
+    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.14.0",
+    "@botonic/core": "~0.18.2",
+    "axios": "^0.21.1",
+    "jsrsasign": "^10.3.0"
+  },
+  "devDependencies": {
+    "@types/webgl2": "0.0.6"
+  },
+  "resolutions": {
+    "@types/webgl2": "0.0.6"
+  },
+  "keywords": [
+    "bot-framework",
+    "google-colab",
+    "translate",
+    "language-detection",
+    "nlp",
+    "typescript"
+  ]
+}

--- a/packages/botonic-plugin-google-translate/package.json
+++ b/packages/botonic-plugin-google-translate/package.json
@@ -20,9 +20,6 @@
     "axios": "^0.21.1",
     "jsrsasign": "^10.3.0"
   },
-  "devDependencies": {
-    "@types/webgl2": "0.0.6"
-  },
   "resolutions": {
     "@types/webgl2": "0.0.6"
   },

--- a/packages/botonic-plugin-google-translate/src/access-token.ts
+++ b/packages/botonic-plugin-google-translate/src/access-token.ts
@@ -1,0 +1,38 @@
+import { KJUR } from 'jsrsasign'
+
+import { Credentials } from './options'
+
+export class AccessToken {
+  value: string
+  private readonly header
+  private readonly payload
+
+  constructor(private readonly credentials: Credentials) {
+    this.header = JSON.stringify({
+      alg: 'RS256',
+      typ: 'JWT',
+      kid: credentials.privateKeyId,
+    })
+    this.payload = JSON.stringify({
+      iss: credentials.clientEmail,
+      sub: credentials.clientEmail,
+      iat: KJUR.jws.IntDate.get('now'),
+      exp: KJUR.jws.IntDate.get('now + 1hour'),
+      aud: 'https://translation.googleapis.com/',
+    })
+    this.value = this.generate()
+  }
+
+  refresh(): void {
+    this.value = this.generate()
+  }
+
+  private generate(): string {
+    return KJUR.jws.JWS.sign(
+      'RS256',
+      this.header,
+      this.payload,
+      this.credentials.privateKey
+    )
+  }
+}

--- a/packages/botonic-plugin-google-translate/src/access-token.ts
+++ b/packages/botonic-plugin-google-translate/src/access-token.ts
@@ -4,8 +4,8 @@ import { Credentials } from './options'
 
 export class AccessToken {
   value: string
-  private readonly header
-  private readonly payload
+  private readonly header: string
+  private readonly payload: string
 
   constructor(private readonly credentials: Credentials) {
     this.header = JSON.stringify({

--- a/packages/botonic-plugin-google-translate/src/google-translate-api-service.ts
+++ b/packages/botonic-plugin-google-translate/src/google-translate-api-service.ts
@@ -1,0 +1,40 @@
+import axios, { AxiosResponse } from 'axios'
+
+import { AccessToken } from './access-token'
+
+export interface LanguageDetection {
+  languageCode: string
+  confidence: number
+}
+
+export class GoogleTranslateApiService {
+  constructor(
+    private readonly accessToken: AccessToken,
+    private readonly projectId: string
+  ) {}
+
+  async detectLanguage(text: string): Promise<LanguageDetection[]> {
+    try {
+      const res = await this.detectLanguageQuery(text)
+      return res.data.languages
+    } catch (e) {
+      this.accessToken.refresh()
+      const res = await this.detectLanguageQuery(text)
+      return res.data.languages
+    }
+  }
+
+  private async detectLanguageQuery(text: string): Promise<AxiosResponse> {
+    return await axios({
+      method: 'post',
+      url: `https://translation.googleapis.com/v3/projects/${this.projectId}/locations/global:detectLanguage`,
+      headers: {
+        Authorization: `Bearer ${this.accessToken.value}`,
+        'Content-Type': 'application/json',
+      },
+      data: {
+        content: text,
+      },
+    })
+  }
+}

--- a/packages/botonic-plugin-google-translate/src/index.ts
+++ b/packages/botonic-plugin-google-translate/src/index.ts
@@ -1,0 +1,36 @@
+import type { Plugin, PluginPostRequest, PluginPreRequest } from '@botonic/core'
+import { INPUT } from '@botonic/core'
+
+import { AccessToken } from './access-token'
+import { GoogleTranslateApiService } from './google-translate-api-service'
+import { LanguageDetector } from './language-detector'
+import { PluginOptions } from './options'
+
+export default class BotonicPluginGoogleTranslate implements Plugin {
+  private readonly service: GoogleTranslateApiService
+  private readonly languageDetector: LanguageDetector
+
+  constructor(readonly options: PluginOptions) {
+    this.service = new GoogleTranslateApiService(
+      new AccessToken(this.options.credentials),
+      this.options.credentials.projectId
+    )
+    this.languageDetector = new LanguageDetector(
+      this.service,
+      this.options.whitelist || []
+    )
+  }
+
+  async pre(request: PluginPreRequest): Promise<void> {
+    try {
+      if (request.input.type == INPUT.TEXT && !request.input.payload) {
+        const text = request.input.data
+        request.session.__locale = await this.languageDetector.detect(text)
+      }
+    } catch (e) {
+      console.log('Cannot use Google Cloud Translate API', e)
+    }
+  }
+
+  post(request: PluginPostRequest): void {}
+}

--- a/packages/botonic-plugin-google-translate/src/index.ts
+++ b/packages/botonic-plugin-google-translate/src/index.ts
@@ -25,7 +25,7 @@ export default class BotonicPluginGoogleTranslate implements Plugin {
     try {
       if (request.input.type == INPUT.TEXT && !request.input.payload) {
         const text = request.input.data
-        request.session.__locale = await this.languageDetector.detect(text)
+        request.input.language = await this.languageDetector.detect(text)
       }
     } catch (e) {
       console.error(

--- a/packages/botonic-plugin-google-translate/src/index.ts
+++ b/packages/botonic-plugin-google-translate/src/index.ts
@@ -28,7 +28,10 @@ export default class BotonicPluginGoogleTranslate implements Plugin {
         request.session.__locale = await this.languageDetector.detect(text)
       }
     } catch (e) {
-      console.log('Cannot use Google Cloud Translate API', e)
+      console.error(
+        'Error detecting language with Google Cloud Translate API',
+        e
+      )
     }
   }
 

--- a/packages/botonic-plugin-google-translate/src/language-detector.ts
+++ b/packages/botonic-plugin-google-translate/src/language-detector.ts
@@ -1,0 +1,40 @@
+import {
+  GoogleTranslateApiService,
+  LanguageDetection,
+} from './google-translate-api-service'
+
+export class LanguageDetector {
+  constructor(
+    private readonly service: GoogleTranslateApiService,
+    readonly whitelist: string[] = [],
+    readonly defaultLanguage = 'en'
+  ) {}
+
+  async detect(text: string): Promise<string> {
+    let detectedLanguages = await this.service.detectLanguage(text)
+    if (this.whitelist.length != 0) {
+      detectedLanguages = this.applyWhitelist(detectedLanguages)
+    }
+    detectedLanguages = this.sortByConfidence(detectedLanguages)
+    if (detectedLanguages.length == 0) {
+      return this.defaultLanguage
+    }
+    return detectedLanguages[0].languageCode
+  }
+
+  private applyWhitelist(
+    detectedLanguages: LanguageDetection[]
+  ): LanguageDetection[] {
+    return detectedLanguages.filter(d =>
+      this.whitelist.includes(d.languageCode)
+    )
+  }
+
+  private sortByConfidence(
+    detectedLanguages: LanguageDetection[]
+  ): LanguageDetection[] {
+    return detectedLanguages.sort((a, b) =>
+      a.confidence < b.confidence ? 1 : -1
+    )
+  }
+}

--- a/packages/botonic-plugin-google-translate/src/options.ts
+++ b/packages/botonic-plugin-google-translate/src/options.ts
@@ -1,0 +1,11 @@
+export interface Credentials {
+  projectId: string
+  privateKeyId: string
+  privateKey: string
+  clientEmail: string
+}
+
+export interface PluginOptions {
+  whitelist?: string[]
+  credentials: Credentials
+}

--- a/packages/botonic-plugin-google-translate/tsconfig.eslint.json
+++ b/packages/botonic-plugin-google-translate/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tests/tsconfig.json",
+  "include": [".*.js", "*.js", "**/*.ts", "**/*.tsx"]
+}

--- a/packages/botonic-plugin-google-translate/tsconfig.json
+++ b/packages/botonic-plugin-google-translate/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "compilerOptions": {
+    "allowUnreachableCode": false,
+    "baseUrl": "src",
+    "paths": {
+      "*": ["src/*", "lib/src/*", "types/*"]
+    },
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "outDir": "lib",
+    "declaration": true,
+    "declarationDir": "lib",
+    "sourceMap": true,
+    "target": "es6",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noImplicitAny": false,
+    "removeComments": false,
+    "preserveConstEnums": true,
+    "lib": ["dom", "es2015", "es2017"],
+    "noUnusedLocals": false,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedParameters": false,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+  },
+
+  "types": ["@types/jest"]
+}


### PR DESCRIPTION
## Description
Creation of `botonic-plugin-google-translate` that detects the language of the user input text.

## Context
If you have a Google Translate API in Google Cloud, now you can use it to detect the language of the user input text.

## Approach taken / Explain the design
To use this plugin, you need to provide some of your credentials to have access to the Google Translate API:
- `Private Key Id`
- `Private Key`
- `Client Email`
- `Project Id`

## To document / Usage example
You can define a `whitelist` into plugin options to only accept specific languages as detection. In case none of the defined languages is the detected one, 'en' would be set as default. 
