### PR TITLE
fix(react): Fix condition to show extra message with webview buttons in whatsapp

### DIFF
--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -143,7 +143,7 @@ export const MultichannelText = props => {
           return [].concat(buttonsTextSeparator, ...postbackButtons)
         }
       })
-      if (webviewButtonElements) {
+      if (webviewButtonElements.length) {
         messages.push([buttonsTextSeparator, ...webviewButtonElements])
       }
 
@@ -194,11 +194,8 @@ export const MultichannelText = props => {
   if (isFacebook(requestContext)) {
     const text = getText(props.children)
     const multichannelFacebook = new MultichannelFacebook()
-    const {
-      texts,
-      propsLastText,
-      propsWithoutChildren,
-    } = multichannelFacebook.convertText(props, text[0])
+    const { texts, propsLastText, propsWithoutChildren } =
+      multichannelFacebook.convertText(props, text[0])
     return (
       <>
         {texts &&

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-text.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-text.test.jsx.snap
@@ -115,6 +115,51 @@ exports[`Multichannel text just text 1`] = `
 </message>
 `;
 
+exports[`Multichannel text split messages with more than 3 postback buttons into separate messages (without webview buttons) 1`] = `
+Array [
+  <message
+    buttonsAsText={0}
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    The verbose text
+    
+- button text2: http://adrss
+    <button
+      payload="payload1"
+    >
+      button text1
+    </button>
+    <button
+      payload="__PATH_PAYLOAD__path"
+    >
+      button text3
+    </button>
+    <button
+      payload="payload2"
+    >
+      button with text ...
+    </button>
+  </message>,
+  <message
+    buttonsAsText={0}
+    delay={0}
+    markdown={0}
+    type="text"
+    typing={0}
+  >
+    More options:
+    <button
+      payload="payload3"
+    >
+      button text5
+    </button>
+  </message>,
+]
+`;
+
 exports[`Multichannel text split messages with more than 3 postback buttons into separate messages 1`] = `
 Array [
   <message

--- a/packages/botonic-react/tests/components/multichannel/multichannel-text.test.jsx
+++ b/packages/botonic-react/tests/components/multichannel/multichannel-text.test.jsx
@@ -229,6 +229,32 @@ describe('Multichannel text', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('split messages with more than 3 postback buttons into separate messages (without webview buttons)', () => {
+    const sut = (
+      <MultichannelText {...AS_BUTTONS_PROPS}>
+        The verbose text
+        <MultichannelButton key='0' payload='payload1'>
+          button text1
+        </MultichannelButton>
+        <MultichannelButton key='1' url='http://adrss'>
+          button text2
+        </MultichannelButton>
+        <MultichannelButton key='2' path='path'>
+          button text3
+        </MultichannelButton>
+        <MultichannelButton key='4' payload='payload2'>
+          button with text longer than 20 chars
+        </MultichannelButton>
+        <MultichannelButton key='5' payload='payload3'>
+          button text5
+        </MultichannelButton>
+      </MultichannelText>
+    )
+    const renderer = whatsappRenderer(sut, CONTEXT_WITH_BUTTONS)
+    const tree = renderer.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
   test('display custom text as button separator when more than 3 buttons in message', () => {
     const sut = (
       <MultichannelText {...AS_BUTTONS_PROPS_CUSTOM}>


### PR DESCRIPTION
## Description
Fix condition to display an extra message with webview buttons in whatsapp when there are more than 3 buttons within a message (whatsapp max. allowed buttons per message)

## Context
In whatsapp, an extra message with the `buttonsTextSeparator` text was displayed if a whatsapp message containing more than 3 buttons didn't contain any webview button.

## Approach taken / Explain the design

## To document / Usage example

## Testing

The pull request has unit tests.