### PR TITLE
feat(contentful): if memoization fails, don't cache the error

### DIFF
--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -30,6 +30,7 @@ import { StartUpDelivery } from './contents/startup'
 import { TextDelivery } from './contents/text'
 import { UrlDelivery } from './contents/url'
 import { CachedClientApi } from './delivery/cache'
+import { ClientApiErrorReporter, ReducedClientApi } from './delivery/client-api'
 import { AdaptorDeliveryApi, DeliveryApi } from './delivery-api'
 import {
   ContentfulEntryUtils,
@@ -62,13 +63,22 @@ export class Contentful implements cms.CMS {
    *  https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/
    */
   constructor(options: ContentfulOptions) {
-    const client = createContentfulClientApi(options)
-    const deliveryApi = new AdaptorDeliveryApi(
-      options.disableCache
-        ? client
-        : new CachedClientApi(client, options.cacheTtlMs),
-      options
-    )
+    const reporter: ClientApiErrorReporter = (
+      msg: string,
+      func: string,
+      args,
+      error: any
+    ) => {
+      console.error(
+        `${msg}. '${func}(${String(args)})' threw '${String(error)}'`
+      )
+      return Promise.resolve()
+    }
+    let client: ReducedClientApi = createContentfulClientApi(options)
+    if (!options.disableCache) {
+      client = new CachedClientApi(client, options.cacheTtlMs, reporter)
+    }
+    const deliveryApi = new AdaptorDeliveryApi(client, options)
     const resumeErrors = options.resumeErrors || false
     const delivery = new IgnoreFallbackDecorator(deliveryApi)
     this._contents = new ContentsDelivery(delivery, resumeErrors)

--- a/packages/botonic-plugin-contentful/src/contentful/delivery/cache.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery/cache.ts
@@ -1,33 +1,82 @@
 import * as contentful from 'contentful'
-import { ContentType, Entry } from 'contentful'
+import { ContentType } from 'contentful'
 import memoize from 'memoizee'
 
-import { ReducedClientApi } from './client-api'
+import { sleep } from '../../../src/util/backoff'
+import { rethrowDecorator } from '../../util'
+import { jsonNormalizer } from '../../util/memoizer'
+import {
+  ClientApiErrorReporter,
+  GetEntriesType,
+  GetEntryType,
+  ReducedClientApi,
+} from './client-api'
 
 export class CachedClientApi implements ReducedClientApi {
+  static readonly NO_EXPIRATION = -1
   readonly getAsset: (id: string, query?: any) => Promise<contentful.Asset>
   readonly getAssets: (query?: any) => Promise<contentful.AssetCollection>
-  readonly getEntries: <T>(query: any) => Promise<contentful.EntryCollection<T>>
-  readonly getEntry: <T>(id: string, query?: any) => Promise<Entry<T>>
+  readonly getEntries: GetEntriesType
+  readonly getEntry: GetEntryType
   readonly getContentType: (id: string) => Promise<ContentType>
 
-  constructor(readonly client: ReducedClientApi, readonly cacheTtlMs = 10000) {
-    const options = (length: number) =>
-      ({
-        primitive: true,
-        maxAge: cacheTtlMs,
-        length,
-        normalizer: function (...args: any): string {
-          return args
-            .map((arg: any) => JSON.stringify(arg))
-            .reduce((a: string, b: string) => a + b)
-        },
-      } as memoize.Options<any>)
+  constructor(
+    readonly client: ReducedClientApi,
+    readonly cacheTtlMs = 10000,
+    readonly errorReport: ClientApiErrorReporter
+  ) {
+    this.getAsset = this.memoize(client.getAsset.bind(client), 2)
+    this.getAssets = this.memoize(client.getAssets.bind(client), 1)
+    this.getEntries = this.memoize(
+      client.getEntries.bind(client),
+      1
+    ) as GetEntriesType
+    this.getEntry = this.memoize(
+      client.getEntry.bind(client),
+      2
+    ) as GetEntryType
+    this.getContentType = this.memoize(client.getContentType.bind(client), 1)
+  }
 
-    this.getAsset = memoize(client.getAsset, options(2))
-    this.getAssets = memoize(client.getAssets, options(1))
-    this.getEntries = memoize(client.getEntries, options(1))
-    this.getEntry = memoize(client.getEntry, options(2))
-    this.getContentType = memoize(client.getContentType, options(1))
+  memoize<
+    Args extends any[],
+    Return,
+    F extends (...args: Args) => Promise<Return>
+  >(func: F, functionLength: number): F {
+    const memo = memoize(func, this.options(functionLength))
+    const dec = rethrowDecorator<Args, Return, F>(
+      memo,
+      async (e, ...args: Args) => {
+        await this.errorReport(
+          'Error calling Contentful API',
+          String(func),
+          args,
+          e
+        )
+        // sleep required to ensure that after a failed invocation, the next one also always fails
+        // https://github.com/medikoo/memoizee/issues/117
+        return sleep(0)
+      }
+    )
+    return dec
+  }
+
+  options(length: number) {
+    return {
+      promise: true,
+      primitive: true,
+      maxAge:
+        this.cacheTtlMs == CachedClientApi.NO_EXPIRATION
+          ? undefined
+          : this.cacheTtlMs,
+      length,
+      normalizer: jsonNormalizer,
+    } as memoize.Options<any>
+  }
+
+  static normalizer(...args: any): string {
+    return args
+      .map((arg: any) => JSON.stringify(arg))
+      .reduce((a: string, b: string) => a + b)
   }
 }

--- a/packages/botonic-plugin-contentful/src/contentful/delivery/client-api.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery/client-api.ts
@@ -1,6 +1,20 @@
-import { ContentfulClientApi } from 'contentful'
+import { ContentfulClientApi, Entry } from 'contentful'
+import * as contentful from 'contentful'
 
 export type ReducedClientApi = Pick<
   ContentfulClientApi,
   'getAsset' | 'getAssets' | 'getEntries' | 'getEntry' | 'getContentType'
 >
+
+export type GetEntriesType = <T>(
+  query: any
+) => Promise<contentful.EntryCollection<T>>
+
+export type GetEntryType = <T>(id: string, query?: any) => Promise<Entry<T>>
+
+export type ClientApiErrorReporter = (
+  description: string,
+  functName: string,
+  args: any[],
+  err: Error
+) => Promise<void>

--- a/packages/botonic-plugin-contentful/src/util/exceptions.ts
+++ b/packages/botonic-plugin-contentful/src/util/exceptions.ts
@@ -2,3 +2,19 @@ export function isError(e: any): e is Error {
   const exception = e as Error
   return !!exception.name && !!exception.message
 }
+
+export function rethrowDecorator<
+  Args extends any[],
+  Return,
+  F extends (...args: Args) => Promise<Return>
+>(func: F, beforeRethrow: (error: any, ...args: Args) => Promise<void>): F {
+  const f = async (...args: Args) => {
+    try {
+      return await func(...args)
+    } catch (e) {
+      await beforeRethrow(e, ...args)
+      throw e
+    }
+  }
+  return f as F
+}

--- a/packages/botonic-plugin-contentful/tests/contentful/delivery/mock-client.helper.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/delivery/mock-client.helper.ts
@@ -1,0 +1,68 @@
+import contentful, {
+  Asset,
+  AssetCollection,
+  ContentType,
+  Entry,
+  EntryCollection,
+} from 'contentful'
+
+import { ReducedClientApi } from '../../../src/contentful/delivery/client-api'
+
+// not using mockito because (maybe due to https://github.com/medikoo/memoizee/issues/117),
+// consecutive calls without a sleep in between were not hitting the cache
+export class MockClientApi implements ReducedClientApi {
+  error: Error | undefined
+  numCalls = 0
+
+  asset = ({ ka: 'va' } as any) as Asset
+  assetCollection = ({
+    items: [this.asset],
+  } as any) as AssetCollection
+
+  contentType = ({ kct: 'vct' } as any) as ContentType
+
+  entry = ({ ke: 've' } as any) as Entry<any>
+  entryCollection = ({
+    items: [],
+  } as any) as EntryCollection<any>
+
+  getAsset(id: string, query: any): Promise<contentful.Asset> {
+    this.numCalls++
+    if (this.error) {
+      return Promise.reject(this.error)
+    }
+    return Promise.resolve(this.asset)
+  }
+
+  getAssets(query: any): Promise<contentful.AssetCollection> {
+    this.numCalls++
+    if (this.error) {
+      return Promise.reject(this.error)
+    }
+    return Promise.resolve(this.assetCollection)
+  }
+
+  getContentType(id: string): Promise<contentful.ContentType> {
+    this.numCalls++
+    if (this.error) {
+      return Promise.reject(this.error)
+    }
+    return Promise.resolve(this.contentType)
+  }
+
+  getEntries<T>(query: any): Promise<EntryCollection<T>> {
+    this.numCalls++
+    if (this.error) {
+      return Promise.reject(this.error)
+    }
+    return Promise.resolve(this.entryCollection)
+  }
+
+  getEntry<T>(id: string, query: any): Promise<Entry<T>> {
+    this.numCalls++
+    if (this.error) {
+      return Promise.reject(this.error)
+    }
+    return Promise.resolve(this.entry)
+  }
+}


### PR DESCRIPTION

## Description
if contentful calls cache fails, don't cache the error. It's better to return the previous successful result than the new error

## Context

This refers to the old (with time expiration) cache that we have to avoid hitting contentful too oftern. It does **not** refer to the [new cache](#1639) that remembers forever the last successful result to be provided whenever contentful call fails. 

## Approach taken / Explain the design

Actually this is already a feature of the memoization library that we use (memoizee), but it required setting the option `promise: true`

## Testing

The pull request...

- has unit tests
