### PR TITLE
Full stack: Persist user/events data in bot-input endpoint

### DIFF
--- a/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
@@ -68,6 +68,16 @@ export class DynamoDBDataProvider implements DataProvider {
     return result.Item
   }
 
+  async getUserByWebsocketId(websocketId: string): Promise<User | undefined> {
+    const result = await this.userEventsTable.query(websocketId, {
+      index: GLOBAL_SECONDARY_INDEX_NAME,
+    })
+    if (result.Count === 0) return undefined
+    return result.Items[0]
+  }
+  // @ts-ignore
+  async getUserByField(field: string, value: any): Promise<User | undefined> {} //TODO: Implement
+
   async saveUser(user: User): Promise<User> {
     const putUser = { ...user, id: user.id, userId: user.id }
     await this.userEntity.put(putUser)
@@ -97,12 +107,4 @@ export class DynamoDBDataProvider implements DataProvider {
 
   // @ts-ignore
   async deleteEvent(id: string): Promise<BotonicEvent | undefined> {} // TODO: Implement
-
-  async getUserByWebsocketId(websocketId: string): Promise<User | undefined> {
-    const result = await this.userEventsTable.query(websocketId, {
-      index: GLOBAL_SECONDARY_INDEX_NAME,
-    })
-    if (result.Count === 0) return undefined
-    return result.Items[0]
-  }
 }

--- a/packages/botonic-api/src/data-provider/index.ts
+++ b/packages/botonic-api/src/data-provider/index.ts
@@ -12,6 +12,14 @@ export const dataProviderProtocols = {
 export interface DataProvider {
   getUsers(limit?: number, offset?: number): User[] | Promise<User[]>
   getUser(id: string): User | Promise<User | undefined> | undefined
+  //TODO: replace getUserByWebsocketId to getUserByField?
+  getUserByWebsocketId(
+    websocketId: string
+  ): User | Promise<User | undefined> | undefined
+  getUserByField(
+    field: string,
+    value: any
+  ): User | Promise<User | undefined> | undefined
   saveUser(user: User): User | Promise<User>
   updateUser(user: User): User | Promise<User>
   getEvents(
@@ -26,9 +34,6 @@ export interface DataProvider {
   deleteEvent(
     id: string
   ): BotonicEvent | Promise<BotonicEvent | undefined> | undefined
-  getUserByWebsocketId(
-    websocketId: string
-  ): User | Promise<User | undefined> | undefined
 }
 
 /** URL examples:

--- a/packages/botonic-api/src/data-provider/local-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/local-data-provider.ts
@@ -35,6 +35,19 @@ export class LocalDevDataProvider implements DataProvider {
     return this.db.exists(path) ? this.db.getObject<User>(path) : undefined
   }
 
+  getUserByWebsocketId(websocketId: string): User | undefined {
+    return this.getUserByField('websocketId', websocketId)
+  }
+
+  getUserByField(field: string, value: any): User | undefined {
+    const path = this.paths.USERS
+    this.db.reload()
+    const dbUser = this.db.exists(path)
+      ? this.db.find<User>(path, (user: User) => user[field] === value)
+      : undefined
+    return dbUser?.[dbUser.id]
+  }
+
   saveUser(user: User): User {
     const path = this.createPath([this.paths.USERS, user.id])
     this.db.reload()
@@ -122,15 +135,6 @@ export class LocalDevDataProvider implements DataProvider {
     const path = this.createPath([this.paths.CONNECTIONS, websocketId])
     this.db.reload()
     this.db.delete(path)
-  }
-
-  getUserByWebsocketId(websocketId: string): User | undefined {
-    const path = this.paths.USERS
-    this.db.reload()
-    return this.db.find<User>(
-      path,
-      (user: User) => user.websocketId === websocketId
-    )
   }
 
   private createPath(urlChunks: string[]): string {

--- a/packages/botonic-api/src/rest/routes/bot-input.ts
+++ b/packages/botonic-api/src/rest/routes/bot-input.ts
@@ -1,0 +1,77 @@
+import { Session } from '@botonic/core'
+import { BotonicOutputParser } from '@botonic/core/lib'
+import { MessageEventFrom } from '@botonic/core/lib/models/events/message'
+import { BotonicEvent } from '@botonic/core/src/models/events'
+import { MessageEventAck } from '@botonic/core/src/models/events/message'
+import { User } from '@botonic/core/src/models/user'
+import { NodeApp } from '@botonic/react'
+import { Request, Router } from 'express'
+import { ulid } from 'ulid'
+import { v4 } from 'uuid'
+
+import { dataProviderFactory } from '../../data-provider'
+
+const dp = dataProviderFactory(process.env.DATA_PROVIDER_URL)
+
+export default function botInputRouter(bot: NodeApp): Router {
+  const router = Router()
+  const botonicOutputParser = new BotonicOutputParser()
+
+  router.route('/').post(async (req, res) => {
+    // TODO: parse: Boolean arg to indicate if we should parse the output or not (default true)
+    const user =
+      (await getUser(req)) ??
+      (await createUser(req.body.session.user.provider_id))
+
+    const output = await bot.input({
+      input: req.body.input,
+      session: { user },
+      lastRoutePath: user.route,
+    })
+
+    const parsedUserEvent = botonicOutputParser.parseFromUserInput(
+      req.body.input
+    )
+    await dp.saveEvent({
+      ...parsedUserEvent,
+      userId: user.id,
+      eventId: ulid(),
+      createdAt: new Date().toISOString(),
+      from: MessageEventFrom.USER,
+      ack: MessageEventAck.SENT,
+    } as BotonicEvent)
+
+    const messages = output.parsedResponse
+    for (const messageEvent of messages) {
+      await dp.saveEvent({
+        ...messageEvent,
+        userId: user.id,
+        eventId: ulid(),
+        createdAt: new Date().toISOString(),
+        from: MessageEventFrom.BOT,
+        ack: MessageEventAck.SENT,
+      })
+    }
+    res.json(output)
+  })
+
+  return router
+}
+
+async function getUser(req: Request): Promise<User | undefined> {
+  return (
+    (await dp.getUser(req.body.session.user.id)) ??
+    (await dp.getUserByField('provider_id', req.body.session.user.provider_id))
+  )
+}
+
+async function createUser(providerId: string): Promise<User> {
+  const user: User = {
+    id: v4(),
+    providerId,
+    isOnline: true,
+    route: '/',
+    session: {} as Session,
+  }
+  return dp.saveUser(user)
+}

--- a/packages/botonic-api/src/rest/routes/index.ts
+++ b/packages/botonic-api/src/rest/routes/index.ts
@@ -1,21 +1,14 @@
+import { NodeApp } from '@botonic/react'
 import { Router } from 'express'
 
+import botInputRouter from './bot-input'
 import events from './events'
 import users from './users'
 
-export const routes = bot => {
+export const routes = (bot: NodeApp) => {
   const router = Router()
   router.use('/users', users)
   router.use('/events', events)
-  router.route('/bot-input').post(async (req, res) => {
-    // TODO: parse: Boolean arg to indicate if we should parse the output or not (default true)
-    // TODO: get session and route from DataProvider
-    const output = await bot.app.input({
-      input: req.body.input,
-      session: req.body.session,
-      lastRoutePath: req.body.route,
-    })
-    res.json(output)
-  })
+  router.use('/bot-input', botInputRouter(bot))
   return router
 }


### PR DESCRIPTION
## Description
Persist user/events data in `bot-input` endpoint using the `DataProvider`.

Also, I've changed the `bot` argument `rest/routes` is receivinig to be directly the `NodeApp` (see [related PR](https://github.com/hubtype/botonic/pull/1731)) instead of an object containing other unused attributes.

## Context
User and events data was not stored when received from the `bot-input` endpoint.

## Approach taken / Explain the design
Instead of adding a `getUserByProviderId` method I preferred to add a generic method (`getUserByField`) to search users by any field.
@ericmarcos @vanbasten17 @marcpdw if you're ok with this implementation maybe it will be nice to deprecate the `getUserByWebsocketId` method and use `getUserByField` instead.

Also, to make the code cleaner, I've add all `bot-input` endpoint's code into a sepparate file, the same way we already have with the other endpoints

## To document / Usage example

## Testing

The pull request has no tests.