### PR TITLE
Full stack/chore(core): add data models for botonic 1.0

### DIFF
--- a/packages/botonic-core/src/models/events/connections/index.ts
+++ b/packages/botonic-core/src/models/events/connections/index.ts
@@ -7,5 +7,5 @@ export enum ConnectionEventStatuses {
 
 export interface ConnectionEvent extends BaseEvent {
   eventType: EventTypes.CONNECTION
-  status: typeof ConnectionEventStatuses[keyof typeof ConnectionEventStatuses]
+  status: ConnectionEventStatuses
 }

--- a/packages/botonic-core/src/models/events/connections/index.ts
+++ b/packages/botonic-core/src/models/events/connections/index.ts
@@ -1,10 +1,11 @@
 import { BaseEvent, EventTypes } from '..'
 
-export enum ConnectionEventStatus {
-  connected = 'connected',
-  disconnected = 'disconnected',
+export enum ConnectionEventStatuses {
+  CONNECTED = 'connected',
+  DISCONNECTED = 'disconnected',
 }
 
-export interface ConnectionEvent extends BaseEvent<EventTypes.connection> {
-  status: keyof typeof ConnectionEventStatus
+export interface ConnectionEvent extends BaseEvent {
+  eventType: EventTypes.CONNECTION
+  status: typeof ConnectionEventStatuses[keyof typeof ConnectionEventStatuses]
 }

--- a/packages/botonic-core/src/models/events/connections/index.ts
+++ b/packages/botonic-core/src/models/events/connections/index.ts
@@ -1,0 +1,10 @@
+import { BaseEvent, EventTypes } from '..'
+
+export enum ConnectionEventStatus {
+  connected = 'connected',
+  disconnected = 'disconnected',
+}
+
+export interface ConnectionEvent extends BaseEvent<EventTypes.connection> {
+  status: keyof typeof ConnectionEventStatus
+}

--- a/packages/botonic-core/src/models/events/index.ts
+++ b/packages/botonic-core/src/models/events/index.ts
@@ -19,6 +19,7 @@ export enum EventTypes {
 
 export interface BaseEvent {
   id: string
+  userId: string
   eventType: typeof EventTypes[keyof typeof EventTypes]
   createdAt: string
   modifiedAt?: string

--- a/packages/botonic-core/src/models/events/index.ts
+++ b/packages/botonic-core/src/models/events/index.ts
@@ -1,20 +1,20 @@
-import { TextMessageEvent } from './message/text'
-import { MediaMessageEvent } from './message/media'
-import { LocationMessageEvent } from './message/location'
+import { ConnectionEvent } from './connections/index'
 import { CarouselMessageEvent } from './message/carousel'
 import { CustomMessageEvent } from './message/custom'
-import { ConnectionEvent } from './connections/index'
+import { LocationMessageEvent } from './message/location'
+import { MediaMessageEvent } from './message/media'
+import { TextMessageEvent } from './message/text'
 
 export enum EventTypes {
-  connection = 'connection',
-  message = 'message',
-  ack = 'ack',
-  track = 'track',
+  CONNECTION = 'connection',
+  MESSAGE = 'message',
+  ACK = 'ack',
+  TRACK = 'track',
 }
 
-export interface BaseEvent<EventType extends EventTypes> {
+export interface BaseEvent {
   id: string
-  eventType: EventType
+  eventType: typeof EventTypes[keyof typeof EventTypes]
   createdAt: string
   modifiedAt?: string
 }

--- a/packages/botonic-core/src/models/events/index.ts
+++ b/packages/botonic-core/src/models/events/index.ts
@@ -1,0 +1,28 @@
+import { TextMessageEvent } from './message/text'
+import { MediaMessageEvent } from './message/media'
+import { LocationMessageEvent } from './message/location'
+import { CarouselMessageEvent } from './message/carousel'
+import { CustomMessageEvent } from './message/custom'
+import { ConnectionEvent } from './connections/index'
+
+export enum EventTypes {
+  connection = 'connection',
+  message = 'message',
+  ack = 'ack',
+  track = 'track',
+}
+
+export interface BaseEvent<EventType extends EventTypes> {
+  id: string
+  eventType: EventType
+  createdAt: string
+  modifiedAt?: string
+}
+
+export type BotonicEvent =
+  | TextMessageEvent
+  | MediaMessageEvent
+  | LocationMessageEvent
+  | CarouselMessageEvent
+  | CustomMessageEvent
+  | ConnectionEvent

--- a/packages/botonic-core/src/models/events/index.ts
+++ b/packages/botonic-core/src/models/events/index.ts
@@ -20,7 +20,7 @@ export enum EventTypes {
 export interface BaseEvent {
   id: string
   userId: string
-  eventType: typeof EventTypes[keyof typeof EventTypes]
+  eventType: EventTypes
   createdAt: string
   modifiedAt?: string
 }

--- a/packages/botonic-core/src/models/events/index.ts
+++ b/packages/botonic-core/src/models/events/index.ts
@@ -2,7 +2,12 @@ import { ConnectionEvent } from './connections/index'
 import { CarouselMessageEvent } from './message/carousel'
 import { CustomMessageEvent } from './message/custom'
 import { LocationMessageEvent } from './message/location'
-import { MediaMessageEvent } from './message/media'
+import {
+  AudioMessageEvent,
+  DocumentMessageEvent,
+  ImageMessageEvent,
+  VideoMessageEvent,
+} from './message/media'
 import { TextMessageEvent } from './message/text'
 
 export enum EventTypes {
@@ -21,7 +26,10 @@ export interface BaseEvent {
 
 export type BotonicEvent =
   | TextMessageEvent
-  | MediaMessageEvent
+  | AudioMessageEvent
+  | DocumentMessageEvent
+  | ImageMessageEvent
+  | VideoMessageEvent
   | LocationMessageEvent
   | CarouselMessageEvent
   | CustomMessageEvent

--- a/packages/botonic-core/src/models/events/message/buttons.ts
+++ b/packages/botonic-core/src/models/events/message/buttons.ts
@@ -1,0 +1,23 @@
+export interface BaseButton {
+  title: string
+}
+
+export interface WebviewButton extends BaseButton {
+  webview: any
+  params?: any
+}
+
+export interface UrlButton extends BaseButton {
+  url: string
+  target?: string
+}
+
+export interface PayloadButton extends BaseButton {
+  payload: string
+}
+
+export type Button = PayloadButton | UrlButton | WebviewButton
+
+export interface WithButtons {
+  buttons?: Button[]
+}

--- a/packages/botonic-core/src/models/events/message/carousel.ts
+++ b/packages/botonic-core/src/models/events/message/carousel.ts
@@ -1,8 +1,7 @@
-import { BotonicMessageEvent, MessageEventType } from '.'
+import { BotonicMessageEvent, MessageEventTypes } from '.'
 import { CarouselElement } from './element'
 
-export interface CarouselMessageEvent
-  extends BotonicMessageEvent<MessageEventType.carousel> {
-  type: MessageEventType.carousel
+export interface CarouselMessageEvent extends BotonicMessageEvent {
+  type: MessageEventTypes.CAROUSEL
   elements: CarouselElement[]
 }

--- a/packages/botonic-core/src/models/events/message/carousel.ts
+++ b/packages/botonic-core/src/models/events/message/carousel.ts
@@ -1,0 +1,8 @@
+import { BotonicMessageEvent, MessageEventType } from '.'
+import { CarouselElement } from './element'
+
+export interface CarouselMessageEvent
+  extends BotonicMessageEvent<MessageEventType.carousel> {
+  type: MessageEventType.carousel
+  elements: CarouselElement[]
+}

--- a/packages/botonic-core/src/models/events/message/custom.ts
+++ b/packages/botonic-core/src/models/events/message/custom.ts
@@ -1,9 +1,7 @@
-import { BotonicMessageEvent, MessageEventType } from '.'
+import { BotonicMessageEvent, MessageEventTypes } from '.'
 import { WithReplies } from './replies'
 
-export interface CustomMessageEvent
-  extends BotonicMessageEvent<MessageEventType.custom>,
-    WithReplies {
-  type: MessageEventType.custom
+export interface CustomMessageEvent extends BotonicMessageEvent, WithReplies {
+  type: MessageEventTypes.CUSTOM
   customTypeName: string
 }

--- a/packages/botonic-core/src/models/events/message/custom.ts
+++ b/packages/botonic-core/src/models/events/message/custom.ts
@@ -1,0 +1,9 @@
+import { BotonicMessageEvent, MessageEventType } from '.'
+import { WithReplies } from './replies'
+
+export interface CustomMessageEvent
+  extends BotonicMessageEvent<MessageEventType.custom>,
+    WithReplies {
+  type: MessageEventType.custom
+  customTypeName: string
+}

--- a/packages/botonic-core/src/models/events/message/element.ts
+++ b/packages/botonic-core/src/models/events/message/element.ts
@@ -1,7 +1,7 @@
 import { WithButtons } from './buttons'
 
 export interface CarouselElement extends WithButtons {
-  src: string
+  pic: string
   title: string
   subtitle?: string
 }

--- a/packages/botonic-core/src/models/events/message/element.ts
+++ b/packages/botonic-core/src/models/events/message/element.ts
@@ -1,0 +1,7 @@
+import { WithButtons } from './buttons'
+
+export interface CarouselElement extends WithButtons {
+  src: string
+  title: string
+  subtitle?: string
+}

--- a/packages/botonic-core/src/models/events/message/index.ts
+++ b/packages/botonic-core/src/models/events/message/index.ts
@@ -1,32 +1,31 @@
-import { BaseEvent, EventTypes } from '..'
+import { BaseEvent } from '..'
 
-export enum MessageEventType {
-  text = 'text',
-  audio = 'audio',
-  document = 'document',
-  image = 'image',
-  video = 'video',
-  location = 'location',
-  carousel = 'carousel',
-  custom = 'custom',
+export enum MessageEventTypes {
+  AUDIO = 'audio',
+  CAROUSEL = 'carousel',
+  CUSTOM = 'custom',
+  DOCUMENT = 'document',
+  IMAGE = 'image',
+  LOCATION = 'location',
+  TEXT = 'text',
+  VIDEO = 'video',
 }
 
 export enum MessageEventAck {
-  draft = 'draft',
-  sent = 'sent',
-  received = 'received',
-  read = 'read',
+  DRAFT = 'draft',
+  READ = 'read',
+  RECEIVED = 'received',
+  SENT = 'sent',
 }
 
 export enum MessageEventFrom {
-  user = 'user',
-  bot = 'bot',
-  agent = 'agent',
+  AGENT = 'agent',
+  BOT = 'bot',
+  USER = 'user',
 }
 
-export interface BotonicMessageEvent<MessageType>
-  extends BaseEvent<EventTypes.message> {
-  type: MessageType
-  ack: keyof typeof MessageEventAck
-  from: keyof typeof MessageEventFrom
+export interface BotonicMessageEvent extends BaseEvent {
+  ack: typeof MessageEventAck[keyof typeof MessageEventAck]
+  from: typeof MessageEventFrom[keyof typeof MessageEventFrom]
+  type: typeof MessageEventTypes[keyof typeof MessageEventTypes]
 }

--- a/packages/botonic-core/src/models/events/message/index.ts
+++ b/packages/botonic-core/src/models/events/message/index.ts
@@ -1,0 +1,32 @@
+import { BaseEvent, EventTypes } from '..'
+
+export enum MessageEventType {
+  text = 'text',
+  audio = 'audio',
+  document = 'document',
+  image = 'image',
+  video = 'video',
+  location = 'location',
+  carousel = 'carousel',
+  custom = 'custom',
+}
+
+export enum MessageEventAck {
+  draft = 'draft',
+  sent = 'sent',
+  received = 'received',
+  read = 'read',
+}
+
+export enum MessageEventFrom {
+  user = 'user',
+  bot = 'bot',
+  agent = 'agent',
+}
+
+export interface BotonicMessageEvent<MessageType>
+  extends BaseEvent<EventTypes.message> {
+  type: MessageType
+  ack: keyof typeof MessageEventAck
+  from: keyof typeof MessageEventFrom
+}

--- a/packages/botonic-core/src/models/events/message/index.ts
+++ b/packages/botonic-core/src/models/events/message/index.ts
@@ -25,7 +25,7 @@ export enum MessageEventFrom {
 }
 
 export interface BotonicMessageEvent extends BaseEvent {
-  ack: typeof MessageEventAck[keyof typeof MessageEventAck]
-  from: typeof MessageEventFrom[keyof typeof MessageEventFrom]
-  type: typeof MessageEventTypes[keyof typeof MessageEventTypes]
+  ack: MessageEventAck
+  from: MessageEventFrom
+  type: MessageEventTypes
 }

--- a/packages/botonic-core/src/models/events/message/location.ts
+++ b/packages/botonic-core/src/models/events/message/location.ts
@@ -1,7 +1,7 @@
-import { BotonicMessageEvent, MessageEventType } from '.'
+import { BotonicMessageEvent, MessageEventTypes } from '.'
 
-export interface LocationMessageEvent
-  extends BotonicMessageEvent<MessageEventType.location> {
+export interface LocationMessageEvent extends BotonicMessageEvent {
+  type: MessageEventTypes.LOCATION
   lat: number
   long: number
 }

--- a/packages/botonic-core/src/models/events/message/location.ts
+++ b/packages/botonic-core/src/models/events/message/location.ts
@@ -1,0 +1,7 @@
+import { BotonicMessageEvent, MessageEventType } from '.'
+
+export interface LocationMessageEvent
+  extends BotonicMessageEvent<MessageEventType.location> {
+  lat: number
+  long: number
+}

--- a/packages/botonic-core/src/models/events/message/media.ts
+++ b/packages/botonic-core/src/models/events/message/media.ts
@@ -7,20 +7,16 @@ interface MediaMessageEvent extends BotonicMessageEvent, WithButtons {
 
 export interface AudioMessageEvent extends MediaMessageEvent {
   type: MessageEventTypes.AUDIO
-  src: string
 }
 
 export interface ImageMessageEvent extends MediaMessageEvent {
   type: MessageEventTypes.IMAGE
-  src: string
 }
 
 export interface DocumentMessageEvent extends MediaMessageEvent {
   type: MessageEventTypes.DOCUMENT
-  src: string
 }
 
 export interface VideoMessageEvent extends MediaMessageEvent {
   type: MessageEventTypes.VIDEO
-  src: string
 }

--- a/packages/botonic-core/src/models/events/message/media.ts
+++ b/packages/botonic-core/src/models/events/message/media.ts
@@ -1,27 +1,23 @@
-import { BotonicMessageEvent, MessageEventType } from '.'
+import { BotonicMessageEvent, MessageEventTypes } from '.'
 import { WithButtons } from './buttons'
 
-export interface AudioMessageEvent
-  extends BotonicMessageEvent<MessageEventType.audio>,
-    WithButtons {
+export interface AudioMessageEvent extends BotonicMessageEvent, WithButtons {
+  type: MessageEventTypes.AUDIO
   src: string
 }
 
-export interface ImageMessageEvent
-  extends BotonicMessageEvent<MessageEventType.image>,
-    WithButtons {
+export interface ImageMessageEvent extends BotonicMessageEvent, WithButtons {
+  type: MessageEventTypes.IMAGE
   src: string
 }
 
-export interface DocumentMessageEvent
-  extends BotonicMessageEvent<MessageEventType.document>,
-    WithButtons {
+export interface DocumentMessageEvent extends BotonicMessageEvent, WithButtons {
+  type: MessageEventTypes.DOCUMENT
   src: string
 }
 
-export interface VideoMessageEvent
-  extends BotonicMessageEvent<MessageEventType.video>,
-    WithButtons {
+export interface VideoMessageEvent extends BotonicMessageEvent, WithButtons {
+  type: MessageEventTypes.VIDEO
   src: string
 }
 

--- a/packages/botonic-core/src/models/events/message/media.ts
+++ b/packages/botonic-core/src/models/events/message/media.ts
@@ -1,0 +1,32 @@
+import { BotonicMessageEvent, MessageEventType } from '.'
+import { WithButtons } from './buttons'
+
+export interface AudioMessageEvent
+  extends BotonicMessageEvent<MessageEventType.audio>,
+    WithButtons {
+  src: string
+}
+
+export interface ImageMessageEvent
+  extends BotonicMessageEvent<MessageEventType.image>,
+    WithButtons {
+  src: string
+}
+
+export interface DocumentMessageEvent
+  extends BotonicMessageEvent<MessageEventType.document>,
+    WithButtons {
+  src: string
+}
+
+export interface VideoMessageEvent
+  extends BotonicMessageEvent<MessageEventType.video>,
+    WithButtons {
+  src: string
+}
+
+export type MediaMessageEvent =
+  | AudioMessageEvent
+  | ImageMessageEvent
+  | DocumentMessageEvent
+  | VideoMessageEvent

--- a/packages/botonic-core/src/models/events/message/media.ts
+++ b/packages/botonic-core/src/models/events/message/media.ts
@@ -1,28 +1,26 @@
 import { BotonicMessageEvent, MessageEventTypes } from '.'
 import { WithButtons } from './buttons'
 
-export interface AudioMessageEvent extends BotonicMessageEvent, WithButtons {
+interface MediaMessageEvent extends BotonicMessageEvent, WithButtons {
+  src: string
+}
+
+export interface AudioMessageEvent extends MediaMessageEvent {
   type: MessageEventTypes.AUDIO
   src: string
 }
 
-export interface ImageMessageEvent extends BotonicMessageEvent, WithButtons {
+export interface ImageMessageEvent extends MediaMessageEvent {
   type: MessageEventTypes.IMAGE
   src: string
 }
 
-export interface DocumentMessageEvent extends BotonicMessageEvent, WithButtons {
+export interface DocumentMessageEvent extends MediaMessageEvent {
   type: MessageEventTypes.DOCUMENT
   src: string
 }
 
-export interface VideoMessageEvent extends BotonicMessageEvent, WithButtons {
+export interface VideoMessageEvent extends MediaMessageEvent {
   type: MessageEventTypes.VIDEO
   src: string
 }
-
-export type MediaMessageEvent =
-  | AudioMessageEvent
-  | ImageMessageEvent
-  | DocumentMessageEvent
-  | VideoMessageEvent

--- a/packages/botonic-core/src/models/events/message/replies.ts
+++ b/packages/botonic-core/src/models/events/message/replies.ts
@@ -1,0 +1,8 @@
+export interface Reply {
+  title: string
+  payload: string
+}
+
+export interface WithReplies {
+  replies?: Reply[]
+}

--- a/packages/botonic-core/src/models/events/message/text.ts
+++ b/packages/botonic-core/src/models/events/message/text.ts
@@ -1,0 +1,11 @@
+import { BotonicMessageEvent, MessageEventType } from '.'
+import { WithButtons } from './buttons'
+import { WithReplies } from './replies'
+
+export interface TextMessageEvent
+  extends BotonicMessageEvent<MessageEventType.text>,
+    WithReplies,
+    WithButtons {
+  markdown: boolean
+  text: string
+}

--- a/packages/botonic-core/src/models/events/message/text.ts
+++ b/packages/botonic-core/src/models/events/message/text.ts
@@ -1,11 +1,12 @@
-import { BotonicMessageEvent, MessageEventType } from '.'
+import { BotonicMessageEvent, MessageEventTypes } from '.'
 import { WithButtons } from './buttons'
 import { WithReplies } from './replies'
 
 export interface TextMessageEvent
-  extends BotonicMessageEvent<MessageEventType.text>,
+  extends BotonicMessageEvent,
     WithReplies,
     WithButtons {
+  type: MessageEventTypes.TEXT
   markdown: boolean
   text: string
 }

--- a/packages/botonic-core/src/models/user.ts
+++ b/packages/botonic-core/src/models/user.ts
@@ -1,0 +1,9 @@
+import { Session } from '../types/'
+export interface User {
+  id: string //TODO: UUID
+  websocketId: string
+  session: Session
+  route: string
+  isOnline: boolean
+  locationInfo: string
+}


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Adding data models proposal into `@botonic/core` (note that some definitions may be susceptible to be changed) without conflicting with current `@botonic/core` functionality.

## Context
* Defining data models for botonic full stack.

## Approach taken / Explain the design
* We defined the most simple data models for botonic full-stack. Each model it's being composed by extending from more basics interfaces (MessageEvent, ConnectionEvent, ...) and defining attributes more specifically in the very bottom interfaces (TextMessageEvent, ConnectionEvent, ...)  For these models it's important to:
1. Be able to have all the event details in separated fields to have the data as plain as possible in the database (will be useful for analytics concerns).
2. Be able to have dynamic resolution of typings.

To achieve both objectives, the purposed model is the following:
<img width="1242" alt="Screenshot 2021-06-17 at 13 40 30" src="https://user-images.githubusercontent.com/35448568/122392161-ec71c600-cf73-11eb-902d-55e1b2cde5ef.png">

A specific instance of a `TextMessageEvent` for example would contain all this information, that will be stored in the database:
<img width="390" alt="Screenshot 2021-06-17 at 13 53 09" src="https://user-images.githubusercontent.com/35448568/122394554-6905a400-cf76-11eb-9beb-ad52382b80c2.png">

With this, we would be able to store the data as plain as possible in a DynamoDB table (with single table design approach, which will allow to save infrastructure costs): 
<img width="774" alt="Screenshot 2021-06-11 at 18 03 18" src="https://user-images.githubusercontent.com/35448568/122394221-03b1b300-cf76-11eb-9d37-e0e128247e41.png">

And having dynamic type resolution:
```
async saveEvent(event: BotonicEvent): Promise<BotonicEvent> {
    if (event.eventType === 'message') {
      if (event.type === 'text') {
        await this.textMessageEventEntity.put(event)
      }
    }
    ...
}
```

**Note**: `MessageEvent` is named as `BotonicMessageEvent` in the source code due to conflicts with typescript dom definitions.

Scheme: 
[models.zip](https://github.com/hubtype/botonic/files/6670234/models.zip)
