### PR TITLE
feat(contentful): memoizer #BOT-467

### DIFF
--- a/packages/botonic-plugin-contentful/README.md
+++ b/packages/botonic-plugin-contentful/README.md
@@ -311,8 +311,8 @@ field named "customFieldText"
 - Implement a class derived from TopContentDelivery in src/contentful/contents
 - Integrate the previous class in ManageContentful as done for other types
 - Implement a delivery function to all classes that implement CMS interface
-- Implement a <NewContent>Builder class derived from TopContentBuilder in src/cms/factories/content-factories.ts.
-  Implement a Rnd<NewContent>Builder class derived from <NewContent>Builder at src/cms/test-helpers/builders.ts
+- Implement a \<NewContent\>Builder class derived from TopContentBuilder in src/cms/factories/content-factories.ts.
+  Implement a Rnd\<NewContent\>Builder class derived from \<NewContent\>Builder at src/cms/test-helpers/builders.ts
 - Write integration tests using the builder classes in tests/contentful/contents which validates delivery of:
   1. Minimal content (all content's optional fields in blank)
   2. Full content. All content's optional fields filled. For complex contents, you may need

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -31,6 +31,7 @@ import { TextDelivery } from './contents/text'
 import { UrlDelivery } from './contents/url'
 import { CachedClientApi } from './delivery/cache'
 import { ClientApiErrorReporter, ReducedClientApi } from './delivery/client-api'
+import { FallbackCachedClientApi } from './delivery/fallback-cache'
 import { AdaptorDeliveryApi, DeliveryApi } from './delivery-api'
 import {
   ContentfulEntryUtils,
@@ -75,6 +76,9 @@ export class Contentful implements cms.CMS {
       return Promise.resolve()
     }
     let client: ReducedClientApi = createContentfulClientApi(options)
+    if (!options.disableFallbackCache) {
+      client = new FallbackCachedClientApi(client, reporter)
+    }
     if (!options.disableCache) {
       client = new CachedClientApi(client, options.cacheTtlMs, reporter)
     }

--- a/packages/botonic-plugin-contentful/src/contentful/delivery/fallback-cache.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery/fallback-cache.ts
@@ -1,0 +1,59 @@
+import * as contentful from 'contentful'
+import { ContentType } from 'contentful'
+
+import { fallbackStrategy, Memoizer } from '../../util/memoizer'
+import {
+  ClientApiErrorReporter,
+  GetEntriesType,
+  GetEntryType,
+  ReducedClientApi,
+} from './client-api'
+
+/**
+ * Use memoization to remember forever the last successful result, and use it
+ * whenever Contentful fails.
+ */
+export class FallbackCachedClientApi implements ReducedClientApi {
+  numRecoveredErrors = 0
+  memoizer: Memoizer
+  readonly getAsset: (id: string, query?: any) => Promise<contentful.Asset>
+  readonly getAssets: (query?: any) => Promise<contentful.AssetCollection>
+  readonly getEntries: GetEntriesType
+  readonly getEntry: GetEntryType
+  readonly getContentType: (id: string) => Promise<ContentType>
+
+  constructor(
+    readonly client: ReducedClientApi,
+    reporter: ClientApiErrorReporter
+  ) {
+    // We could maybe use a more optimal normalizer than jsonNormalizer
+    // (like they do in fast-json-stringify to avoid JSON.stringify for functions with a single nulls, numbers and booleans).
+    // But it's not worth since stringify will have a cost much lower than constructing/rendering a botonic component
+    // (and we're already optimizing the costly call to CMS)
+    this.memoizer = new Memoizer(
+      fallbackStrategy((f, args, e) =>
+        reporter(
+          `Successfully used cached fallback after Contentful API error`,
+          f,
+          args,
+          e
+        )
+      )
+    )
+    this.getAsset = this.memoize(client.getAsset.bind(client))
+    this.getAssets = this.memoize(client.getAssets.bind(client))
+    this.getEntries = this.memoize(
+      client.getEntries.bind(client)
+    ) as GetEntriesType
+    this.getEntry = this.memoize(client.getEntry.bind(client)) as GetEntryType
+    this.getContentType = this.memoize(client.getContentType.bind(client))
+  }
+
+  memoize<
+    Args extends any[],
+    Return,
+    F extends (...args: Args) => Promise<Return>
+  >(func: F): F {
+    return this.memoizer.memoize<Args, Return, F>(func)
+  }
+}

--- a/packages/botonic-plugin-contentful/src/plugin.ts
+++ b/packages/botonic-plugin-contentful/src/plugin.ts
@@ -44,6 +44,13 @@ export interface ContentfulOptions extends OptionsBase, ContentfulCredentials {
   cacheTtlMs?: number
   disableCache?: boolean
 
+  /**
+   * By default, the result of the last delivery invocation will be cached
+   * forever and will only be used when a delivery call with the same arguments
+   * fail.
+   */
+  disableFallbackCache?: boolean
+
   contentfulFactory?: (opts: ContentfulOptions) => cms.CMS
 
   /** For locales not supported by the CMS (eg. English on a non-English country) */

--- a/packages/botonic-plugin-contentful/src/tools/l10n/import-updater.ts
+++ b/packages/botonic-plugin-contentful/src/tools/l10n/import-updater.ts
@@ -170,16 +170,6 @@ export class ImportContentUpdater {
   }
 
   private async updateFields(content: ContentToImport) {
-    for (const field of getFieldsForContentType(content.contentId.model)) {
-      const f = CONTENT_FIELDS.get(field)!
-      switch (f.valueType) {
-        case ContentFieldValueType.STRING_ARRAY:
-        case ContentFieldValueType.STRING:
-          break
-        default:
-          continue
-      }
-    }
     const newVal = await this.manageCms.updateFields(
       this.context,
       content.contentId,

--- a/packages/botonic-plugin-contentful/src/util/backoff.ts
+++ b/packages/botonic-plugin-contentful/src/util/backoff.ts
@@ -1,4 +1,4 @@
-export function sleep(ms: number) {
+export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 

--- a/packages/botonic-plugin-contentful/src/util/memoizer.ts
+++ b/packages/botonic-plugin-contentful/src/util/memoizer.ts
@@ -49,13 +49,12 @@ export class Memoizer {
     const cache: Cache<Return> = this.cacheFactory()
     const f = (...args: Args) =>
       this.strategy<Args, Return>(cache, this.normalizer, func, ...args)
-    // f.cache = cache
     return f as F
   }
 }
 
 /***
- * Only reinvoke if not in cache
+ * Only re-invoke if not in cache
  */
 export const cacheForeverStrategy: MemoizerStrategy = async <
   Args extends any[],
@@ -87,7 +86,6 @@ export function fallbackStrategy(
     func: (...args: Args) => Promise<Return>,
     ...args: Args
   ) => {
-    // return func(...args)
     const id = normalizer(...args)
     const oldVal = cache.get(id)
 

--- a/packages/botonic-plugin-contentful/src/util/memoizer.ts
+++ b/packages/botonic-plugin-contentful/src/util/memoizer.ts
@@ -1,0 +1,106 @@
+export class Cache<V> {
+  static readonly NOT_FOUND = Symbol('NOT_FOUND')
+  cache: Record<string, V> = {}
+  set(id: string, val: V): void {
+    this.cache[id] = val
+  }
+  get(id: string): V | typeof Cache.NOT_FOUND {
+    // Cache.has is only checked when undefined to avoid always searching twice in the object
+    const val = this.cache[id]
+    if (val === undefined && !this.has(id)) {
+      return Cache.NOT_FOUND
+    }
+    return val
+  }
+  has(id: string): boolean {
+    return id in this.cache
+  }
+}
+
+export type MemoizerNormalizer = (...args: any) => string
+
+export const jsonNormalizer: MemoizerNormalizer = (...args: any) => {
+  return JSON.stringify(args)
+}
+
+export type MemoizedFunction<Args extends any[], Return> = (
+  ...args: Args
+) => Promise<Return> //& { cache: Cache<Return> }
+
+export type MemoizerStrategy = <Args extends any[], Return>(
+  cache: Cache<Return>,
+  normalizer: typeof jsonNormalizer,
+  func: (...args: Args) => Promise<Return>,
+  ...args: Args
+) => Promise<Return>
+
+export class Memoizer {
+  constructor(
+    private readonly strategy: MemoizerStrategy,
+    private readonly cacheFactory = () => new Cache<any>(),
+    private readonly normalizer = jsonNormalizer
+  ) {}
+
+  memoize<
+    Args extends any[],
+    Return,
+    F extends (...args: Args) => Promise<Return>
+  >(func: F): F {
+    const cache: Cache<Return> = this.cacheFactory()
+    const f = (...args: Args) =>
+      this.strategy<Args, Return>(cache, this.normalizer, func, ...args)
+    // f.cache = cache
+    return f as F
+  }
+}
+
+/***
+ * Only reinvoke if not in cache
+ */
+export const cacheForeverStrategy: MemoizerStrategy = async <
+  Args extends any[],
+  Return
+>(
+  cache: Cache<Return>,
+  normalizer = jsonNormalizer,
+  func: (...args: Args) => Promise<Return>,
+  ...args: Args
+) => {
+  const id = normalizer(...args)
+  let val = cache.get(id)
+  if (val === Cache.NOT_FOUND) {
+    val = await func(...args)
+    cache.set(id, val)
+  }
+  return val
+}
+
+/**
+ * Always invokes the function, but fallbacks to last invocation result if available
+ */
+export function fallbackStrategy(
+  usingFallback: (functName: string, args: any[], error: any) => Promise<void>
+): MemoizerStrategy {
+  return async <Args extends any[], Return>(
+    cache: Cache<Return>,
+    normalizer = jsonNormalizer,
+    func: (...args: Args) => Promise<Return>,
+    ...args: Args
+  ) => {
+    // return func(...args)
+    const id = normalizer(...args)
+    const oldVal = cache.get(id)
+
+    try {
+      const newVal = await func(...args)
+      cache.set(id, newVal)
+      return newVal
+    } catch (e) {
+      if (oldVal !== Cache.NOT_FOUND) {
+        await usingFallback(String(func.name), args, e)
+        return oldVal
+      }
+      throw e
+    }
+  }
+}

--- a/packages/botonic-plugin-contentful/tests/contentful/delivery/fallback-cache.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/delivery/fallback-cache.test.ts
@@ -1,0 +1,136 @@
+import { FallbackCachedClientApi } from '../../../src/contentful/delivery/fallback-cache'
+import { MockClientApi } from './mock-client.helper'
+
+test('TEST: FallbackCachedClientApi.getAsset', async () => {
+  const id = Math.random().toString()
+  await testFallbackCache(
+    sut => sut.getAsset(id),
+    sut => sut.asset
+  )
+})
+
+test('TEST: FallbackCachedClientApi.getAssets', async () => {
+  await testFallbackCache(
+    sut => sut.getAssets({ qk: 'qv' }),
+    sut => sut.assetCollection
+  )
+})
+
+test('TEST: FallbackCachedClientApi.getContentType', async () => {
+  const id = Math.random().toString()
+  await testFallbackCache(
+    sut => sut.getContentType(id),
+    sut => sut.contentType
+  )
+})
+
+test('TEST: FallbackCachedClientApi.getEntries', async () => {
+  await testFallbackCache(
+    sut => sut.getEntries({ qk: 'qv' }),
+    sut => sut.entryCollection
+  )
+})
+
+test('TEST: FallbackCachedClientApi.getEntry', async () => {
+  const id = Math.random().toString()
+  await testFallbackCache(
+    sut => sut.getEntry(id),
+    sut => sut.entry
+  )
+})
+
+async function testFallbackCache<R>(
+  call: (api: FallbackCachedClientApi) => Promise<R>,
+  expectedReturn: (api: MockClientApi) => R
+) {
+  await testFallbackIfFailure(call, expectedReturn)
+
+  await testCallAfterHit(call, expectedReturn)
+  await testSuccessAfterFailure(call, expectedReturn)
+}
+
+async function testCallAfterHit<R>(
+  call: (api: FallbackCachedClientApi) => Promise<R>,
+  expectedReturn: (api: MockClientApi) => R
+) {
+  const mockApi = new MockClientApi()
+  const sut = new FallbackCachedClientApi(mockApi, usingFallback)
+  const expected = expectedReturn(mockApi)
+
+  await expect(call(sut)).resolves.toBe(expected)
+  expect(mockApi.numCalls).toBe(1)
+
+  await expect(call(sut)).resolves.toBe(expected)
+  expect(mockApi.numCalls).toBe(2)
+}
+
+async function testFallbackIfFailure<R>(
+  call: (api: FallbackCachedClientApi) => Promise<R>,
+  expectedReturn: (api: MockClientApi) => R
+) {
+  const mockApi = new MockClientApi()
+  const sut = new FallbackCachedClientApi(mockApi, usingFallback)
+  const expected = expectedReturn(mockApi)
+
+  await expect(call(sut)).resolves.toBe(expected)
+  // expect(sut.numRecoveredErrors).toBe(0)
+  expect(mockApi.numCalls).toBe(1)
+
+  // provide last success result
+  mockApi.error = new Error('forced failure')
+  await expect(call(sut)).resolves.toBe(expected)
+  // expect(sut.numRecoveredErrors).toBe(1)
+  expect(mockApi.numCalls).toBe(2)
+
+  mockApi.error = undefined
+  await expect(call(sut)).resolves.toBe(expected)
+  // expect(sut.numRecoveredErrors).toBe(1)
+  expect(mockApi.numCalls).toBe(3)
+}
+
+async function testSuccessAfterFailure<R>(
+  call: (api: FallbackCachedClientApi) => Promise<R>,
+  expectedReturn: (api: MockClientApi) => R
+) {
+  const mockApi = new MockClientApi()
+  const sut = new FallbackCachedClientApi(mockApi, usingFallback)
+  const expected = expectedReturn(mockApi)
+
+  mockApi.error = new Error('forced failure')
+  await expect(call(sut)).rejects.toThrowError(mockApi.error)
+  expect(mockApi.numCalls).toBe(1)
+
+  mockApi.error = undefined
+  await expect(call(sut)).resolves.toBe(expected)
+  expect(mockApi.numCalls).toBe(2)
+}
+
+export function usingFallback(
+  description: string,
+  funcName: string,
+  args: any[],
+  e: any
+): Promise<void> {
+  console.error(
+    `${description}: ${funcName}(${String(args)}) after error: ${String(e)}`
+  )
+  return Promise.resolve()
+}
+
+// test('TEST: CachedDelivery getAsset is cached', async () => {
+//   const CACHE_TTL = 30
+//   const mockApi = mock<ReducedClientApi>()
+//   const id = Math.random().toString()
+//   const query = {}
+//   const entry = ({} as any) as Entry<any>
+//   when(mockApi.getAsset(id, query)).thenResolve(entry)
+//   const sut = new FallbackCachedClientApi(instance(mockApi), CACHE_TTL)
+//
+//   await expect(sut.getAsset(id, query)).resolves.toBe(entry)
+//   await expect(sut.getAsset(id, query)).resolves.toBe(entry)
+//   verify(mockApi.getAsset(id, query)).once()
+//
+//   await new Promise(resolve => setTimeout(resolve, CACHE_TTL))
+//   await expect(sut.getAsset(id, query)).resolves.toBe(entry)
+//   verify(mockApi.getAsset(id, query)).twice()
+// })

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-asset.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-asset.test.ts
@@ -23,7 +23,10 @@ describe('ManageContentful assets', () => {
 
   test('TEST: createAsset and removeAsset', async () => {
     const context = ctxt({ locale: ENGLISH })
-    const contentful = testContentful({ disableCache: true })
+    const contentful = testContentful({
+      disableCache: true,
+      disableFallbackCache: true,
+    })
     const sut = testManageContentful()
     let assetId: string
     const file = JSON.stringify({ a: rndStr(), b: rndStr() })

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-entry.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-entry.test.ts
@@ -14,7 +14,10 @@ import { ctxt, testManageContentful } from './manage-contentful.helper'
 describe('ManageContentful entries', () => {
   const context = ctxt({ locale: ENGLISH })
   test('TEST: createContent and deleteContent', async () => {
-    const contentful = testContentful({ disableCache: true })
+    const contentful = testContentful({
+      disableCache: true,
+      disableFallbackCache: true,
+    })
     const sut = testManageContentful()
     const id = rndStr()
     const TEST_NEW_CONTENT_ID = new TopContentId(ContentType.TEXT, id)
@@ -83,7 +86,10 @@ describe('ManageContentful entries', () => {
 
   test('TEST: updateFields is able to manage fields of type ButtonStyle and FollowUps', async () => {
     const sut = testManageContentful()
-    const contentful = testContentful({ disableCache: true })
+    const contentful = testContentful({
+      disableCache: true,
+      disableFallbackCache: true,
+    })
     const NEW_CONTENT = new TopContentId(ContentType.TEXT, rndStr())
     const FOLLOW_UP_CONTENT = new TopContentId(ContentType.TEXT, rndStr())
     const name = rndStr()

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful.test.ts
@@ -18,7 +18,10 @@ describe('ManageContentful fields', () => {
     '627QkyJrFo3grJryj0vu6L' //TEST_MANAGE_CMS
   )
   const RESTORE_TEXT_VALUE = undefined // so that it fallbacks to English
-  const contentful = testContentful({ disableCache: true })
+  const contentful = testContentful({
+    disableCache: true,
+    disableFallbackCache: true,
+  })
   // @ts-ignore
   let fallbackLocaleContent: cms.Text = undefined
 
@@ -58,7 +61,10 @@ describe('ManageContentful fields', () => {
     newValue: string | undefined,
     expectedValue: string
   ) {
-    const contentful = testContentful({ disableCache: true })
+    const contentful = testContentful({
+      disableCache: true,
+      disableFallbackCache: true,
+    })
     const oldTextValue = (
       await contentful.text(
         TEST_CONTENT_ID.id,
@@ -152,7 +158,10 @@ describe('ManageContentful fields', () => {
   test(
     'TEST: copyField buttons',
     async () => {
-      const contentful = testContentful({ disableCache: true })
+      const contentful = testContentful({
+        disableCache: true,
+        disableFallbackCache: true,
+      })
       const oldContent = await contentful.text(TEST_CONTENT_ID.id)
       const sut = testManageContentful()
       const FROM_LOCALE = ENGLISH

--- a/packages/botonic-plugin-contentful/tests/util/memoizer.test.ts
+++ b/packages/botonic-plugin-contentful/tests/util/memoizer.test.ts
@@ -1,0 +1,172 @@
+import {
+  cacheForeverStrategy,
+  fallbackStrategy,
+  Memoizer,
+} from '../../src/util/memoizer'
+
+class MockF {
+  callsFA = 0
+  callsFB = 0
+  error: Error | undefined
+  salt = ''
+
+  fA(a: number, b: string): Promise<string> {
+    this.callsFA++
+    if (this.error) {
+      return Promise.reject(this.error)
+    }
+    return Promise.resolve('A' + String(a) + b + this.salt)
+  }
+
+  fB(a = 1, b = 'b'): Promise<string> {
+    this.callsFB++
+    if (this.error) {
+      return Promise.reject(this.error)
+    }
+    return Promise.resolve('B' + String(a) + b + this.salt)
+  }
+}
+
+describe('Memoizer', () => {
+  it('TEST: cacheForeverStrategy common properties', async () => {
+    await assertCommonStrategyProperties(
+      () => new Memoizer(cacheForeverStrategy),
+      false
+    )
+  })
+  it('TEST: cacheForeverStrategy only fails if last call failed', async () => {
+    const sut = new Memoizer(cacheForeverStrategy)
+    const mock = new MockF()
+    const memoized = sut.memoize(mock.fA.bind(mock))
+
+    // act/assert
+    mock.error = new Error('forced failure')
+    await expect(memoized(2, 'b')).rejects.toThrowError(mock.error)
+    mock.error = undefined
+    await expect(memoized(2, 'b')).resolves.toBe('A2b')
+    expect(mock.callsFA).toBe(2)
+  })
+
+  function usingFallback(funcName: string, args: any[], e: any): Promise<void> {
+    console.error(
+      `Using fallback for ${funcName}(${String(args)}) after error: ${String(
+        e
+      )}`
+    )
+    return Promise.resolve()
+  }
+
+  it('TEST: fallbackStrategy common properties', async () => {
+    await assertCommonStrategyProperties(
+      () => new Memoizer(fallbackStrategy(usingFallback)),
+      true
+    )
+  })
+
+  it('TEST: fallbackStrategy uses last invocation result', async () => {
+    const sut = new Memoizer(fallbackStrategy(usingFallback))
+    const mock = new MockF()
+    const memoized = sut.memoize(mock.fA.bind(mock))
+
+    // act/assert
+    await expect(memoized(2, 'b')).resolves.toBe('A2b')
+    mock.salt = 'pepper'
+    await expect(memoized(2, 'b')).resolves.toBe('A2b' + mock.salt)
+    expect(mock.callsFA).toBe(2)
+  })
+
+  test('TEST: fallbackStrategy returns latest success return if function fails', async () => {
+    const sut = new Memoizer(fallbackStrategy(usingFallback))
+    const mock = new MockF()
+    const memoized = sut.memoize(mock.fA.bind(mock))
+
+    // arrange
+    await memoized(2, 'b')
+    mock.salt = 'pepper'
+    await memoized(2, 'b')
+
+    mock.error = new Error('forced failure')
+    await memoized(2, 'b')
+
+    // act
+    mock.error = undefined
+    await expect(memoized(2, 'b')).resolves.toBe('A2bpepper')
+    expect(mock.callsFA).toBe(4)
+  })
+})
+
+async function assertCommonStrategyProperties(
+  sutFactory: () => Memoizer,
+  expectReinvocation: boolean
+) {
+  await memoizerDoesNotMixUpDifferentFunctionsOrArguments(
+    sutFactory(),
+    expectReinvocation
+  )
+  await memoizerFailsIfAllPreviousInvocationsFailed(sutFactory())
+  await memoizerWorksWithDefaultValueArgs(sutFactory(), expectReinvocation)
+}
+
+async function memoizerFailsIfAllPreviousInvocationsFailed(sut: Memoizer) {
+  const mock = new MockF()
+  const memoized = sut.memoize(mock.fA.bind(mock))
+
+  // act/assert
+  mock.error = new Error('forced failure')
+  await expect(memoized(2, 'b')).rejects.toThrowError(mock.error)
+  await expect(memoized(2, 'b')).rejects.toThrowError(mock.error)
+
+  mock.error = undefined
+  await expect(memoized(2, 'b')).resolves.toBe('A2b')
+}
+
+async function memoizerDoesNotMixUpDifferentFunctionsOrArguments(
+  sut: Memoizer,
+  expectReinvocation: boolean
+) {
+  const mock = new MockF()
+  const memoizedA = sut.memoize(mock.fA.bind(mock))
+  const memoizedB = sut.memoize(mock.fB.bind(mock))
+
+  // act/assert
+  await expect(memoizedA(2, 'b')).resolves.toBe('A2b')
+  //same function, arguments
+  await expect(memoizedA(2, 'b')).resolves.toBe('A2b')
+  expect(mock.callsFA).toBe(expectReinvocation ? 2 : 1)
+
+  //same function, different arguments
+  await expect(memoizedA(2, 'c')).resolves.toBe('A2c')
+  expect(mock.callsFA).toBe(expectReinvocation ? 3 : 2)
+
+  //different function, same arguments
+  await expect(memoizedB(2, 'b')).resolves.toBe('B2b')
+  expect(mock.callsFB).toBe(expectReinvocation ? 1 : 1)
+}
+
+async function memoizerWorksWithDefaultValueArgs(
+  sut: Memoizer,
+  expectReinvocation: boolean
+) {
+  const mock = new MockF()
+  const memoized = sut.memoize(mock.fB.bind(mock))
+
+  // act/assert
+  // All default arguments
+  await expect(memoized()).resolves.toBe('B1b')
+  await expect(memoized()).resolves.toBe('B1b')
+  expect(mock.callsFB).toBe(expectReinvocation ? 2 : 1)
+
+  // explicitly passing the default value
+  await expect(memoized(1, 'b')).resolves.toBe('B1b')
+  await expect(memoized(1, 'b')).resolves.toBe('B1b')
+  expect(mock.callsFB).toBe(expectReinvocation ? 4 : 2)
+
+  // 1 argument by default, 1 explicit
+  await expect(memoized(4)).resolves.toBe('B4b')
+  await expect(memoized(4)).resolves.toBe('B4b')
+  expect(mock.callsFB).toBe(expectReinvocation ? 6 : 3)
+
+  await expect(memoized(4, 'c')).resolves.toBe('B4c')
+  await expect(memoized(4, 'c')).resolves.toBe('B4c')
+  expect(mock.callsFB).toBe(expectReinvocation ? 8 : 4)
+}


### PR DESCRIPTION
Depends on #1640. :warning:  **Please review it first**

## Description
Use memoization to remember forever the last successful invocation for each combination of arguments, and use its result whenever Contentful fails.

## Context

Contentful failing during 1h on 2021/6/8 and 2021/6/9.

## Approach taken / Explain the design

* Create a generic Memoizer class with several strategies. 
* Create a decorator (FallbackCachedClientApi) around the Contentful API class which uses the Memoizer fallbackStrategy.
* Compose the new decorator within the existing decorator (CachedClientApi) which avoids recent calls.

FallbackCachedClientApi does not use the memoization library used by CachedClientApi (memoizee) because this library does not allow directly accessing the cache. 

## To document / Usage example

The contentful plugin by default uses memoization to remember forever the last successful invocation for each combination of arguments, and use its result whenever Contentful fails. To disable this feature, use to `true` the new plugin option beloew

```
  /**
   * By default, the result of the last delivery invocation will be cached
   * forever and will only be used when a delivery call with the same arguments
   * fail.
   */
  disableFallbackCache?: boolean

```

## Testing

The pull request...

- has unit tests
