### PR TITLE
Full stack/api local json db

### DIFF
--- a/packages/botonic-api/package-lock.json
+++ b/packages/botonic-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/api",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-api/package-lock.json
+++ b/packages/botonic-api/package-lock.json
@@ -258,9 +258,9 @@
       }
     },
     "@botonic/core": {
-      "version": "1.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-1.0.0-alpha.0.tgz",
-      "integrity": "sha512-BhFKRxGsE4xMKO1lO9jOtq+VQ6KkUncdp6mCq18lVrJJ0ivKl5OCk5LsvEiDWY0p6hNYu0qsmql2a6Rnub49PQ==",
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-n8ZjNwCuxFVTMJ6KVWaMcP+8tbFajNEgTMFGA5M44FtYIeh1fho8cez3ercyBX1uTXDElMPU9qbM8cWq9mo0qA==",
       "requires": {
         "axios": "^0.21.0",
         "decode": "^0.3.0",
@@ -1071,6 +1071,11 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1085,6 +1090,14 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
       "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+    },
+    "node-json-db": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-json-db/-/node-json-db-1.3.0.tgz",
+      "integrity": "sha512-3IK9KuqfKdK12zFKtzmnD6Y5J9qL0TY0gnnZ5XKpzdhCP019zOxPxGCaH6cmIqiho2ymFgcTMKQeJvYkbBFraQ==",
+      "requires": {
+        "mkdirp": "~1.0.4"
+      }
     },
     "node-releases": {
       "version": "1.1.73",

--- a/packages/botonic-api/package.json
+++ b/packages/botonic-api/package.json
@@ -31,6 +31,7 @@
     "cors": "^2.8.5",
     "dynamodb-toolbox": "^0.3.4",
     "express": "^4.17.1",
+    "node-json-db": "^1.3.0",
     "terminal-link": "^3.0.0",
     "ulid": "^2.3.0",
     "utf-8-validate": "^5.0.5",

--- a/packages/botonic-api/package.json
+++ b/packages/botonic-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/api",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
@@ -21,7 +21,7 @@ export class DynamoDBDataProvider implements DataProvider {
   messageEventEntities: Record<string, Entity<any>>
   textMessageEventEntity: Entity<any>
   connectionEntity: Entity<any>
-  constructor(url) {
+  constructor(url: string) {
     try {
       ;[this.tableName, this.region] = url.split('://')[1].split('.')
       this.userEventsTable = getUserEventsTable(this.tableName, this.region)
@@ -33,14 +33,14 @@ export class DynamoDBDataProvider implements DataProvider {
     }
   }
 
-  async addConnection(websocketId) {
+  async addConnection(websocketId: string): Promise<void> {
     await this.connectionEntity.put({
       websocketId: websocketId,
       [`${SORT_KEY_NAME}`]: websocketId,
     })
   }
 
-  async updateConnection(websocketId, userId) {
+  async updateConnection(websocketId: string, userId: string): Promise<void> {
     await this.connectionEntity.update({
       websocketId: websocketId,
       [`${SORT_KEY_NAME}`]: websocketId,
@@ -48,14 +48,17 @@ export class DynamoDBDataProvider implements DataProvider {
     })
   }
 
-  async deleteConnection(websocketId) {
+  async deleteConnection(websocketId: string): Promise<void> {
     await this.connectionEntity.delete({
       websocketId: websocketId,
       [`${SORT_KEY_NAME}`]: websocketId,
     })
   }
 
-  async getUser(id) {
+  // @ts-ignore
+  async getUsers(limit = 10, offset = 0): Promise<User[]> {} // TODO: Implement
+
+  async getUser(id: string): Promise<User | undefined> {
     const userById = {
       id: id,
       SK: id,
@@ -76,7 +79,10 @@ export class DynamoDBDataProvider implements DataProvider {
     return user
   }
   // @ts-ignore
-  getEvent(id) {} // TODO: Implement
+  async getEvents(limit = 10, offset = 0): Promise<BotonicEvent[]> {} // TODO: Implement
+
+  // @ts-ignore
+  async getEvent(id: string): Promise<BotonicEvent | undefined> {} // TODO: Implement
 
   async saveEvent(event: BotonicEvent): Promise<BotonicEvent> {
     if (event.eventType === EventTypes.MESSAGE) {
@@ -86,7 +92,7 @@ export class DynamoDBDataProvider implements DataProvider {
     return event
   }
 
-  async getUserByWebsocketId(websocketId) {
+  async getUserByWebsocketId(websocketId: string): Promise<User | undefined> {
     const result = await this.userEventsTable.query(websocketId, {
       index: GLOBAL_SECONDARY_INDEX_NAME,
     })

--- a/packages/botonic-api/src/data-provider/index.ts
+++ b/packages/botonic-api/src/data-provider/index.ts
@@ -6,6 +6,7 @@ import { LocalDevDataProvider } from './local-data-provider'
 
 export const dataProviderProtocols = {
   DYNAMO_DB: 'dynamodb',
+  FILE: 'file',
 }
 
 export interface DataProvider {
@@ -26,19 +27,26 @@ export interface DataProvider {
   ): User | Promise<User | undefined> | undefined
 }
 
-const localDataProvider: LocalDevDataProvider | undefined = undefined
-// url: dynamodb://my-table.my-region.aws.com
-// url: postgresql://my-database.my-db-provider.com
+/** URL examples:
+ * dynamodb://my-table.my-region.aws.com
+ * postgresql://my-database.my-db-provider.com
+ * file://path/to/local/db.json
+ */
 export function dataProviderFactory(url?: string): DataProvider {
   if (!url) {
-    return localDataProvider ?? new LocalDevDataProvider()
+    return new LocalDevDataProvider()
   }
 
   const protocol = url.split('://')[0]
   switch (protocol) {
     case dataProviderProtocols.DYNAMO_DB:
       return new DynamoDBDataProvider(url)
+    case dataProviderProtocols.FILE:
+      return new LocalDevDataProvider(url)
     default:
-      return localDataProvider ?? new LocalDevDataProvider()
+      console.error(
+        `Protocol ${protocol} not implemented, using local DB instead.`
+      )
+      return new LocalDevDataProvider()
   }
 }

--- a/packages/botonic-api/src/data-provider/local-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/local-data-provider.ts
@@ -23,6 +23,7 @@ export class LocalDevDataProvider implements DataProvider {
   getUsers(limit = 10, offset = 0): User[] {
     const path = this.paths.USERS
     try {
+      this.db.reload()
       const userList = this.db.getObject<Record<string, User>>(path)
       const users = Object.values(userList)
       const from = offset * limit
@@ -37,6 +38,7 @@ export class LocalDevDataProvider implements DataProvider {
   getUser(userId: string): User | undefined {
     const path = this.createPath([this.paths.USERS, userId])
     try {
+      this.db.reload()
       return this.db.exists(path) ? this.db.getObject<User>(path) : undefined
     } catch (e) {
       console.error(`Error fetching user with ID '${userId}' from local DB`, e)
@@ -47,6 +49,7 @@ export class LocalDevDataProvider implements DataProvider {
   saveUser(user: User): User {
     const path = this.createPath([this.paths.USERS, user.id])
     try {
+      this.db.reload()
       this.db.push(path, user, false)
     } catch (e) {
       console.error(`Error saving user with ID '${user.id}' to local DB`, e)
@@ -57,6 +60,7 @@ export class LocalDevDataProvider implements DataProvider {
   updateUser(user: User): User {
     const path = this.createPath([this.paths.USERS, user.id])
     try {
+      this.db.reload()
       this.db.push(path, user, true)
     } catch (e) {
       console.error(`Error updating user with ID '${user.id}' to local DB`, e)
@@ -67,6 +71,7 @@ export class LocalDevDataProvider implements DataProvider {
   getEvents(limit = 10, offset = 0): BotonicEvent[] {
     const path = this.paths.EVENTS
     try {
+      this.db.reload()
       const eventList = this.db.getObject<Record<string, BotonicEvent>>(path)
       const events = Object.values(eventList)
       const from = offset * limit
@@ -81,6 +86,7 @@ export class LocalDevDataProvider implements DataProvider {
   getEvent(id: string): BotonicEvent | undefined {
     const path = this.createPath([this.paths.EVENTS, id])
     try {
+      this.db.reload()
       return this.db.exists(path)
         ? this.db.getObject<BotonicEvent>(path)
         : undefined
@@ -93,6 +99,7 @@ export class LocalDevDataProvider implements DataProvider {
   saveEvent(event: BotonicEvent): BotonicEvent {
     const path = this.createPath([this.paths.EVENTS, event.eventId])
     try {
+      this.db.reload()
       this.db.push(path, event, false)
     } catch (e) {
       console.error(
@@ -106,6 +113,7 @@ export class LocalDevDataProvider implements DataProvider {
   addConnection(websocketId: string) {
     const path = this.createPath([this.paths.CONNECTIONS, websocketId])
     try {
+      this.db.reload()
       this.db.push(path, '', false)
     } catch (e) {
       console.error(
@@ -117,6 +125,7 @@ export class LocalDevDataProvider implements DataProvider {
   updateConnection(websocketId: string, userId: string) {
     const path = this.createPath([this.paths.CONNECTIONS, websocketId])
     try {
+      this.db.reload()
       this.db.push(path, userId, true)
     } catch (e) {
       console.error(
@@ -128,6 +137,7 @@ export class LocalDevDataProvider implements DataProvider {
   deleteConnection(websocketId: string) {
     const path = this.createPath([this.paths.CONNECTIONS, websocketId])
     try {
+      this.db.reload()
       this.db.delete(path)
     } catch (e) {
       console.error(
@@ -140,6 +150,7 @@ export class LocalDevDataProvider implements DataProvider {
   getUserByWebsocketId(websocketId: string): User | undefined {
     const path = this.paths.USERS
     try {
+      this.db.reload()
       this.db.find<User>(path, (user: User) => user.websocketId === websocketId)
     } catch (e) {
       console.error(

--- a/packages/botonic-api/src/data-provider/local-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/local-data-provider.ts
@@ -15,8 +15,9 @@ export class LocalDevDataProvider implements DataProvider {
   }
   db: JsonDB
 
-  constructor() {
-    this.db = new JsonDB(new Config(this.DB_PATH, true, false, this.SEPARATOR))
+  constructor(url?: string) {
+    const dbPath = url ? url.split('://')[1] : this.DB_PATH
+    this.db = new JsonDB(new Config(dbPath, true, false, this.SEPARATOR))
   }
 
   getUsers(limit = 10, offset = 0): User[] {

--- a/packages/botonic-api/src/data-provider/local-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/local-data-provider.ts
@@ -1,55 +1,155 @@
 import { BotonicEvent } from '@botonic/core/src/models/events'
 import { User } from '@botonic/core/src/models/user'
+import { JsonDB } from 'node-json-db'
+import { Config } from 'node-json-db/dist/lib/JsonDBConfig'
 
 import { DataProvider } from '.'
 
 export class LocalDevDataProvider implements DataProvider {
-  users: any
-  events: BotonicEvent[]
-  connections: {}
+  private readonly DB_PATH = 'tmp/localDb'
+  private readonly SEPARATOR = '/'
+  private readonly paths = {
+    USERS: '/users',
+    EVENTS: '/events',
+    CONNECTIONS: '/connections',
+  }
+  db: JsonDB
 
   constructor() {
-    this.users = []
-    this.events = []
-    this.connections = []
+    this.db = new JsonDB(new Config(this.DB_PATH, true, false, this.SEPARATOR))
+  }
+
+  getUsers(limit = 10, offset = 0): User[] {
+    const path = this.paths.USERS
+    try {
+      const userList = this.db.getObject<Record<string, User>>(path)
+      const users = Object.values(userList)
+      const from = offset * limit
+      const to = limit !== 0 ? from + limit : undefined
+      return users.slice(from, to)
+    } catch (e) {
+      console.error('Error fetching users from local DB', e)
+    }
+    return []
   }
 
   getUser(userId: string): User | undefined {
-    const filteredUser = this.users.filter(u => u.id === userId)
-    if (filteredUser.length === 0) return undefined
-    return filteredUser[0]
+    const path = this.createPath([this.paths.USERS, userId])
+    try {
+      return this.db.exists(path) ? this.db.getObject<User>(path) : undefined
+    } catch (e) {
+      console.error(`Error fetching user with ID '${userId}' from local DB`, e)
+    }
+    return undefined
   }
 
   saveUser(user: User): User {
-    this.users.push(user)
+    const path = this.createPath([this.paths.USERS, user.id])
+    try {
+      this.db.push(path, user, false)
+    } catch (e) {
+      console.error(`Error saving user with ID '${user.id}' to local DB`, e)
+    }
     return user
   }
 
   updateUser(user: User): User {
-    this.users = this.users.map(u => (u.id === user.id ? user : u))
+    const path = this.createPath([this.paths.USERS, user.id])
+    try {
+      this.db.push(path, user, true)
+    } catch (e) {
+      console.error(`Error updating user with ID '${user.id}' to local DB`, e)
+    }
     return user
   }
 
-  getEvent(id: string) {
-    return this.events.find(e => e.userId === id)
+  getEvents(limit = 10, offset = 0): BotonicEvent[] {
+    const path = this.paths.EVENTS
+    try {
+      const eventList = this.db.getObject<Record<string, BotonicEvent>>(path)
+      const events = Object.values(eventList)
+      const from = offset * limit
+      const to = limit !== 0 ? from + limit : undefined
+      return events.slice(from, to)
+    } catch (e) {
+      console.error('Error fetching events from local DB', e)
+    }
+    return []
+  }
+
+  getEvent(id: string): BotonicEvent | undefined {
+    const path = this.createPath([this.paths.EVENTS, id])
+    try {
+      return this.db.exists(path)
+        ? this.db.getObject<BotonicEvent>(path)
+        : undefined
+    } catch (e) {
+      console.error(`Error fetching event with ID '${id}' from local DB`, e)
+    }
+    return undefined
   }
 
   saveEvent(event: BotonicEvent): BotonicEvent {
-    this.events.push(event)
+    const path = this.createPath([this.paths.EVENTS, event.eventId])
+    try {
+      this.db.push(path, event, false)
+    } catch (e) {
+      console.error(
+        `Error saving event with user ID '${event.userId}' to local DB`,
+        e
+      )
+    }
     return event
   }
 
   addConnection(websocketId: string) {
-    this.connections[`${websocketId}`] = ''
+    const path = this.createPath([this.paths.CONNECTIONS, websocketId])
+    try {
+      this.db.push(path, '', false)
+    } catch (e) {
+      console.error(
+        `Error adding connection with ID '${websocketId}' to local DB`,
+        e
+      )
+    }
   }
   updateConnection(websocketId: string, userId: string) {
-    this.connections[`${websocketId}`] = userId
+    const path = this.createPath([this.paths.CONNECTIONS, websocketId])
+    try {
+      this.db.push(path, userId, true)
+    } catch (e) {
+      console.error(
+        `Error updating connection with ID '${websocketId}' to local DB`,
+        e
+      )
+    }
   }
   deleteConnection(websocketId: string) {
-    delete this.connections[`${websocketId}`]
+    const path = this.createPath([this.paths.CONNECTIONS, websocketId])
+    try {
+      this.db.delete(path)
+    } catch (e) {
+      console.error(
+        `Error deleting connection with ID '${websocketId}' to local DB`,
+        e
+      )
+    }
   }
 
-  getUserByWebsocketId(websocketId: string) {
-    return this.users.find(u => u.websocketId === websocketId)
+  getUserByWebsocketId(websocketId: string): User | undefined {
+    const path = this.paths.USERS
+    try {
+      this.db.find<User>(path, (user: User) => user.websocketId === websocketId)
+    } catch (e) {
+      console.error(
+        `Error fetching user by websocket ID with ID '${websocketId}' from local DB`,
+        e
+      )
+    }
+    return undefined
+  }
+
+  private createPath(urlChunks: string[]): string {
+    return urlChunks.join(this.SEPARATOR)
   }
 }


### PR DESCRIPTION
## Description
Use of [node-json-db](https://www.npmjs.com/package/node-json-db) package to store data locally (users, events and connections) when no data provider is set.

Also I've done these improvements:
- Fixed some missing types and functions (`getUsers` and `getEvents)` in `DataProvider` interface and its implementations.
- Refactored `dataProviderFactory` to always return a `DataProvider`.
- Bump version of @botonic/api to `1.0.0-alpha.1`

## Context
We were facing an issue while storing data locally in memory because rest and websocket were storing their data independently and we need to have it together. 

## Approach taken / Explain the design

## To document / Usage example

## Testing

The pull request has no tests.