### PR TITLE
Full stack: Add providerId in User interface

### DIFF
--- a/packages/botonic-core/src/models/user.ts
+++ b/packages/botonic-core/src/models/user.ts
@@ -1,7 +1,8 @@
 import { Session } from '../types/'
 export interface User {
   id: string //TODO: UUID
-  websocketId: string
+  providerId?: string
+  websocketId?: string
   session: Session
   route: string
   isOnline: boolean

--- a/packages/botonic-core/src/router.test.js
+++ b/packages/botonic-core/src/router.test.js
@@ -340,8 +340,6 @@ test.each([
     const input = { type: 'postback', payload: inputPayload }
     expect(router.getOnFinishParams(input)).toEqual(expectedParams)
     expect(input.path).toEqual(expectedPath)
-    if (input.path) {
-      expect(input.payload).toBeUndefined()
-    }
+    expect(input.payload).toEqual(input.path ? undefined : input.payload)
   }
 )


### PR DESCRIPTION
## Description
Add missing `providerId` attribute in User interface as an optional attribute.
Also, modified the existing `websocketId` attribute to optional.

Fix lint error (`no-conditional-expect`) in test.

## Context
Improvement of types in the full-stack version.

## Approach taken / Explain the design

## To document / Usage example

## Testing

The pull request has unit tests.