### PR TITLE
feat(core): add optional timeout to getOpenQueues & storeCaseRating

### DIFF
--- a/packages/botonic-core/src/handoff.js
+++ b/packages/botonic-core/src/handoff.js
@@ -2,9 +2,17 @@ import axios from 'axios'
 
 const HUBTYPE_API_URL = 'https://api.hubtype.com'
 
-export async function getOpenQueues(session) {
+function contextDefaults(context) {
+  return {
+    timeoutMs: context.timeoutMs || 10000,
+  }
+}
+
+export async function getOpenQueues(session, context = {}) {
+  //be aware of https://github.com/axios/axios/issues/1543
   const baseUrl = session._hubtype_api || HUBTYPE_API_URL
   const endpointUrl = `${baseUrl}/v1/queues/get_open_queues/`
+  context = contextDefaults(context)
   const resp = await axios({
     headers: {
       Authorization: `Bearer ${session._access_token}`,
@@ -12,6 +20,7 @@ export async function getOpenQueues(session) {
     method: 'post',
     url: endpointUrl,
     data: { bot_id: session.bot.id },
+    timeout: context.timeoutMs,
   })
   return resp.data
 }
@@ -130,9 +139,10 @@ async function _humanHandOff(
   session._botonic_action = `create_case:${JSON.stringify(params)}`
 }
 
-export async function storeCaseRating(session, rating) {
+export async function storeCaseRating(session, rating, context = {}) {
   const baseUrl = session._hubtype_api || HUBTYPE_API_URL
   const chatId = session.user.id
+  context = contextDefaults(context)
   const resp = await axios({
     headers: {
       Authorization: `Bearer ${session._access_token}`,
@@ -140,6 +150,7 @@ export async function storeCaseRating(session, rating) {
     method: 'post',
     url: `${baseUrl}/v1/chats/${chatId}/store_case_rating/`,
     data: { chat_id: chatId, rating },
+    timeout: context.timeoutMs,
   })
   return resp.data
 }

--- a/packages/botonic-core/src/types/handoff.d.ts
+++ b/packages/botonic-core/src/types/handoff.d.ts
@@ -8,13 +8,22 @@ export interface HubtypeAgentsInfo {
   status: string
 }
 
+/**
+ * TODO add context argument to all API calls
+ */
+export interface BackendContext {
+  timeoutMs?: number
+}
+
 export declare function getOpenQueues(
-  session: Session
+  session: Session,
+  context?: BackendContext
 ): Promise<{ queues: string[] }>
 
 export declare function storeCaseRating(
   session: Session,
-  rating: number
+  rating: number,
+  context?: BackendContext
 ): Promise<{ status: string }>
 
 export declare function getAvailableAgentsByQueue(


### PR DESCRIPTION
## Description

Added timeout argument to 2 of the API calls to backend. If approach is approved, it should be added to the rest of API calls

## Context

* In case a call to backend hangs for many seconds, timeout ensures that the bot is able to react (eg. providing an error message or retrying) before the AWS lambda timeout aborts the bot invocation.

## Approach taken / Explain the design

Added in a context argument (like in contentful plugin) so that more options can be added in the future

## To document / Usage example

TODO

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because it's a call to backend