### PR TITLE
fix(contentful): use of 1st argument (file_to_import)

### DIFF
--- a/packages/botonic-plugin-contentful/bin/import-contentful-models.sh
+++ b/packages/botonic-plugin-contentful/bin/import-contentful-models.sh
@@ -8,7 +8,7 @@ if [[ "$1" == "" ]]; then
   exit 1
 fi
 
-JSON_FILE="$( cd "$( dirname "$SOURCE" )" && pwd )/$(basename $SOURCE)"
+JSON_FILE="$( cd "$( dirname "$1" )" && pwd )/$(basename $1)"
 
 if [[ "$CONTENTFUL_SPACEID" == "" ]]; then
   echo "Assign your contentful account space id to environment variable CONTENTFUL_SPACEID"


### PR DESCRIPTION
## Description
Fix the `import-contentful-models.sh` script to load the import file correctly (the `file_to_import` argument was not used in the script)

## Context
The `import-contentful-models.sh` was loading the file to import properly.

## Approach taken / Explain the design

## To document / Usage example

## Testing

The pull request has no tests.