### PR TITLE
Chore/bump to 0.19 beta

### DIFF
--- a/packages/botonic-core/package-lock.json
+++ b/packages/botonic-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "1.0.0-alpha.1",
+  "version": "0.19.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "1.0.0-alpha.1",
+  "version": "0.19.0-beta.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "lib/index.js",

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "1.0.0-alpha.2",
+  "version": "0.19.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1192,9 +1192,9 @@
       }
     },
     "@botonic/core": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-n8ZjNwCuxFVTMJ6KVWaMcP+8tbFajNEgTMFGA5M44FtYIeh1fho8cez3ercyBX1uTXDElMPU9qbM8cWq9mo0qA==",
+      "version": "0.19.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.19.0-beta.0.tgz",
+      "integrity": "sha512-oqS+/BAi7QkbNcQAsDbgifHrEaKQXo5TsoLD4Td6Pb1IPHsV9QBkDHMnDLXaAx/DpBbNJLRxsYzml9ny0kzQQw==",
       "requires": {
         "axios": "^0.21.0",
         "decode": "^0.3.0",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "1.0.0-alpha.2",
+  "version": "0.19.0-beta.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@botonic/core": "alpha",
+    "@botonic/core": "^0.19.0-beta.0",
     "axios": "^0.21.1",
     "emoji-picker-react": "^3.2.3",
     "framer-motion": "^3.1.1",


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

* Bumping to 0.19.0 beta versions of core/react containing the new multichannel features, raw component, mixed with new botonic 1.0 code.
