### PR TITLE
Contentful/cache size limit

### DIFF
--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -64,20 +64,19 @@ export class Contentful implements cms.CMS {
    *  https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/
    */
   constructor(options: ContentfulOptions) {
+    const logger = options.logger ?? console.error
     const reporter: ClientApiErrorReporter = (
       msg: string,
       func: string,
       args,
       error: any
     ) => {
-      console.error(
-        `${msg}. '${func}(${String(args)})' threw '${String(error)}'`
-      )
+      logger(`${msg}. '${func}(${String(args)})' threw '${String(error)}'`)
       return Promise.resolve()
     }
     let client: ReducedClientApi = createContentfulClientApi(options)
     if (!options.disableFallbackCache) {
-      client = new FallbackCachedClientApi(client, reporter)
+      client = new FallbackCachedClientApi(client, reporter, logger)
     }
     if (!options.disableCache) {
       client = new CachedClientApi(client, options.cacheTtlMs, reporter)

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -14,7 +14,7 @@ import {
   TopContent,
   TopContentType,
 } from '../cms'
-import { ContentfulOptions } from '../plugin'
+import { ContentfulOptions, DEFAULT_FALLBACK_CACHE_LIMIT_KB } from '../plugin'
 import { SearchCandidate } from '../search'
 import { AssetDelivery } from './contents/asset'
 import { ButtonDelivery } from './contents/button'
@@ -76,7 +76,12 @@ export class Contentful implements cms.CMS {
     }
     let client: ReducedClientApi = createContentfulClientApi(options)
     if (!options.disableFallbackCache) {
-      client = new FallbackCachedClientApi(client, reporter, logger)
+      client = new FallbackCachedClientApi(
+        client,
+        options.fallbackCacheLimitKB ?? DEFAULT_FALLBACK_CACHE_LIMIT_KB,
+        reporter,
+        logger
+      )
     }
     if (!options.disableCache) {
       client = new CachedClientApi(client, options.cacheTtlMs, reporter)

--- a/packages/botonic-plugin-contentful/src/contentful/delivery/fallback-cache.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/delivery/fallback-cache.ts
@@ -1,6 +1,7 @@
 import * as contentful from 'contentful'
 import { ContentType } from 'contentful'
 
+import { InMemoryCache, LimitedCacheDecorator } from '../../util/cache'
 import { fallbackStrategy, Memoizer } from '../../util/memoizer'
 import {
   ClientApiErrorReporter,
@@ -21,18 +22,29 @@ export class FallbackCachedClientApi implements ReducedClientApi {
   readonly getEntries: GetEntriesType
   readonly getEntry: GetEntryType
   readonly getContentType: (id: string) => Promise<ContentType>
+  private static readonly NUM_APIS = 5
+  private numMemoizations = 0
 
   constructor(
     client: ReducedClientApi,
+    cacheLimitKB: number,
     reporter: ClientApiErrorReporter,
-    private readonly logger: (msg: string) => void = console.error
+    logger: (msg: string) => void = console.error
   ) {
+    // TODO share the same cache for all APIs to avoid reaching a Memoizer limit
+    // while others have empty space
+    const memoizerCache = () =>
+      new LimitedCacheDecorator(
+        new InMemoryCache<any>(),
+        cacheLimitKB / FallbackCachedClientApi.NUM_APIS,
+        logger
+      )
     // We could maybe use a more optimal normalizer than jsonNormalizer
     // (like they do in fast-json-stringify to avoid JSON.stringify for functions with a single nulls, numbers and booleans).
     // But it's not worth since stringify will have a cost much lower than constructing/rendering a botonic component
     // (and we're already optimizing the costly call to CMS)
     this.memoizer = new Memoizer({
-      logger: this.logger,
+      cacheFactory: memoizerCache,
       strategy: fallbackStrategy((f, args, e) =>
         reporter(
           `Successfully used cached fallback after Contentful API error`,
@@ -49,6 +61,11 @@ export class FallbackCachedClientApi implements ReducedClientApi {
     ) as GetEntriesType
     this.getEntry = this.memoize(client.getEntry.bind(client)) as GetEntryType
     this.getContentType = this.memoize(client.getContentType.bind(client))
+    if (this.numMemoizations != FallbackCachedClientApi.NUM_APIS) {
+      throw new Error(
+        'FallbackCachedClientApi.NUM_APIS must equal the number of memoized APIs'
+      )
+    }
   }
 
   memoize<
@@ -56,6 +73,7 @@ export class FallbackCachedClientApi implements ReducedClientApi {
     Return,
     F extends (...args: Args) => Promise<Return>
   >(func: F): F {
+    this.numMemoizations++
     return this.memoizer.memoize<Args, Return, F>(func)
   }
 }

--- a/packages/botonic-plugin-contentful/src/plugin.ts
+++ b/packages/botonic-plugin-contentful/src/plugin.ts
@@ -24,6 +24,7 @@ export interface CmsOptions extends OptionsBase {
 
 export const DEFAULT_TIMEOUT_MS = 30000
 export const DEFAULT_CACHE_TTL_MS = 10000
+export const DEFAULT_FALLBACK_CACHE_LIMIT_KB = 100 * 1024
 
 export interface ContentfulCredentials {
   spaceId: string
@@ -50,6 +51,10 @@ export interface ContentfulOptions extends OptionsBase, ContentfulCredentials {
    * fail.
    */
   disableFallbackCache?: boolean
+  /**
+   * {@link DEFAULT_FALLBACK_CACHE_LIMIT_KB} by default
+   */
+  fallbackCacheLimitKB?: number
 
   contentfulFactory?: (opts: ContentfulOptions) => cms.CMS
 

--- a/packages/botonic-plugin-contentful/src/util/cache.ts
+++ b/packages/botonic-plugin-contentful/src/util/cache.ts
@@ -98,7 +98,7 @@ export class LimitedCacheDecorator<V> implements Cache<V> {
       }
       if (!itFits) {
         this.logger(
-          `Cannot add object in cache because it's larger than max capacity(${this.limitKB})`
+          `Cannot add entry in cache because IT ALONE is larger than max capacity(${this.limitKB})`
         )
         return
       }

--- a/packages/botonic-plugin-contentful/src/util/cache.ts
+++ b/packages/botonic-plugin-contentful/src/util/cache.ts
@@ -1,0 +1,134 @@
+import { roughSizeOfObject } from './objects'
+
+export const NOT_FOUND_IN_CACHE = Symbol('NOT_FOUND')
+
+export interface Cache<V> {
+  set(id: string, val: V): void
+  get(id: string): V | typeof NOT_FOUND_IN_CACHE
+  has(id: string): boolean
+  del(id: string): void
+
+  /**
+   * @return size in KB
+   */
+  size(): number
+
+  /**
+   * Provides the Cache keys in undefined order 1 by 1
+   * @param getMoreKeys will return true if the consumer of the keys wants another key
+   */
+  keys(): Generator<string>
+}
+
+export class InMemoryCache<V> implements Cache<V> {
+  private cache: Record<string, V> = {}
+  private sizeBytes = 0
+
+  set(id: string, val: V): void {
+    this.del(id)
+    this.sizeBytes += roughSizeOfObject(id) + roughSizeOfObject(val)
+    this.cache[id] = val
+  }
+
+  del(id: string): void {
+    const val = this.get(id)
+    if (val == NOT_FOUND_IN_CACHE) {
+      return
+    }
+    delete this.cache[id]
+    this.sizeBytes -= roughSizeOfObject(id) + roughSizeOfObject(val)
+  }
+
+  get(id: string): V | typeof NOT_FOUND_IN_CACHE {
+    // Cache.has is only checked when undefined to avoid always searching twice in the object
+    const val = this.cache[id]
+    if (val === undefined && !this.has(id)) {
+      return NOT_FOUND_IN_CACHE
+    }
+    return val
+  }
+
+  has(id: string): boolean {
+    return id in this.cache
+  }
+
+  size(): number {
+    return this.sizeBytes / 1024
+  }
+
+  len(): number {
+    return Object.keys(this.cache).length
+  }
+
+  *keys(): Generator<string> {
+    for (const k of Object.keys(this.cache)) {
+      yield k
+    }
+  }
+}
+
+/**
+ * Decorates a cache by limiting its size
+ */
+export class LimitedCacheDecorator<V> implements Cache<V> {
+  constructor(
+    private readonly cache: Cache<V>,
+    readonly limitKB: number,
+    private readonly logger: (msg: string) => void = console.error,
+    readonly sizeWarningsRatio = [0.5, 0.75, 0.9]
+  ) {}
+
+  set(id: string, val: V): void {
+    const incBytes = roughSizeOfObject(id) + roughSizeOfObject(val)
+    const checkFit = () =>
+      this.cache.size() * 1024 + incBytes <= this.limitKB * 1024
+    let itFits = checkFit()
+
+    if (!itFits) {
+      for (const k of this.cache.keys()) {
+        if (itFits) {
+          break
+        }
+        this.cache.del(k)
+        itFits = checkFit()
+      }
+      if (!itFits) {
+        this.logger(
+          `Cannot add object in cache because it's larger than max capacity(${this.limitKB})`
+        )
+        return
+      }
+    }
+    this.cache.set(id, val)
+    this.warnSizeRatio(incBytes / 1024)
+  }
+
+  warnSizeRatio(incKB: number): void {
+    const sizeKB = this.size()
+    for (const warnRatio of this.sizeWarningsRatio.sort((a, b) => b - a)) {
+      if (sizeKB / this.limitKB >= warnRatio && sizeKB - incKB < warnRatio) {
+        this.logger(`Cache is now more than ${warnRatio * 100}% full`)
+        return
+      }
+    }
+  }
+
+  get(id: string): V | typeof NOT_FOUND_IN_CACHE {
+    return this.cache.get(id)
+  }
+
+  has(id: string): boolean {
+    return this.cache.has(id)
+  }
+  del(id: string): void {
+    return this.cache.del(id)
+  }
+
+  keys(): Generator<string> {
+    return this.cache.keys()
+  }
+
+  size(): number {
+    return this.cache.size()
+  }
+}

--- a/packages/botonic-plugin-contentful/src/util/cache.ts
+++ b/packages/botonic-plugin-contentful/src/util/cache.ts
@@ -68,7 +68,11 @@ export class InMemoryCache<V> implements Cache<V> {
 }
 
 /**
- * Decorates a cache by limiting its size
+ * Decorates a cache by limiting its size.
+ *
+ * TODO Use an external library to have a LRU cache. However, it's not critical
+ * because typically data in CMS is small (we're not caching media, only their
+ * URLs)
  */
 export class LimitedCacheDecorator<V> implements Cache<V> {
   constructor(

--- a/packages/botonic-plugin-contentful/src/util/memoizer.ts
+++ b/packages/botonic-plugin-contentful/src/util/memoizer.ts
@@ -1,22 +1,9 @@
-export class Cache<V> {
-  static readonly NOT_FOUND = Symbol('NOT_FOUND')
-  cache: Record<string, V> = {}
-  set(id: string, val: V): void {
-    this.cache[id] = val
-  }
-  get(id: string): V | typeof Cache.NOT_FOUND {
-    // Cache.has is only checked when undefined to avoid always searching twice in the object
-    const val = this.cache[id]
-    if (val === undefined && !this.has(id)) {
-      return Cache.NOT_FOUND
-    }
-    return val
-  }
-  has(id: string): boolean {
-    return id in this.cache
-  }
-}
-
+import {
+  Cache,
+  InMemoryCache,
+  LimitedCacheDecorator,
+  NOT_FOUND_IN_CACHE,
+} from './cache'
 export type MemoizerNormalizer = (...args: any) => string
 
 export const jsonNormalizer: MemoizerNormalizer = (...args: any) => {
@@ -67,7 +54,7 @@ export const cacheForeverStrategy: MemoizerStrategy = async <
 ) => {
   const id = normalizer(...args)
   let val = cache.get(id)
-  if (val === Cache.NOT_FOUND) {
+  if (val === NOT_FOUND_IN_CACHE) {
     val = await func(...args)
     cache.set(id, val)
   }
@@ -94,7 +81,7 @@ export function fallbackStrategy(
       cache.set(id, newVal)
       return newVal
     } catch (e) {
-      if (oldVal !== Cache.NOT_FOUND) {
+      if (oldVal !== NOT_FOUND_IN_CACHE) {
         await usingFallback(String(func.name), args, e)
         return oldVal
       }

--- a/packages/botonic-plugin-contentful/src/util/memoizer.ts
+++ b/packages/botonic-plugin-contentful/src/util/memoizer.ts
@@ -1,9 +1,5 @@
-import {
-  Cache,
-  InMemoryCache,
-  LimitedCacheDecorator,
-  NOT_FOUND_IN_CACHE,
-} from './cache'
+import { Cache, InMemoryCache, NOT_FOUND_IN_CACHE } from './cache'
+
 export type MemoizerNormalizer = (...args: any) => string
 
 export const jsonNormalizer: MemoizerNormalizer = (...args: any) => {
@@ -23,7 +19,6 @@ export type MemoizerStrategy = <Args extends any[], Return>(
 
 export interface MemoizerOptions {
   strategy: MemoizerStrategy
-  logger?: (msg: string) => void
   cacheFactory?: () => Cache<any>
   normalizer?: MemoizerNormalizer
 }
@@ -33,16 +28,8 @@ export class Memoizer {
   constructor(opts: MemoizerOptions) {
     this.opts = {
       strategy: opts.strategy,
-      logger: opts.logger || console.error,
       normalizer: opts.normalizer || jsonNormalizer,
-      cacheFactory:
-        opts.cacheFactory ||
-        (() =>
-          new LimitedCacheDecorator(
-            new InMemoryCache<any>(),
-            100 * 1024,
-            this.opts.logger
-          )),
+      cacheFactory: opts.cacheFactory || (() => new InMemoryCache<any>()),
     }
   }
 

--- a/packages/botonic-plugin-contentful/src/util/objects.ts
+++ b/packages/botonic-plugin-contentful/src/util/objects.ts
@@ -61,3 +61,37 @@ export interface Stringable {
 }
 
 export interface ValueObject extends Equatable, Stringable {}
+
+/**
+ * It returns a ROUGH estimation, since V8 will greatly optimize anyway
+ * @return the number of bytes
+ * Not using https://www.npmjs.com/package/object-sizeof to minimize dependencies
+ */
+export function roughSizeOfObject(object: any): number {
+  const objectList: any[] = []
+
+  const recurse = function (value: any) {
+    let bytes = 0
+    if (typeof value === 'boolean') {
+      bytes = 4
+    } else if (typeof value === 'string') {
+      bytes = value.length * 2
+    } else if (typeof value === 'number') {
+      bytes = 8
+    } else if (value == null) {
+      // Required because typeof null == 'object'
+      bytes = 0
+    } else if (typeof value === 'object' && objectList.indexOf(value) === -1) {
+      objectList.push(value)
+      for (const [k, v] of Object.entries(value)) {
+        bytes += 8 // an assumed existence overhead
+        bytes += recurse(k)
+        bytes += recurse(v)
+      }
+    }
+
+    return bytes
+  }
+
+  return recurse(object)
+}

--- a/packages/botonic-plugin-contentful/tests/contentful/delivery/fallback-cache.test.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/delivery/fallback-cache.test.ts
@@ -54,7 +54,7 @@ async function testCallAfterHit<R>(
   expectedReturn: (api: MockClientApi) => R
 ) {
   const mockApi = new MockClientApi()
-  const sut = new FallbackCachedClientApi(mockApi, usingFallback)
+  const sut = new FallbackCachedClientApi(mockApi, 1, usingFallback)
   const expected = expectedReturn(mockApi)
 
   await expect(call(sut)).resolves.toBe(expected)
@@ -69,7 +69,7 @@ async function testFallbackIfFailure<R>(
   expectedReturn: (api: MockClientApi) => R
 ) {
   const mockApi = new MockClientApi()
-  const sut = new FallbackCachedClientApi(mockApi, usingFallback)
+  const sut = new FallbackCachedClientApi(mockApi, 1, usingFallback)
   const expected = expectedReturn(mockApi)
 
   await expect(call(sut)).resolves.toBe(expected)
@@ -93,7 +93,7 @@ async function testSuccessAfterFailure<R>(
   expectedReturn: (api: MockClientApi) => R
 ) {
   const mockApi = new MockClientApi()
-  const sut = new FallbackCachedClientApi(mockApi, usingFallback)
+  const sut = new FallbackCachedClientApi(mockApi, 1, usingFallback)
   const expected = expectedReturn(mockApi)
 
   mockApi.error = new Error('forced failure')

--- a/packages/botonic-plugin-contentful/tests/util/cache.test.ts
+++ b/packages/botonic-plugin-contentful/tests/util/cache.test.ts
@@ -1,0 +1,67 @@
+import { roughSizeOfObject } from '../../src'
+import {
+  Cache,
+  InMemoryCache,
+  LimitedCacheDecorator,
+} from '../../src/util/cache'
+
+describe('InMemoryCache', () => {
+  it('TEST: common functions', () => {
+    const sut = new InMemoryCache<string>()
+    testAllCacheMethod(sut)
+  })
+})
+
+describe('LimitedCacheDecorator', () => {
+  it('TEST: common functions', () => {
+    const sut = new LimitedCacheDecorator(new InMemoryCache<string>(), 1)
+    testAllCacheMethod(sut)
+  })
+
+  it('TEST: removes 2 items if it does not fit', () => {
+    const sut = new LimitedCacheDecorator(new InMemoryCache<string>(), 8 / 1024)
+    sut.set('1', '1')
+    sut.set('2', '2')
+    expect(sut.size()).toBe((2 * (2 + 2)) / 1024)
+
+    // act
+    sut.set('33', '33')
+
+    // arrange
+    expect(sut.size()).toBe((4 + 4) / 1024)
+    expect(Array.from(sut.keys())).toEqual(['33'])
+  })
+
+  it('TEST: does not add it if it does not fit', () => {
+    const sut = new LimitedCacheDecorator(new InMemoryCache<string>(), 4 / 1024)
+    sut.set('1', '1')
+
+    // act
+    sut.set('22', '22')
+
+    // arrange
+    expect(sut.size()).toBe(0)
+  })
+})
+
+function testAllCacheMethod(sut: Cache<string>) {
+  sut.set('k1', '1')
+  sut.set('k2', '12')
+  sut.set('k3', '123')
+  sut.del('k3')
+
+  // act
+  expect(sut.get('k2')).toEqual('12')
+
+  expect(sut.has('k3')).toEqual(false)
+
+  expect(Array.from(sut.keys())).toEqual(['k1', 'k2'])
+
+  expect(sut.size()).toBe(
+    (roughSizeOfObject('k1') +
+      roughSizeOfObject('1') +
+      roughSizeOfObject('k2') +
+      roughSizeOfObject('12')) /
+      1024
+  )
+}

--- a/packages/botonic-plugin-contentful/tests/util/memoizer.test.ts
+++ b/packages/botonic-plugin-contentful/tests/util/memoizer.test.ts
@@ -30,12 +30,12 @@ class MockF {
 describe('Memoizer', () => {
   it('TEST: cacheForeverStrategy common properties', async () => {
     await assertCommonStrategyProperties(
-      () => new Memoizer(cacheForeverStrategy),
+      () => new Memoizer({ strategy: cacheForeverStrategy }),
       false
     )
   })
   it('TEST: cacheForeverStrategy only fails if last call failed', async () => {
-    const sut = new Memoizer(cacheForeverStrategy)
+    const sut = new Memoizer({ strategy: cacheForeverStrategy })
     const mock = new MockF()
     const memoized = sut.memoize(mock.fA.bind(mock))
 
@@ -58,13 +58,13 @@ describe('Memoizer', () => {
 
   it('TEST: fallbackStrategy common properties', async () => {
     await assertCommonStrategyProperties(
-      () => new Memoizer(fallbackStrategy(usingFallback)),
+      () => new Memoizer({ strategy: fallbackStrategy(usingFallback) }),
       true
     )
   })
 
   it('TEST: fallbackStrategy uses last invocation result', async () => {
-    const sut = new Memoizer(fallbackStrategy(usingFallback))
+    const sut = new Memoizer({ strategy: fallbackStrategy(usingFallback) })
     const mock = new MockF()
     const memoized = sut.memoize(mock.fA.bind(mock))
 
@@ -76,7 +76,7 @@ describe('Memoizer', () => {
   })
 
   test('TEST: fallbackStrategy returns latest success return if function fails', async () => {
-    const sut = new Memoizer(fallbackStrategy(usingFallback))
+    const sut = new Memoizer({ strategy: fallbackStrategy(usingFallback) })
     const mock = new MockF()
     const memoized = sut.memoize(mock.fA.bind(mock))
 

--- a/packages/botonic-plugin-contentful/tests/util/objects.test.ts
+++ b/packages/botonic-plugin-contentful/tests/util/objects.test.ts
@@ -1,4 +1,8 @@
-import { deepClone, shallowClone } from '../../src/util/objects'
+import {
+  deepClone,
+  roughSizeOfObject,
+  shallowClone,
+} from '../../src/util/objects'
 
 class Subclass {
   constructor(public field: number) {}
@@ -52,4 +56,18 @@ test('TEST: deepClone no recursive call', () => {
   // act
   const copy = deepClone(source)
   expect(copy).toEqual(source)
+})
+
+describe('roughSizeOfObject', () => {
+  const repeatedObject = { '1': undefined }
+  test.each([
+    [true, 4],
+    [42, 8],
+    ['42', 2 * 2],
+    [{ '42': 42 }, 8 + 2 * 2 + 8],
+    [repeatedObject, 2 + 8],
+    [{ '4': repeatedObject, '2': repeatedObject }, 2 * (8 + 2) + 10],
+  ])('TEST roughSizeOfObject(%j)=%d', (o: any, size: number) => {
+    expect(roughSizeOfObject(o)).toBe(size)
+  })
 })


### PR DESCRIPTION
Depends on #1639 . :warning:  **Please review it first**

## Description

#1639 created fallback cache decorator around Contentful API which remembers forever the last successful invocation for each combination of arguments, and use its result whenever Contentful fails. 
This PR adds a limit in the in memory cache size to avoid memory overflows.

## Context

In case any bot adds arguments with non repeated values, the cache could grow infinitely.

## Approach taken / Explain the design

* When Cache reaches 50%, 75% or 90% size, a warning is reported to the logger configured in Contentful options
*  When Cache surpass the maximum size, existing cache items are deleted until the new item fits. 
* In the future, we might use an external library to have a LRU cache. Not critical because typically data in CMS is small (we're not caching media, only their URLs)

## To document / Usage example
The contentful plugin by default uses memoization to remember forever the last successful invocation for each combination of arguments, and use its result whenever Contentful fails. To limit the amount of memory

```
```

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
