### PR TITLE
feat(react): Display <Button> components as normal buttons in whatsapp

### DIFF
--- a/packages/botonic-react/src/components/multichannel/index.d.ts
+++ b/packages/botonic-react/src/components/multichannel/index.d.ts
@@ -31,6 +31,7 @@ export interface MultichannelCarouselProps extends MultichannelViewOptions {
   indexMode?: IndexMode
   showTitle?: boolean
   showSubtitle?: boolean
+  buttonsAsText?: boolean
 }
 export const MultichannelCarousel: React.FunctionComponent<MultichannelCarouselProps>
 

--- a/packages/botonic-react/src/components/multichannel/index.d.ts
+++ b/packages/botonic-react/src/components/multichannel/index.d.ts
@@ -19,6 +19,8 @@ export interface MultichannelTextProps extends MultichannelViewOptions {
   indexMode?: IndexMode
   /** Defaults to no separator between lines*/
   newline?: string
+  buttonsAsText?: boolean
+  buttonsTextSeparator?: string
 }
 
 export const MultichannelText: React.FunctionComponent<MultichannelTextProps>
@@ -39,6 +41,7 @@ export interface MultichannelButtonProps {
   payload?: string
   url?: string
   webview?: string
+  asText?: boolean
 }
 export const MultichannelButton: React.FunctionComponent<MultichannelButtonProps>
 

--- a/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
@@ -64,7 +64,8 @@ export const MultichannelButton = props => {
   }
 
   if (isWhatsapp(requestContext)) {
-    if (props.asText) {
+    const asText = props.asText == null ? true : props.asText
+    if (asText) {
       if (hasUrl()) {
         return `${getText()}: ${getUrl()}`
       } else if (hasPath() || hasPayload()) {

--- a/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
@@ -34,10 +34,7 @@ export const MultichannelButton = props => {
   }
 
   const formatIndex = index => {
-    const boldIndex =
-      multichannelContext.boldIndex == null
-        ? false
-        : multichannelContext.boldIndex
+    const boldIndex = multichannelContext.boldIndex ?? false
     return boldIndex ? `*${index}*` : index
   }
 
@@ -64,7 +61,7 @@ export const MultichannelButton = props => {
   }
 
   if (isWhatsapp(requestContext)) {
-    const asText = props.asText == null ? true : props.asText
+    const asText = props.asText ?? true
     if (asText) {
       if (hasUrl()) {
         return `${getText()}: ${getUrl()}`

--- a/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
@@ -73,13 +73,12 @@ export const MultichannelButton = props => {
         increaseCurrentIndex()
         return `${text}`
       } else if (hasWebview()) return <Button {...props}>{getText()}</Button>
-    } else {
-      return (
-        <Button {...props}>
-          {truncateText(props.children, WHATSAPP_MAX_BUTTON_CHARS)}
-        </Button>
-      )
     }
+    return (
+      <Button {...props}>
+        {truncateText(props.children, WHATSAPP_MAX_BUTTON_CHARS)}
+      </Button>
+    )
   }
   return <Button {...props}>{props.children}</Button>
 }

--- a/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-button.jsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react'
 import { RequestContext } from '../../contexts'
 import { Button } from '../button'
 import { MultichannelContext } from './multichannel-context'
-import { isWhatsapp } from './multichannel-utils'
+import { isWhatsapp, WHATSAPP_MAX_BUTTON_CHARS } from './multichannel-utils'
 
 export const MultichannelButton = props => {
   const requestContext = useContext(RequestContext)
@@ -56,15 +56,29 @@ export const MultichannelButton = props => {
     return text
   }
 
+  const truncateText = (text, maxLength, ellipsis = '...') => {
+    if (text.length > maxLength) {
+      return text.substring(0, maxLength - ellipsis.length) + ellipsis
+    }
+    return text
+  }
+
   if (isWhatsapp(requestContext)) {
-    if (hasUrl()) {
-      return `${getText()}: ${getUrl()}`
-    } else if (hasPath() || hasPayload()) {
-      const text = getText()
-      increaseCurrentIndex()
-      return `${text}`
-    } else if (hasWebview()) return <Button {...props}>{getText()}</Button>
-    else return <Button {...props}>{props.children}</Button>
+    if (props.asText) {
+      if (hasUrl()) {
+        return `${getText()}: ${getUrl()}`
+      } else if (hasPath() || hasPayload()) {
+        const text = getText()
+        increaseCurrentIndex()
+        return `${text}`
+      } else if (hasWebview()) return <Button {...props}>{getText()}</Button>
+    } else {
+      return (
+        <Button {...props}>
+          {truncateText(props.children, WHATSAPP_MAX_BUTTON_CHARS)}
+        </Button>
+      )
+    }
   }
   return <Button {...props}>{props.children}</Button>
 }

--- a/packages/botonic-react/src/components/multichannel/multichannel-carousel.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-carousel.jsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react'
 
 import { RequestContext } from '../../contexts'
 import { Carousel } from '../carousel'
-// import { Image } from '../image'
 import { MultichannelText } from './multichannel-text'
 import {
   getFilteredElements,
@@ -18,7 +17,7 @@ export const MultichannelCarousel = props => {
     [].concat(getFilteredElements(node, isMultichannelButton))
 
   if (isWhatsapp(requestContext)) {
-    const elementsAsTexts = props.children
+    const elements = props.children
       .map(e => e.props.children)
       .map((element, i) => {
         let imageProps = undefined
@@ -59,7 +58,12 @@ export const MultichannelCarousel = props => {
 
         return (
           // TODO: newkey only for 1 nested button
-          <MultichannelText key={i} newkey={i} indexMode={props.indexMode}>
+          <MultichannelText
+            key={i}
+            newkey={i}
+            indexMode={props.indexMode}
+            buttonsAsText={props.buttonsAsText}
+          >
             {header || null}
             {buttons}
           </MultichannelText>
@@ -83,7 +87,7 @@ export const MultichannelCarousel = props => {
         // )
         // }
       })
-    return elementsAsTexts
+    return elements
   } else {
     return <Carousel {...props}>{props.children}</Carousel>
   }

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -23,8 +23,7 @@ import {
 export const MultichannelText = props => {
   const requestContext = useContext(RequestContext)
   const multichannelContext = useContext(MultichannelContext)
-  const postbackButtonsAsText =
-    props.buttonsAsText == null ? true : props.buttonsAsText
+  const postbackButtonsAsText = props.buttonsAsText ?? true
 
   let elements = []
 

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -6,10 +6,12 @@ import { MultichannelFacebook } from './facebook/facebook'
 import { MultichannelButton } from './multichannel-button'
 import { MultichannelContext } from './multichannel-context'
 import {
+  buttonTypes,
   DEFAULT_WHATSAPP_MAX_BUTTON_SEPARATOR,
   elementHasPostback,
   elementHasUrl,
   elementHasWebview,
+  getButtonType,
   getMultichannelButtons,
   getMultichannelReplies,
   isFacebook,
@@ -17,12 +19,6 @@ import {
   MULTICHANNEL_WHATSAPP_PROPS,
   WHATSAPP_MAX_BUTTONS,
 } from './multichannel-utils'
-
-const buttonTypes = {
-  POSTBACK: 'postback',
-  URL: 'url',
-  WEBVIEW: 'webview',
-}
 
 export const MultichannelText = props => {
   const requestContext = useContext(RequestContext)
@@ -75,9 +71,11 @@ export const MultichannelText = props => {
     return props.indexMode === 'letter' ? 'a' : 1
   }
 
-  const generateMultichannelButtons = (type, newLineFirstButton = true) => {
-    const asText = type === buttonTypes.POSTBACK ? postbackButtonsAsText : true
-    const generator = (element, i) => {
+  const regenerateMultichannelButtons = (newLineFirstButton = true) => {
+    const generator = (multichannelButton, i) => {
+      const type = getButtonType(multichannelButton)
+      const asText =
+        type === buttonTypes.POSTBACK ? postbackButtonsAsText : true
       const newline =
         multichannelContext.messageSeparator == null &&
         !newLineFirstButton &&
@@ -89,9 +87,9 @@ export const MultichannelText = props => {
           key={`${type}${i}`}
           newline={newline}
           asText={asText}
-          {...element.props}
+          {...multichannelButton.props}
         >
-          {element.props.children}
+          {multichannelButton.props.children}
         </MultichannelButton>
       )
     }
@@ -115,7 +113,7 @@ export const MultichannelText = props => {
     })
 
     const webviewButtonElements = webviewButtons.map(
-      generateMultichannelButtons('webview', false)
+      regenerateMultichannelButtons(false)
     )
 
     const buttonsTextSeparator =
@@ -126,13 +124,10 @@ export const MultichannelText = props => {
       postbackButtons.length > WHATSAPP_MAX_BUTTONS
     ) {
       const urlButtonElements = urlButtons.map(
-        generateMultichannelButtons('url', !!texts.length)
+        regenerateMultichannelButtons(!!texts.length)
       )
       const postbackButtonElements = postbackButtons.map(
-        generateMultichannelButtons(
-          'postback',
-          !!texts.length || !!urlButtons.length
-        )
+        regenerateMultichannelButtons(!!texts.length || !!urlButtons.length)
       )
       const messagesPostbackButtons = splitPostbackButtons(
         postbackButtonElements
@@ -165,11 +160,10 @@ export const MultichannelText = props => {
     } else {
       multichannelContext.currentIndex = getDefaultIndex()
       const postbackButtonElements = postbackButtons.map(
-        generateMultichannelButtons('postback', !!texts.length)
+        regenerateMultichannelButtons(!!texts.length)
       )
       const urlButtonElements = urlButtons.map(
-        generateMultichannelButtons(
-          'url',
+        regenerateMultichannelButtons(
           !!texts.length || !!postbackButtons.length
         )
       )

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -6,20 +6,29 @@ import { MultichannelFacebook } from './facebook/facebook'
 import { MultichannelButton } from './multichannel-button'
 import { MultichannelContext } from './multichannel-context'
 import {
+  DEFAULT_WHATSAPP_MAX_BUTTON_SEPARATOR,
   elementHasPostback,
   elementHasUrl,
   getMultichannelButtons,
   getMultichannelReplies,
   isFacebook,
-  isMultichannelButton,
-  isMultichannelReply,
   isWhatsapp,
   MULTICHANNEL_WHATSAPP_PROPS,
+  WHATSAPP_MAX_BUTTON_CHARS,
+  WHATSAPP_MAX_BUTTONS,
 } from './multichannel-utils'
+
+const buttonTypes = {
+  POSTBACK: 'postback',
+  URL: 'url',
+  WEBVIEW: 'webview',
+}
 
 export const MultichannelText = props => {
   const requestContext = useContext(RequestContext)
   const multichannelContext = useContext(MultichannelContext)
+  const postbackButtonsAsText =
+    props.buttonsAsText !== undefined ? props.buttonsAsText : true
 
   let elements = []
 
@@ -64,36 +73,87 @@ export const MultichannelText = props => {
     return props.indexMode === 'letter' ? 'a' : 1
   }
 
+  const generateMultichannelButtons = type => {
+    const asText = type === buttonTypes.POSTBACK ? postbackButtonsAsText : true
+    const generator = (element, i) => {
+      return (
+        <MultichannelButton
+          key={`${type}${i}`}
+          newline={'\n'}
+          asText={asText}
+          {...element.props}
+        >
+          {element.props.children}
+        </MultichannelButton>
+      )
+    }
+    return generator
+  }
+
+  const splitPostbackButtons = postbackButtons => {
+    const messages = []
+    for (let i = 0; i < postbackButtons.length; i += WHATSAPP_MAX_BUTTONS) {
+      messages.push(postbackButtons.slice(i, i + WHATSAPP_MAX_BUTTONS))
+    }
+    return messages
+  }
+
   if (isWhatsapp(requestContext)) {
-    const text = getText(props.children)
+    const texts = getText(props.children)
     const { postbackButtons, urlButtons } = getWhatsappButtons()
 
-    elements = [].concat([...text], [...postbackButtons], [...urlButtons])
-    multichannelContext.currentIndex = getDefaultIndex()
-    elements = elements.map((element, i) => {
-      const newline =
-        multichannelContext.messageSeparator == null && i === 0 ? '' : '\n'
-      if (isMultichannelButton(element) || isMultichannelReply(element)) {
-        return (
-          <MultichannelButton key={i} newline={newline} {...element.props}>
-            {element.props.children}
-          </MultichannelButton>
-        )
-      } else if (typeof element === 'string') {
-        return (props.newline || '') + element
-      } else {
-        return element
-      }
+    const textElements = texts.map(text => {
+      return (props.newline || '') + text
     })
-    if (multichannelContext.messageSeparator != null) {
-      return elements
-    }
-    return (
-      <Text {...MULTICHANNEL_WHATSAPP_PROPS} {...props}>
-        {elements}
-      </Text>
+    const postbackButtonElements = postbackButtons.map(
+      generateMultichannelButtons('postback')
     )
+    const urlButtonElements = urlButtons.map(generateMultichannelButtons('url'))
+
+    if (
+      !postbackButtonsAsText &&
+      postbackButtons.length > WHATSAPP_MAX_BUTTONS
+    ) {
+      const messagesPostbackButtons = splitPostbackButtons(
+        postbackButtonElements
+      )
+      const messages = messagesPostbackButtons.map((postbackButtons, i) => {
+        const buttonsTextSeparator =
+          props.buttonsTextSeparator || DEFAULT_WHATSAPP_MAX_BUTTON_SEPARATOR
+
+        if (i === 0) {
+          return [].concat(...texts, ...urlButtonElements, ...postbackButtons)
+        } else {
+          return [].concat(buttonsTextSeparator, ...postbackButtons)
+        }
+      })
+      return (
+        <>
+          {messages.map((message, i) => (
+            <Text key={i} {...MULTICHANNEL_WHATSAPP_PROPS} {...props}>
+              {message}
+            </Text>
+          ))}
+        </>
+      )
+    } else {
+      multichannelContext.currentIndex = getDefaultIndex()
+      elements = [].concat(
+        [...textElements],
+        [...postbackButtonElements],
+        [...urlButtonElements]
+      )
+      if (multichannelContext.messageSeparator != null) {
+        return elements
+      }
+      return (
+        <Text {...MULTICHANNEL_WHATSAPP_PROPS} {...props}>
+          {elements}
+        </Text>
+      )
+    }
   }
+
   if (isFacebook(requestContext)) {
     const text = getText(props.children)
     const multichannelFacebook = new MultichannelFacebook()

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -157,41 +157,39 @@ export const MultichannelText = props => {
           ))}
         </>
       )
-    } else {
-      multichannelContext.currentIndex = getDefaultIndex()
-      const postbackButtonElements = postbackButtons.map(
-        regenerateMultichannelButtons(!!texts.length)
-      )
-      const urlButtonElements = urlButtons.map(
-        regenerateMultichannelButtons(
-          !!texts.length || !!postbackButtons.length
-        )
-      )
-
-      elements = [].concat(
-        [...textElements],
-        [...postbackButtonElements],
-        [...urlButtonElements]
-      )
-      if (multichannelContext.messageSeparator != null) {
-        return elements
-      }
-      const messages = [
-        <Text key={0} {...MULTICHANNEL_WHATSAPP_PROPS} {...props}>
-          {elements}
-        </Text>,
-      ]
-      if (webviewButtonElements.length) {
-        messages.push(
-          <Text key={1} {...MULTICHANNEL_WHATSAPP_PROPS} {...props}>
-            {buttonsTextSeparator}
-            {webviewButtonElements}
-          </Text>
-        )
-      }
-
-      return <>{messages}</>
     }
+
+    multichannelContext.currentIndex = getDefaultIndex()
+    const postbackButtonElements = postbackButtons.map(
+      regenerateMultichannelButtons(!!texts.length)
+    )
+    const urlButtonElements = urlButtons.map(
+      regenerateMultichannelButtons(!!texts.length || !!postbackButtons.length)
+    )
+
+    elements = [].concat(
+      [...textElements],
+      [...postbackButtonElements],
+      [...urlButtonElements]
+    )
+    if (multichannelContext.messageSeparator != null) {
+      return elements
+    }
+    const messages = [
+      <Text key={0} {...MULTICHANNEL_WHATSAPP_PROPS} {...props}>
+        {elements}
+      </Text>,
+    ]
+    if (webviewButtonElements.length) {
+      messages.push(
+        <Text key={1} {...MULTICHANNEL_WHATSAPP_PROPS} {...props}>
+          {buttonsTextSeparator}
+          {webviewButtonElements}
+        </Text>
+      )
+    }
+
+    return <>{messages}</>
   }
 
   if (isFacebook(requestContext)) {

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -28,7 +28,7 @@ export const MultichannelText = props => {
   const requestContext = useContext(RequestContext)
   const multichannelContext = useContext(MultichannelContext)
   const postbackButtonsAsText =
-    props.buttonsAsText !== undefined ? props.buttonsAsText : true
+    props.buttonsAsText == null ? true : props.buttonsAsText
 
   let elements = []
 

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -75,13 +75,19 @@ export const MultichannelText = props => {
     return props.indexMode === 'letter' ? 'a' : 1
   }
 
-  const generateMultichannelButtons = type => {
+  const generateMultichannelButtons = (type, newLineFirstButton = true) => {
     const asText = type === buttonTypes.POSTBACK ? postbackButtonsAsText : true
     const generator = (element, i) => {
+      const newline =
+        multichannelContext.messageSeparator == null &&
+        !newLineFirstButton &&
+        i === 0
+          ? ''
+          : '\n'
       return (
         <MultichannelButton
           key={`${type}${i}`}
-          newline={'\n'}
+          newline={newline}
           asText={asText}
           {...element.props}
         >
@@ -107,12 +113,9 @@ export const MultichannelText = props => {
     const textElements = texts.map(text => {
       return (props.newline || '') + text
     })
-    const postbackButtonElements = postbackButtons.map(
-      generateMultichannelButtons('postback')
-    )
-    const urlButtonElements = urlButtons.map(generateMultichannelButtons('url'))
+
     const webviewButtonElements = webviewButtons.map(
-      generateMultichannelButtons('webview')
+      generateMultichannelButtons('webview', false)
     )
 
     const buttonsTextSeparator =
@@ -122,13 +125,26 @@ export const MultichannelText = props => {
       !postbackButtonsAsText &&
       postbackButtons.length > WHATSAPP_MAX_BUTTONS
     ) {
+      const urlButtonElements = urlButtons.map(
+        generateMultichannelButtons('url', !!texts.length)
+      )
+      const postbackButtonElements = postbackButtons.map(
+        generateMultichannelButtons(
+          'postback',
+          !!texts.length || !!urlButtons.length
+        )
+      )
       const messagesPostbackButtons = splitPostbackButtons(
         postbackButtonElements
       )
 
       const messages = messagesPostbackButtons.map((postbackButtons, i) => {
         if (i === 0) {
-          return [].concat(...texts, ...urlButtonElements, ...postbackButtons)
+          return [].concat(
+            ...textElements,
+            ...urlButtonElements,
+            ...postbackButtons
+          )
         } else {
           return [].concat(buttonsTextSeparator, ...postbackButtons)
         }
@@ -148,6 +164,16 @@ export const MultichannelText = props => {
       )
     } else {
       multichannelContext.currentIndex = getDefaultIndex()
+      const postbackButtonElements = postbackButtons.map(
+        generateMultichannelButtons('postback', !!texts.length)
+      )
+      const urlButtonElements = urlButtons.map(
+        generateMultichannelButtons(
+          'url',
+          !!texts.length || !!postbackButtons.length
+        )
+      )
+
       elements = [].concat(
         [...textElements],
         [...postbackButtonElements],

--- a/packages/botonic-react/src/components/multichannel/multichannel-utils.js
+++ b/packages/botonic-react/src/components/multichannel/multichannel-utils.js
@@ -39,6 +39,20 @@ export function elementHasWebview(element) {
   return element.props && element.props.webview
 }
 
+export const buttonTypes = {
+  POSTBACK: 'postback',
+  URL: 'url',
+  WEBVIEW: 'webview',
+}
+
+export function getButtonType(multichannelButton) {
+  if (elementHasUrl(multichannelButton)) return buttonTypes.URL
+  if (elementHasPostback(multichannelButton)) return buttonTypes.POSTBACK
+  if (elementHasWebview(multichannelButton)) return buttonTypes.WEBVIEW
+
+  return undefined
+}
+
 export function getFilteredElements(node, filter) {
   const elements = []
   for (const n of node) {

--- a/packages/botonic-react/src/components/multichannel/multichannel-utils.js
+++ b/packages/botonic-react/src/components/multichannel/multichannel-utils.js
@@ -7,6 +7,10 @@ import { Providers } from '@botonic/core'
  */
 export const MULTICHANNEL_WHATSAPP_PROPS = { markdown: false }
 
+export const WHATSAPP_MAX_BUTTONS = 3
+export const WHATSAPP_MAX_BUTTON_CHARS = 20
+export const DEFAULT_WHATSAPP_MAX_BUTTON_SEPARATOR = 'More options:'
+
 export function isMultichannelButton(node) {
   return isNodeKind(node, 'MultichannelButton')
 }

--- a/packages/botonic-react/src/components/multichannel/multichannel-utils.js
+++ b/packages/botonic-react/src/components/multichannel/multichannel-utils.js
@@ -35,6 +35,9 @@ export function elementHasPostback(element) {
     (element.props && element.props.path)
   )
 }
+export function elementHasWebview(element) {
+  return element.props && element.props.webview
+}
 
 export function getFilteredElements(node, filter) {
   const elements = []

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-button.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-button.test.jsx.snap
@@ -8,16 +8,16 @@ exports[`Multichannel buttons: truncate text if more than 20 chars in whatsapp b
 </button>
 `;
 
-exports[`Multichannel buttons: with URL 1`] = `"- button text with URL: https://docs.botonic.io/"`;
+exports[`Multichannel buttons: with URL 1`] = `"- With URL: https://docs.botonic.io/"`;
 
-exports[`Multichannel buttons: with path 1`] = `"1.- button text with path1"`;
+exports[`Multichannel buttons: with path 1`] = `"1.- With path"`;
 
-exports[`Multichannel buttons: with payload 1`] = `"1- button text with payload1"`;
+exports[`Multichannel buttons: with payload 1`] = `"1- With payload"`;
 
 exports[`Multichannel buttons: with webview 1`] = `
 <button
   url="/webviews/undefined?"
 >
-  button text with Webview
+  With webview
 </button>
 `;

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-button.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-button.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`Multichannel buttons: truncate text if more than 20 chars in whatsapp b
 <button
   payload="payload1"
 >
-  button text with ...
+  With text longer ...
 </button>
 `;
 

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-button.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-button.test.jsx.snap
@@ -1,7 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Multichannel buttons: truncate text if more than 20 chars in whatsapp buttons 1`] = `
+<button
+  payload="payload1"
+>
+  button text with ...
+</button>
+`;
+
 exports[`Multichannel buttons: with URL 1`] = `"- button text with URL: https://docs.botonic.io/"`;
 
 exports[`Multichannel buttons: with path 1`] = `"1.- button text with path1"`;
 
 exports[`Multichannel buttons: with payload 1`] = `"1- button text with payload1"`;
+
+exports[`Multichannel buttons: with webview 1`] = `
+<button
+  url="/webviews/undefined?"
+>
+  button text with Webview
+</button>
+`;

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel-multibutton.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel-multibutton.test.jsx.snap
@@ -29,6 +29,85 @@ Array [
 ]
 `;
 
+exports[`Multichannel carousel COMPACT mode N Buttons dynamic carousel with URL and postback buttons N Buttons displaying only postback buttons as whatsapp buttons 1`] = `
+Array [
+  <message
+    buttonsAsText={0}
+    delay={0}
+    indexMode="number"
+    markdown={0}
+    newkey={0}
+    type="text"
+    typing={0}
+  >
+    *Title1* _Subtitle1_
+    <button
+      payload="payload1"
+    >
+      Previo a la compra
+    </button>
+    <button
+      payload="payload2"
+    >
+      another button
+      0
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    indexMode="number"
+    markdown={0}
+    newkey={1}
+    type="text"
+    typing={0}
+  >
+    *Title2* _Subtitle2_
+    <button
+      payload="payload1"
+    >
+      Durante la compra
+    </button>
+    <button
+      payload="payload2"
+    >
+      another button
+      1
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    indexMode="number"
+    markdown={0}
+    newkey={2}
+    type="text"
+    typing={0}
+  >
+    *Snatch* _Five minutes, Turkish_
+    
+- Visit website: https://www.imdb.com/title/tt0208092
+    
+- Another website,0: anotherurl.com
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    indexMode="number"
+    markdown={0}
+    newkey={3}
+    type="text"
+    typing={0}
+  >
+    *El laberinto del fauno* _2006_
+    
+- Visit website: https://www.imdb.com/title/tt0457430
+    
+- Another website,1: anotherurl.com
+  </message>,
+]
+`;
+
 exports[`Multichannel carousel COMPACT mode N Buttons dynamic carousel with payload/path buttons N Buttons 1`] = `
 Array [
   <message

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel.test.jsx.snap
@@ -34,6 +34,69 @@ Array [
 ]
 `;
 
+exports[`Multichannel carousel COMPACT mode dynamic carousel with URL and postback buttons and displaying only postback buttons as whatsapp buttons 1`] = `
+Array [
+  <message
+    buttonsAsText={0}
+    delay={0}
+    indexMode="number"
+    markdown={0}
+    newkey={0}
+    type="text"
+    typing={0}
+  >
+    *Title1* _Subtitle1_
+    <button
+      payload="Payload1"
+    >
+      Previo a la compra
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    indexMode="number"
+    markdown={0}
+    newkey={1}
+    type="text"
+    typing={0}
+  >
+    *Title2* _Subtitle2_
+    <button
+      payload="Payload2"
+    >
+      Durante la compra
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    indexMode="number"
+    markdown={0}
+    newkey={2}
+    type="text"
+    typing={0}
+  >
+    *Snatch* _Five minutes, Turkish_
+    
+- Visit website: https://www.imdb.com/title/tt0208092
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    indexMode="number"
+    markdown={0}
+    newkey={3}
+    type="text"
+    typing={0}
+  >
+    *El laberinto del fauno* _2006_
+    
+- Visit website: https://www.imdb.com/title/tt0457430
+  </message>,
+]
+`;
+
 exports[`Multichannel carousel COMPACT mode dynamic carousel with payload/path buttons 1`] = `
 Array [
   <message

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-text.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-text.test.jsx.snap
@@ -1,5 +1,108 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Multichannel text display URL buttons as text even if buttonsAsText is set to false 1`] = `
+<message
+  buttonsAsText={0}
+  delay={0}
+  markdown={0}
+  type="text"
+  typing={0}
+>
+  The verbose text
+  <button
+    payload="payload1"
+  >
+    button text1
+  </button>
+  
+- button text2: http://adrss
+</message>
+`;
+
+exports[`Multichannel text display custom text as button separator when more than 3 buttons in message 1`] = `
+Array [
+  <message
+    buttonsAsText={0}
+    buttonsTextSeparator="Custom message"
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    The verbose text
+    
+- button text2: http://adrss
+    <button
+      payload="payload1"
+    >
+      button text1
+    </button>
+    <button
+      payload="__PATH_PAYLOAD__path"
+    >
+      button text3
+    </button>
+    <button
+      payload="payload2"
+    >
+      button with text ...
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    buttonsTextSeparator="Custom message"
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    Custom message
+    <button
+      payload="payload3"
+    >
+      button text5
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    buttonsTextSeparator="Custom message"
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    Custom message
+    <button
+      url="/webviews/undefined?"
+    >
+      button text4
+    </button>
+  </message>,
+]
+`;
+
+exports[`Multichannel text display postback buttons as whatsapp buttons 1`] = `
+<message
+  buttonsAsText={0}
+  delay={0}
+  markdown={0}
+  type="text"
+  typing={0}
+>
+  The verbose text
+  <button
+    payload="payload1"
+  >
+    button text1
+  </button>
+  <button
+    payload="__PATH_PAYLOAD__path"
+  >
+    button text2
+  </button>
+</message>
+`;
+
 exports[`Multichannel text just text 1`] = `
 <message
   delay={0}
@@ -10,6 +113,98 @@ exports[`Multichannel text just text 1`] = `
 >
   Some text
 </message>
+`;
+
+exports[`Multichannel text split messages with more than 3 postback buttons into separate messages 1`] = `
+Array [
+  <message
+    buttonsAsText={0}
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    The verbose text
+    
+- button text2: http://adrss
+    <button
+      payload="payload1"
+    >
+      button text1
+    </button>
+    <button
+      payload="__PATH_PAYLOAD__path"
+    >
+      button text3
+    </button>
+    <button
+      payload="payload2"
+    >
+      button with text ...
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    More options:
+    <button
+      payload="payload3"
+    >
+      button text5
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    More options:
+    <button
+      url="/webviews/undefined?"
+    >
+      button text4
+    </button>
+  </message>,
+]
+`;
+
+exports[`Multichannel text split webview buttons into separate messages 1`] = `
+Array [
+  <message
+    buttonsAsText={0}
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    The verbose text
+    <button
+      payload="payload1"
+    >
+      button text1
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    More options:
+    <button
+      url="/webviews/undefined?"
+    >
+      webview button text
+    </button>
+  </message>,
+]
 `;
 
 exports[`Multichannel text with buttons as array 1`] = `

--- a/packages/botonic-react/tests/components/multichannel/multichannel-button.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-button.test.jsx
@@ -5,22 +5,9 @@ import { MultichannelButton } from '../../../src/components/multichannel'
 import { whatsappRenderer } from '../../helpers/test-utils'
 
 describe('Multichannel buttons:', () => {
-  const Buttons = {}
-  Buttons.withPayload = (
-    <Button payload='payload1'>button text with payload1</Button>
-  )
-  Buttons.withPath = <Button path='path1'>button text with path1</Button>
-  Buttons.withUrl = (
-    <Button url='https://docs.botonic.io/'>button text with URL</Button>
-  )
-  Buttons.withWebview = (
-    <Button webview='webview'>button text with Webview</Button>
-  )
   test('with payload', () => {
     const sut = (
-      <MultichannelButton {...Buttons.withPayload.props}>
-        {Buttons.withPayload.props.children}
-      </MultichannelButton>
+      <MultichannelButton payload='payload1'>With payload</MultichannelButton>
     )
 
     const rendered = whatsappRenderer(sut, { indexSeparator: '-' }).toJSON()
@@ -28,11 +15,7 @@ describe('Multichannel buttons:', () => {
   })
 
   test('with path', () => {
-    const sut = (
-      <MultichannelButton {...Buttons.withPath.props}>
-        {Buttons.withPath.props.children}
-      </MultichannelButton>
-    )
+    const sut = <MultichannelButton path='path1'>With path</MultichannelButton>
 
     const rendered = whatsappRenderer(sut, { indexSeparator: '.-' }).toJSON()
     expect(rendered).toMatchSnapshot()
@@ -40,8 +23,8 @@ describe('Multichannel buttons:', () => {
 
   test('with URL', () => {
     const sut = (
-      <MultichannelButton {...Buttons.withUrl.props}>
-        {Buttons.withUrl.props.children}
+      <MultichannelButton url='https://docs.botonic.io/'>
+        With URL
       </MultichannelButton>
     )
     const rendered = whatsappRenderer(sut).toJSON()
@@ -50,9 +33,7 @@ describe('Multichannel buttons:', () => {
 
   test('with webview', () => {
     const sut = (
-      <MultichannelButton {...Buttons.withWebview.props}>
-        {Buttons.withWebview.props.children}
-      </MultichannelButton>
+      <MultichannelButton webview='webview'>With webview</MultichannelButton>
     )
     const rendered = whatsappRenderer(sut).toJSON()
     expect(rendered).toMatchSnapshot()
@@ -60,8 +41,8 @@ describe('Multichannel buttons:', () => {
 
   test('truncate text if more than 20 chars in whatsapp buttons', () => {
     const sut = (
-      <MultichannelButton asText={false} {...Buttons.withPayload.props}>
-        {Buttons.withPayload.props.children}
+      <MultichannelButton asText={false} payload='payload1'>
+        With text longer than 20 characters
       </MultichannelButton>
     )
     const rendered = whatsappRenderer(sut).toJSON()

--- a/packages/botonic-react/tests/components/multichannel/multichannel-button.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-button.test.jsx
@@ -13,6 +13,9 @@ describe('Multichannel buttons:', () => {
   Buttons.withUrl = (
     <Button url='https://docs.botonic.io/'>button text with URL</Button>
   )
+  Buttons.withWebview = (
+    <Button webview='webview'>button text with Webview</Button>
+  )
   test('with payload', () => {
     const sut = (
       <MultichannelButton {...Buttons.withPayload.props}>
@@ -39,6 +42,26 @@ describe('Multichannel buttons:', () => {
     const sut = (
       <MultichannelButton {...Buttons.withUrl.props}>
         {Buttons.withUrl.props.children}
+      </MultichannelButton>
+    )
+    const rendered = whatsappRenderer(sut).toJSON()
+    expect(rendered).toMatchSnapshot()
+  })
+
+  test('with webview', () => {
+    const sut = (
+      <MultichannelButton {...Buttons.withWebview.props}>
+        {Buttons.withWebview.props.children}
+      </MultichannelButton>
+    )
+    const rendered = whatsappRenderer(sut).toJSON()
+    expect(rendered).toMatchSnapshot()
+  })
+
+  test('truncate text if more than 20 chars in whatsapp buttons', () => {
+    const sut = (
+      <MultichannelButton asText={false} {...Buttons.withPayload.props}>
+        {Buttons.withPayload.props.children}
       </MultichannelButton>
     )
     const rendered = whatsappRenderer(sut).toJSON()

--- a/packages/botonic-react/tests/components/multichannel/multichannel-carousel-multibutton.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-carousel-multibutton.test.jsx
@@ -163,4 +163,45 @@ describe('Multichannel carousel COMPACT mode N Buttons', () => {
     const tree = renderer.toJSON()
     expect(tree).toMatchSnapshot()
   })
+
+  test('dynamic carousel with URL and postback buttons N Buttons displaying only postback buttons as whatsapp buttons', () => {
+    const postbackButtons = options.map((e, i) => (
+      <Element key={e.name}>
+        <Pic src={e.pic} />
+        <Title>{e.name}</Title>
+        <Subtitle>{e.desc}</Subtitle>
+        {[
+          <MultichannelButton key={'1'} payload={'payload1'}>
+            {e.buttonText}
+          </MultichannelButton>,
+          <MultichannelButton key={'2'} payload={'payload2'}>
+            another button{i}
+          </MultichannelButton>,
+        ]}
+      </Element>
+    ))
+    const urlButtons = movies.map((e, i) => (
+      <Element key={e.name}>
+        <Pic src={e.pic} />
+        <Title>{e.name}</Title>
+        <Subtitle>{e.desc}</Subtitle>
+        {[
+          <MultichannelButton key={'1'} url={e.url}>
+            Visit website
+          </MultichannelButton>,
+          <MultichannelButton key={'2'} url={'anotherurl.com'}>
+            Another website{i}
+          </MultichannelButton>,
+        ]}
+      </Element>
+    ))
+    const sut = (
+      <MultichannelCarousel {...LEGACY_PROPS} buttonsAsText={false}>
+        {[...postbackButtons, ...urlButtons]}
+      </MultichannelCarousel>
+    )
+    const renderer = whatsappRenderer(sut, LEGACY_CONTEXT)
+    const tree = renderer.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/packages/botonic-react/tests/components/multichannel/multichannel-carousel.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-carousel.test.jsx
@@ -1,18 +1,13 @@
 import React from 'react'
 
 import {
-  Button,
-  Carousel,
   Element,
   MultichannelButton,
+  MultichannelCarousel,
   Pic,
   Subtitle,
   Title,
 } from '../../../src'
-import {
-  Multichannel,
-  MultichannelCarousel,
-} from '../../../src/components/multichannel'
 import { whatsappRenderer } from '../../helpers/test-utils'
 
 const movies = [
@@ -164,6 +159,35 @@ describe('Multichannel carousel COMPACT mode', () => {
       </MultichannelCarousel>
     )
     const renderer = whatsappRenderer(sut, { messageSeparator: '\n' })
+    const tree = renderer.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('dynamic carousel with URL and postback buttons and displaying only postback buttons as whatsapp buttons', () => {
+    const postbackButtons = options.map((e, i) => (
+      <Element key={e.name}>
+        <Pic src={e.pic} />
+        <Title>{e.name}</Title>
+        <Subtitle>{e.desc}</Subtitle>
+        <MultichannelButton payload={e.payload}>
+          {e.buttonText}
+        </MultichannelButton>
+      </Element>
+    ))
+    const urlButtons = movies.map((e, i) => (
+      <Element key={e.name}>
+        <Pic src={e.pic} />
+        <Title>{e.name}</Title>
+        <Subtitle>{e.desc}</Subtitle>
+        <MultichannelButton url={e.url}>Visit website</MultichannelButton>
+      </Element>
+    ))
+    const sut = (
+      <MultichannelCarousel {...LEGACY_PROPS} buttonsAsText={false}>
+        {[...postbackButtons, ...urlButtons]}
+      </MultichannelCarousel>
+    )
+    const renderer = whatsappRenderer(sut, LEGACY_CONTEXT)
     const tree = renderer.toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/packages/botonic-react/tests/components/multichannel/multichannel-text.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-text.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Text } from '../../../src'
+import { Button, Text } from '../../../src'
 import {
   MultichannelButton,
   MultichannelText,
@@ -14,6 +14,26 @@ const LEGACY_CONTEXT = {
 }
 const LEGACY_PROPS = {
   indexMode: 'number',
+}
+
+const CONTEXT_WITH_BUTTONS = {
+  text: {
+    buttonsAsText: false,
+  },
+}
+const CONTEXT_WITH_BUTTONS_CUSTOM = {
+  text: {
+    buttonsAsText: false,
+    buttonsTextSeparator: 'Custom message',
+  },
+}
+
+const AS_BUTTONS_PROPS = {
+  buttonsAsText: false,
+}
+const AS_BUTTONS_PROPS_CUSTOM = {
+  buttonsAsText: false,
+  buttonsTextSeparator: 'Custom message',
 }
 
 describe('Multichannel text', () => {
@@ -125,6 +145,115 @@ describe('Multichannel text', () => {
       </MultichannelText>
     )
     const renderer = whatsappRenderer(sut, LEGACY_CONTEXT)
+    const tree = renderer.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('display postback buttons as whatsapp buttons', () => {
+    const sut = (
+      <MultichannelText {...AS_BUTTONS_PROPS}>
+        The verbose text
+        <MultichannelButton key='0' payload='payload1'>
+          button text1
+        </MultichannelButton>
+        <MultichannelButton key='1' path='path'>
+          button text2
+        </MultichannelButton>
+      </MultichannelText>
+    )
+    const renderer = whatsappRenderer(sut, CONTEXT_WITH_BUTTONS)
+    const tree = renderer.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('display URL buttons as text even if buttonsAsText is set to false', () => {
+    const sut = (
+      <MultichannelText {...AS_BUTTONS_PROPS}>
+        The verbose text
+        <MultichannelButton key='0' payload='payload1'>
+          button text1
+        </MultichannelButton>
+        <MultichannelButton key='1' url='http://adrss'>
+          button text2
+        </MultichannelButton>
+      </MultichannelText>
+    )
+    const renderer = whatsappRenderer(sut, CONTEXT_WITH_BUTTONS)
+    const tree = renderer.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('split webview buttons into separate messages', () => {
+    const sut = (
+      <MultichannelText {...AS_BUTTONS_PROPS}>
+        The verbose text
+        <MultichannelButton key='0' payload='payload1'>
+          button text1
+        </MultichannelButton>
+        <MultichannelButton key='1' webview='webview'>
+          webview button text
+        </MultichannelButton>
+      </MultichannelText>
+    )
+    const renderer = whatsappRenderer(sut, CONTEXT_WITH_BUTTONS)
+    const tree = renderer.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('split messages with more than 3 postback buttons into separate messages', () => {
+    const sut = (
+      <MultichannelText {...AS_BUTTONS_PROPS}>
+        The verbose text
+        <MultichannelButton key='0' payload='payload1'>
+          button text1
+        </MultichannelButton>
+        <MultichannelButton key='1' url='http://adrss'>
+          button text2
+        </MultichannelButton>
+        <MultichannelButton key='2' path='path'>
+          button text3
+        </MultichannelButton>
+        <MultichannelButton key='3' webview='webview'>
+          button text4
+        </MultichannelButton>
+        <MultichannelButton key='4' payload='payload2'>
+          button with text longer than 20 chars
+        </MultichannelButton>
+        <MultichannelButton key='5' payload='payload3'>
+          button text5
+        </MultichannelButton>
+      </MultichannelText>
+    )
+    const renderer = whatsappRenderer(sut, CONTEXT_WITH_BUTTONS)
+    const tree = renderer.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('display custom text as button separator when more than 3 buttons in message', () => {
+    const sut = (
+      <MultichannelText {...AS_BUTTONS_PROPS_CUSTOM}>
+        The verbose text
+        <MultichannelButton key='0' payload='payload1'>
+          button text1
+        </MultichannelButton>
+        <MultichannelButton key='1' url='http://adrss'>
+          button text2
+        </MultichannelButton>
+        <MultichannelButton key='2' path='path'>
+          button text3
+        </MultichannelButton>
+        <MultichannelButton key='3' webview='webview'>
+          button text4
+        </MultichannelButton>
+        <MultichannelButton key='4' payload='payload2'>
+          button with text longer than 20 chars
+        </MultichannelButton>
+        <MultichannelButton key='5' payload='payload3'>
+          button text5
+        </MultichannelButton>
+      </MultichannelText>
+    )
+    const renderer = whatsappRenderer(sut, CONTEXT_WITH_BUTTONS_CUSTOM)
     const tree = renderer.toJSON()
     expect(tree).toMatchSnapshot()
   })


### PR DESCRIPTION
## Description
Added new attributes (`buttonsAsText` and `buttonsTextSeparator`) in `text` prop for `Multichannel` component in order to decide to display `<Button>` components as text or as buttons in whatsapp.

Also, allow to display buttons pointing to webviews alongside other buttons (now webview buttons needed to be alone within a `<Text>` component)

## Context
Allow `@botonic/react` `Multichannel` component to be able to display real buttons in whatsapp.

## Approach taken / Explain the design
Since only 3 buttons (postback buttons) per message are allowed in whatsapp, if we detect more than 3 buttons within a message we're splitting the message in multiple messages in order to ensure all buttons will be displayed.

Since buttons pointing to URLs are not allowed in whatsapp, they will be displayed as text (the same way it's done right now).

## To document / Usage example
Here are some examples of how messages containing buttons will be displayed in whatsapp:
Having this piece of code:
![Captura de pantalla de 2021-07-06 10-54-50](https://user-images.githubusercontent.com/1886708/124572182-bde75c80-de48-11eb-8334-993fd763e5dc.png)

This is what will be displayed in whatsapp:
![Captura de pantalla de 2021-07-06 10-42-00](https://user-images.githubusercontent.com/1886708/124572306-d8213a80-de48-11eb-8fbb-377233517310.png)

If we change the value of the `buttonAsText` attribute to `true`, in order to display the buttons as text as we do now, this is what will be displayed in whatsapp:
![Captura de pantalla de 2021-07-06 10-43-33](https://user-images.githubusercontent.com/1886708/124572466-f6873600-de48-11eb-8bd2-0f110b93643c.png)


## Testing

The pull request has unit tests.