### PR TITLE
chore(ner/intent): support for botonic full-stack

### DIFF
--- a/packages/botonic-plugin-intent-classification/src/index.ts
+++ b/packages/botonic-plugin-intent-classification/src/index.ts
@@ -9,10 +9,7 @@ export default class BotonicPluginIntentClassification implements Plugin {
   private readonly modelsSelector: Promise<IntentModelSelector>
 
   constructor(readonly options: PluginOptions) {
-    this.modelsSelector = IntentModelSelector.build(
-      this.options.locales,
-      this.options.modelsBaseUrl
-    )
+    this.modelsSelector = IntentModelSelector.build(this.options.locales)
   }
 
   async pre(request: PluginPreRequest): Promise<void> {

--- a/packages/botonic-plugin-intent-classification/src/model/model-selector.ts
+++ b/packages/botonic-plugin-intent-classification/src/model/model-selector.ts
@@ -9,11 +9,13 @@ export class IntentModelSelector extends ModelSelector<
   IntentClassifier,
   IntentClassifierConfig
 > {
-  static async build(
-    locales: Locale[],
-    modelsBaseUrl: string
-  ): Promise<IntentModelSelector> {
-    const selector = new IntentModelSelector(locales, modelsBaseUrl)
+  static async build(locales: Locale[]): Promise<IntentModelSelector> {
+    const baseUrl =
+      // @ts-ignore
+      (typeof MODELS_BASE_URL !== 'undefined' && MODELS_BASE_URL) ||
+      process.env.MODELS_BASE_URL
+    const intentModelsUrl = `${baseUrl}/intent-classification/models`
+    const selector = new IntentModelSelector(locales, intentModelsUrl)
     return await selector.load()
   }
 

--- a/packages/botonic-plugin-intent-classification/src/model/model-selector.ts
+++ b/packages/botonic-plugin-intent-classification/src/model/model-selector.ts
@@ -10,7 +10,7 @@ export class IntentModelSelector extends ModelSelector<
   IntentClassifierConfig
 > {
   static async build(locales: Locale[]): Promise<IntentModelSelector> {
-    const baseUrl =
+    const baseUrl: string =
       // @ts-ignore
       (typeof MODELS_BASE_URL !== 'undefined' && MODELS_BASE_URL) ||
       process.env.MODELS_BASE_URL

--- a/packages/botonic-plugin-intent-classification/src/options.ts
+++ b/packages/botonic-plugin-intent-classification/src/options.ts
@@ -1,3 +1,3 @@
 import { Locale } from '@botonic/nlp/lib/types'
 
-export type PluginOptions = { locales: Locale[]; modelsBaseUrl: string }
+export type PluginOptions = { locales: Locale[] }

--- a/packages/botonic-plugin-ner/src/index.ts
+++ b/packages/botonic-plugin-ner/src/index.ts
@@ -9,10 +9,7 @@ export default class BotonicPluginNER implements Plugin {
   private modelsSelector: Promise<NerModelSelector>
 
   constructor(readonly options: PluginOptions) {
-    this.modelsSelector = NerModelSelector.build(
-      this.options.locales,
-      this.options.modelsBaseUrl
-    )
+    this.modelsSelector = NerModelSelector.build(this.options.locales)
   }
 
   async pre(request: PluginPreRequest): Promise<void> {

--- a/packages/botonic-plugin-ner/src/model/model-selector.ts
+++ b/packages/botonic-plugin-ner/src/model/model-selector.ts
@@ -10,7 +10,7 @@ export class NerModelSelector extends ModelSelector<
   NerConfig
 > {
   static async build(locales: Locale[]): Promise<NerModelSelector> {
-    const baseUrl =
+    const baseUrl: string =
       // @ts-ignore
       (typeof MODELS_BASE_URL !== 'undefined' && MODELS_BASE_URL) ||
       process.env.MODELS_BASE_URL

--- a/packages/botonic-plugin-ner/src/model/model-selector.ts
+++ b/packages/botonic-plugin-ner/src/model/model-selector.ts
@@ -9,11 +9,13 @@ export class NerModelSelector extends ModelSelector<
   NamedEntityRecognizer,
   NerConfig
 > {
-  static async build(
-    locales: Locale[],
-    modelsBaseUrl: string
-  ): Promise<NerModelSelector> {
-    const selector = new NerModelSelector(locales, modelsBaseUrl)
+  static async build(locales: Locale[]): Promise<NerModelSelector> {
+    const baseUrl =
+      // @ts-ignore
+      (typeof MODELS_BASE_URL !== 'undefined' && MODELS_BASE_URL) ||
+      process.env.MODELS_BASE_URL
+    const nerModelsUrl = `${baseUrl}/ner/models`
+    const selector = new NerModelSelector(locales, nerModelsUrl)
     return await selector.load()
   }
 

--- a/packages/botonic-plugin-ner/src/options.ts
+++ b/packages/botonic-plugin-ner/src/options.ts
@@ -1,3 +1,3 @@
 import { Locale } from '@botonic/nlp/lib/types'
 
-export type PluginOptions = { locales: Locale[]; modelsBaseUrl: string }
+export type PluginOptions = { locales: Locale[] }


### PR DESCRIPTION
## Description
* Support for nlp plugins in botonic full-stack project.

## Context
MODELS_BASE_URL will be defined when the lambda of the bot is deployed under an env variable `process.env.MODELS_BASE_URL` and defined by webpack when it's run in development mode under `MODELS_BASE_URL`.