### PR TITLE
refactor(create-botonic-app): Export only the NodeApp in bot/src/index.js

### DIFF
--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -194,8 +194,11 @@ export const MultichannelText = props => {
   if (isFacebook(requestContext)) {
     const text = getText(props.children)
     const multichannelFacebook = new MultichannelFacebook()
-    const { texts, propsLastText, propsWithoutChildren } =
-      multichannelFacebook.convertText(props, text[0])
+    const {
+      texts,
+      propsLastText,
+      propsWithoutChildren,
+    } = multichannelFacebook.convertText(props, text[0])
     return (
       <>
         {texts &&

--- a/packages/create-botonic-app/template/api/src/rest/app.ts
+++ b/packages/create-botonic-app/template/api/src/rest/app.ts
@@ -2,7 +2,7 @@ import * as express from 'express'
 import * as cors from 'cors'
 import * as morgan from 'morgan'
 import { routes } from '@botonic/api/src/rest/routes'
-import * as bot from 'bot/src'
+import { app as bot } from 'bot/src'
 
 export let app
 app = express()

--- a/packages/create-botonic-app/template/bot/src/actions/Welcome.js
+++ b/packages/create-botonic-app/template/bot/src/actions/Welcome.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import { Text } from '@botonic/react/src/experimental'
-
-const WelcomeAction = () => <Text>Welcome to Botonic!</Text>
-
-export default WelcomeAction

--- a/packages/create-botonic-app/template/bot/src/actions/Welcome.js
+++ b/packages/create-botonic-app/template/bot/src/actions/Welcome.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Text } from '@botonic/react/src/experimental'
+
+const WelcomeAction = () => <Text>Welcome to Botonic!</Text>
+
+export default WelcomeAction

--- a/packages/create-botonic-app/template/bot/src/index.js
+++ b/packages/create-botonic-app/template/bot/src/index.js
@@ -1,7 +1,8 @@
 import { NodeApp } from '@botonic/react'
-import { routes } from './routes'
-import { plugins } from './plugins'
-import { locales } from './locales'
 
-export const config = { defaultDelay: 0, defaultTyping: 0 }
-export let app = new NodeApp({ routes, locales, plugins, ...config })
+import { locales } from './locales'
+import { plugins } from './plugins'
+import { routes } from './routes'
+
+const config = { defaultDelay: 0, defaultTyping: 0 }
+export const app = new NodeApp({ routes, locales, plugins, ...config })

--- a/packages/create-botonic-app/template/bot/src/nlp/data/en/business.order.status.yaml
+++ b/packages/create-botonic-app/template/bot/src/nlp/data/en/business.order.status.yaml
@@ -1,0 +1,37 @@
+intent: business.order.status
+
+entities:
+  - product
+
+data-augmentation:
+  product:
+    - jacket
+    - shirt
+    - t-shirt
+    - coat
+    - suit
+    - sweater
+    - hat
+    - socks
+  
+  order:
+    - order
+    - parcel
+    - packet
+    - request
+    - purchase
+    - shipment
+    - material
+
+samples:
+  - Where is my [order]?
+  - Where is my [product]?
+  - Is my [order] delayed?
+  - When will my [order] arrive?
+  - When will my [product] arrive?
+  - Will my [order] arrive tomorrow?
+  - My [order] should have arrived yesterday
+  - My [order] should have arrived today
+  - I was expecting my [order] today
+  - I was expecting my [order] to arrive yesterday
+  - Can I expect my [order] anytime soon?

--- a/packages/create-botonic-app/template/bot/src/nlp/data/en/business.product.search.yaml
+++ b/packages/create-botonic-app/template/bot/src/nlp/data/en/business.product.search.yaml
@@ -1,0 +1,60 @@
+intent: business.product.search
+
+entities:
+  - product
+  - color
+  - size
+
+data-augmentation:
+  product:
+    - jacket
+    - shirt
+    - t-shirt
+    - coat
+    - suit
+    - sweater
+    - hat
+    - socks
+
+  color:
+    - black
+    - white
+    - blue
+    - red
+    - gray
+    - purple
+    - orange
+    - beige
+    - yellow
+    - pink
+
+  size:
+    - XS
+    - S
+    - M
+    - L
+    - XL
+    - XXL
+
+samples:
+  - "[product]"
+  - "[color] [product]"
+  - "[size] [product]"
+  - I'm looking for [product]
+  - Show me [color] [product]
+  - Can I get some [product]
+  - I'd like to get a [color] [product]
+  - Do you have any [color] [product]?
+  - Do you have any [product] in [color]?
+  - Do you have any [product] in [size] size?
+  - Do you have any [size] [product]?
+  - Do you have any [size] [product] available?
+  - Is there any [product] available?
+  - I wonder if you have stock of these [trousers](product)
+  - I want this [product] in size [size]
+  - Do you only have this [product] online?
+  - When will be stock again of this [product] in size [size]?
+  - I think this [product] in size [size] is out of stock, can you confirm that?
+  - I would like to buy a [color] [product] but your website says there is no stock, is it right?
+  - When will you have the [color] [product] available?
+  - I would like to know if there is stock of [product], [size] size

--- a/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.farewell.bye.yaml
+++ b/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.farewell.bye.yaml
@@ -1,0 +1,9 @@
+intent: smalltalk.farewell.bye
+
+samples:
+  - Bye
+  - bye bye!
+  - Adios
+  - See ya!
+  - See you later
+  - Goodbye

--- a/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.farewell.courtesy.yaml
+++ b/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.farewell.courtesy.yaml
@@ -1,0 +1,14 @@
+intent: smalltalk.farewell.courtesy
+
+samples:
+  - Thanks, bye
+  - Thanks for the help, goodbye
+  - Thank you, bye
+  - Thank you, goodbye
+  - Thanks goodbye
+  - Thanks good bye
+  - It was a pleasure talking to you
+  - I really enjoyed this conversation, bye!
+  - Thanks for your help, bye bye
+  - Farewell!
+  - Godspeed!

--- a/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.greeting.courtesy.yaml
+++ b/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.greeting.courtesy.yaml
@@ -1,0 +1,10 @@
+intent: smalltalk.greeting.courtesy
+
+samples:
+  - How are you?
+  - Hi how are you?
+  - Hello how are you?
+  - Hola how are you?
+  - How are you doing?
+  - Hope you are doing well?
+  - Hello hope you are doing well?

--- a/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.greeting.hi.yaml
+++ b/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.greeting.hi.yaml
@@ -1,0 +1,12 @@
+intent: smalltalk.greeting.hi
+
+samples:
+  - Hi
+  - Hi there
+  - Hola
+  - Hey!
+  - Hello
+  - Hello there!
+  - Hya
+  - Hya there
+  - Howdy

--- a/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.thanks.yaml
+++ b/packages/create-botonic-app/template/bot/src/nlp/data/en/smalltalk.thanks.yaml
@@ -1,0 +1,12 @@
+intent: smalltalk.thanks
+
+samples:
+  - OK thank you
+  - OK thanks
+  - OK
+  - Thanks
+  - Thank you
+  - Oh, thank you
+  - I appreciate that
+  - That's helpful
+  - That was really helpful

--- a/packages/create-botonic-app/template/bot/src/routes.js
+++ b/packages/create-botonic-app/template/bot/src/routes.js
@@ -1,5 +1,3 @@
 import Welcome from './actions/Welcome'
 
-export const routes = [
-    {text: /hi/i, action: Welcome}
-]
+export const routes = [{ text: /hi/i, action: Welcome }]


### PR DESCRIPTION
:warning: Depends on #1730 

## Description
Small improvement by exporting only the `NodeApp` in `bot/src/index.js`. No need to export de config passed to the `NodeApp` since it's already inside it.

## Context
Small improvement to make clearer what the bot is exporting.

## Approach taken / Explain the design

## To document / Usage example

## Testing

The pull request has no tests.