### PR TITLE
feat(contentful): add paging in searchByKeywords

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+      "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
       "dev": true
     },
     "@babel/highlight": {
@@ -68,9 +68,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
-      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
+      "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -398,15 +398,21 @@
       "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw=="
     },
     "@types/marked": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.3.tgz",
-      "integrity": "sha512-lbhSN1rht/tQ+dSWxawCzGgTfxe9DB31iLgiT1ZVT5lshpam/nyOA1m3tKHRoNPctB2ukSL22JZI5Fr+WI/zYg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.4.tgz",
+      "integrity": "sha512-L9VRSe0Id8xbPL99mUo/4aKgD7ZoRwFZqUQScNKHi2pFjF9ZYSMNShUHD6VlMT6J/prQq0T1mxuU25m3R7dFzg==",
       "dev": true
     },
     "@types/memoizee": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.5.tgz",
-      "integrity": "sha512-+ZzZZ3+0a7/ajBPeAAD4+LxrBsCat0EFZQtO3o0rwpIeLmDmSaM8KF/oYPuFxeUFAMiHIHFcGucFnY/8S4Hszg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.6.tgz",
+      "integrity": "sha512-qJezGqoi3pW9Pset2w1Gfv8jATvmHHHnpO9Dq8x8pJGyYIpiUZJqRU0NM7xenmN0AcXEe7vqshI8H98KeFLYcg==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
+      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -416,18 +422,18 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.11",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-      "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+      "version": "13.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
@@ -1228,9 +1234,9 @@
       }
     },
     "contentful-cli": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/contentful-cli/-/contentful-cli-1.8.12.tgz",
-      "integrity": "sha512-vfFIE4BZutGBojcwNyL4Z9sN4mXB5XGtfsfQ3KqFbv6jCV4j9dpO5ui55rHGHDkuOGnH8G4kVDg1VFEa8vLIlw==",
+      "version": "1.8.22",
+      "resolved": "https://registry.npmjs.org/contentful-cli/-/contentful-cli-1.8.22.tgz",
+      "integrity": "sha512-aBYSTnpDzqsInC4PJsePgvdgPChC/eWs7/Qb7Isv1ILr3+fUzyfIF3UVHbiXcqWzZgEqb6wR+yzdcPAlA+4lxw==",
       "dev": true,
       "requires": {
         "ast-types": "^0.14.2",
@@ -1616,9 +1622,9 @@
       }
     },
     "contentful-export": {
-      "version": "7.12.28",
-      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-7.12.28.tgz",
-      "integrity": "sha512-8Asl0MM7Rm904t43Vl4M1P4nG6leHQZsKTwOJKw+3AgvB0B6Q0v4X6IrpOPcWvyqqauvcXLuspAIhokqKDkaSA==",
+      "version": "7.12.33",
+      "resolved": "https://registry.npmjs.org/contentful-export/-/contentful-export-7.12.33.tgz",
+      "integrity": "sha512-9HvFCWzAajFbI+2IHprl+4eANbgrAm7L6MdDErXGHKuydudA3aGUqm16Bq3e5buGBuHIc3M9XYzpywBVw81tcw==",
       "dev": true,
       "requires": {
         "bfj": "^7.0.2",
@@ -1779,9 +1785,9 @@
       }
     },
     "contentful-import": {
-      "version": "8.1.17",
-      "resolved": "https://registry.npmjs.org/contentful-import/-/contentful-import-8.1.17.tgz",
-      "integrity": "sha512-h84J7FgApagiukC146hbY9pBkFlAAg7ml+qvJOb8leKA44vlwlbLAbMum2BqGN7DaADueCg/5GYLHCSo+3TDgA==",
+      "version": "8.1.24",
+      "resolved": "https://registry.npmjs.org/contentful-import/-/contentful-import-8.1.24.tgz",
+      "integrity": "sha512-ldaGf9nMW3UiR+BgCgcM/1W4bkUn1PmCNnHshayumNe4DkD6ePGlYNzyM4M60xaezCCz7C5wbfa4AfCXTxZOgA==",
       "requires": {
         "bluebird": "^3.5.1",
         "cli-table3": "^0.6.0",
@@ -1799,9 +1805,9 @@
       }
     },
     "contentful-management": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.25.1.tgz",
-      "integrity": "sha512-V8tcSHw3MwWKWHWMW+AZB6lP31hreos+v2gtayZczWXYRcfd+owt+qVjbkLZk1pL80ewSmc8Pl1A7rM/oB2ldw==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.31.0.tgz",
+      "integrity": "sha512-YhPikvkO/ckRTO400I+iHYpVLuHwPyMzTQcMwBWpUluXYCF45I/RpWw7cyNQciQ19Q0NpjgEfUTQnhFhIqHtwA==",
       "requires": {
         "@types/json-patch": "0.0.30",
         "axios": "^0.21.0",
@@ -1812,9 +1818,9 @@
       }
     },
     "contentful-migration": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.2.3.tgz",
-      "integrity": "sha512-+VXz3U5CBcDq5PpG0EskHpehseKPzbhpA26OOGmWfP5VFrqmK8JTuDhmXiAuN7sbj8TPetqlXThRS27CSNFqTw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.2.5.tgz",
+      "integrity": "sha512-3aTt/XAHrlVDJ254o164Qoyr+FNrtK5nLbHdQ1T94Jtw7kRnfL91jDUk+UpkLQT/pdjkoAXx9PFHJSYU148XHA==",
       "dev": true,
       "requires": {
         "axios": "^0.21.0",
@@ -1822,7 +1828,7 @@
         "callsites": "^3.1.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.0.0",
-        "contentful-management": "^7.3.1",
+        "contentful-management": "^7.25.1",
         "didyoumean2": "^5.0.0",
         "hoek": "^6.1.3",
         "https-proxy-agent": "^5.0.0",
@@ -1850,14 +1856,6 @@
           "dev": true,
           "requires": {
             "type-fest": "^0.21.3"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.21.3",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-              "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-              "dev": true
-            }
           }
         },
         "ansi-styles": {
@@ -1919,20 +1917,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "contentful-management": {
-          "version": "7.27.0",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.27.0.tgz",
-          "integrity": "sha512-HGwUmR0160TI9RNiqLWjlFpPmjiXGC2VAgtzqM0mXMCJKJTzLBmsETVycQ7Nwip+2+CHdDRta5a9vQEN89UNTw==",
-          "dev": true,
-          "requires": {
-            "@types/json-patch": "0.0.30",
-            "axios": "^0.21.0",
-            "contentful-sdk-core": "^6.8.0",
-            "fast-copy": "^2.1.0",
-            "lodash.isplainobject": "^4.0.6",
-            "type-fest": "^0.20.2"
-          }
         },
         "debug": {
           "version": "4.3.2",
@@ -2012,9 +1996,9 @@
           }
         },
         "joi": {
-          "version": "17.4.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
-          "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+          "version": "17.4.1",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.1.tgz",
+          "integrity": "sha512-gDPOwQ5sr+BUxXuPDGrC1pSNcVR/yGGcTI0aCnjYxZEa3za60K/iCQ+OFIkEHWZGVCUcUlXlFKvMmrlmxrG6UQ==",
           "dev": true,
           "requires": {
             "@hapi/hoek": "^9.0.0",
@@ -2069,6 +2053,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -2475,9 +2465,9 @@
       },
       "dependencies": {
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "mimic-fn": {
@@ -3183,9 +3173,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.1.tgz",
-      "integrity": "sha512-hUDjc3vBkh/uk1gPfMAD/7Z188Q8cvTGl0nxwaCdwSbzFh6ZKkZh+s2ozVxbE5G9ZNRyeY0+lgbAIOUFsFf98w==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
+      "integrity": "sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -3198,7 +3188,7 @@
         "mute-stream": "0.0.8",
         "ora": "^5.3.0",
         "run-async": "^2.4.0",
-        "rxjs": "^6.6.6",
+        "rxjs": "^7.2.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
@@ -3302,6 +3292,15 @@
             "signal-exit": "^3.0.2"
           }
         },
+        "rxjs": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.2.0.tgz",
+          "integrity": "sha512-aX8w9OpKrQmiPKfT1bqETtUr9JygIz6GZ+gql8v7CijClsP0laoFUdKzxFAoWuRdSlOdU2+crss+cMf+cqMTnw==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3310,6 +3309,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
         },
         "type-fest": {
           "version": "0.21.3",
@@ -3538,9 +3543,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -4151,9 +4156,9 @@
           }
         },
         "date-fns": {
-          "version": "2.22.1",
-          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.22.1.tgz",
-          "integrity": "sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg=="
+          "version": "2.23.0",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
+          "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -4820,9 +4825,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -5272,9 +5277,9 @@
       }
     },
     "recast": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.4.tgz",
-      "integrity": "sha512-6qLIBGGRcwjrTZGIiBpJVC/NeuXpogXNyRQpqU1zWPUigCphvApoCs9KIwDYh1eDuJ6dAFlQoi/QUyE5KQ6RBQ==",
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
       "dev": true,
       "requires": {
         "ast-types": "0.14.2",
@@ -5310,9 +5315,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regex-escape": {
       "version": "3.4.10",
@@ -5906,9 +5911,9 @@
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
+      "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",

--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.19.0-alpha.5",
+  "version": "0.19.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -64,7 +64,6 @@
     "memoizee": "^0.4.15",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.33",
-    "perf_hooks": "0.0.1",
     "sort-stream": "^1.0.1",
     "xlsx": "^0.17.0"
   },

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -15,7 +15,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.19.0-alpha.5",
+  "version": "0.19.0-alpha.6",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-dummy.ts
@@ -133,7 +133,10 @@ export class DummyCMS implements CMS {
     return Promise.resolve([])
   }
 
-  contentsWithKeywords({} = DEFAULT_CONTEXT): Promise<SearchCandidate[]> {
+  contentsWithKeywords(
+    {} = DEFAULT_CONTEXT,
+    paging?: PagingOptions
+  ): Promise<SearchCandidate[]> {
     const contents = this.buttonCallbacks.map((cb, id) => {
       const button = DummyCMS.buttonFromCallback(cb)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/botonic-plugin-contentful/src/cms/cms-error.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-error.ts
@@ -170,9 +170,12 @@ export class ErrorReportingCMS implements CMS {
     )
   }
 
-  contentsWithKeywords(context?: Context): Promise<SearchCandidate[]> {
+  contentsWithKeywords(
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<SearchCandidate[]> {
     return this.cms
-      .contentsWithKeywords(context)
+      .contentsWithKeywords(context, paging)
       .catch(this.handleError('contentsWithKeywords', {}, context))
   }
 

--- a/packages/botonic-plugin-contentful/src/cms/cms-log.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-log.ts
@@ -91,9 +91,12 @@ export class LogCMS implements CMS {
     return this.cms.content(id, context)
   }
 
-  contentsWithKeywords(context?: Context): Promise<SearchCandidate[]> {
+  contentsWithKeywords(
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<SearchCandidate[]> {
     this.logger('contentsWithKeywords')
-    return this.cms.contentsWithKeywords(context)
+    return this.cms.contentsWithKeywords(context, paging)
   }
 
   topContents<T extends TopContent>(

--- a/packages/botonic-plugin-contentful/src/cms/cms-multilocale.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms-multilocale.ts
@@ -60,8 +60,11 @@ export class MultiContextCms implements CMS {
     return this.cmsFromContext(context).assets(context)
   }
 
-  contentsWithKeywords(context?: Context): Promise<SearchCandidate[]> {
-    return this.cmsFromContext(context).contentsWithKeywords(context)
+  contentsWithKeywords(
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<SearchCandidate[]> {
+    return this.cmsFromContext(context).contentsWithKeywords(context, paging)
   }
 
   dateRange(id: string, context?: Context): Promise<DateRangeContent> {

--- a/packages/botonic-plugin-contentful/src/cms/cms.ts
+++ b/packages/botonic-plugin-contentful/src/cms/cms.ts
@@ -161,7 +161,10 @@ export interface CMS {
    * For contents with 'Searchable by' field (eg. {@link Queue}), it returns one result per each 'Seachable by' entry
    * @param context If locale specified, it does not return contents without values for the locale (even if it has value for the fallback locale)
    */
-  contentsWithKeywords(context?: Context): Promise<SearchCandidate[]>
+  contentsWithKeywords(
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<SearchCandidate[]>
   schedule(id: string, context?: Context): Promise<ScheduleContent>
   dateRange(id: string, context?: Context): Promise<DateRangeContent>
   asset(id: string, context?: Context): Promise<Asset>

--- a/packages/botonic-plugin-contentful/src/cms/transform/cms-filter.ts
+++ b/packages/botonic-plugin-contentful/src/cms/transform/cms-filter.ts
@@ -119,8 +119,11 @@ export class FilteredCMS implements CMS {
     return this.cms.content(id, context)
   }
 
-  contentsWithKeywords(context?: Context): Promise<SearchCandidate[]> {
-    return this.cms.contentsWithKeywords(context)
+  contentsWithKeywords(
+    context?: Context,
+    paging?: PagingOptions
+  ): Promise<SearchCandidate[]> {
+    return this.cms.contentsWithKeywords(context, paging)
   }
 
   async topContents<T extends TopContent>(

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -258,9 +258,10 @@ export class Contentful implements cms.CMS {
   }
 
   async contentsWithKeywords(
-    context = DEFAULT_CONTEXT
+    context = DEFAULT_CONTEXT,
+    paging = new PagingOptions()
   ): Promise<SearchCandidate[]> {
-    return this._keywords.contentsWithKeywords(context)
+    return this._keywords.contentsWithKeywords(context, paging)
   }
 
   async schedule(id: string): Promise<ScheduleContent> {

--- a/packages/botonic-plugin-contentful/src/contentful/search/keywords.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/search/keywords.ts
@@ -1,8 +1,14 @@
 import { Entry, EntryCollection } from 'contentful'
 
 import * as cms from '../../cms'
-import { CommonFields, Context, TopContentId, TopContentType } from '../../cms'
-import { ContentType } from '../../cms/cms'
+import {
+  CommonFields,
+  ContentType,
+  Context,
+  PagingOptions,
+  TopContentId,
+  TopContentType,
+} from '../../cms'
 import { SearchCandidate } from '../../search'
 import { QueueFields } from '../contents/queue'
 import { DeliveryApi } from '../delivery-api'
@@ -13,6 +19,7 @@ export class KeywordsDelivery {
 
   async contentsWithKeywords(
     context: Context,
+    paging: PagingOptions,
     modelsWithKeywords = [
       ContentType.TEXT,
       ContentType.CAROUSEL,
@@ -22,7 +29,11 @@ export class KeywordsDelivery {
   ): Promise<SearchCandidate[]> {
     // TODO maybe it's more efficient to get all contents (since most have keywords anyway and we normally have few non
     //  TopContents such as Buttons)
-    const fromKeywords = this.entriesWithKeywords(context, modelsWithKeywords)
+    const fromKeywords = this.entriesWithKeywords(
+      context,
+      modelsWithKeywords,
+      paging
+    )
     const fromSearchable = this.entriesWithSearchableByKeywords(
       context,
       modelsWithSearchableByKeywords
@@ -99,10 +110,12 @@ export class KeywordsDelivery {
 
   private entriesWithKeywords(
     context: Context,
-    models: TopContentType[]
+    models: TopContentType[],
+    paging: PagingOptions
   ): Promise<SearchCandidate[]> {
     const getWithKeywords = (contentType: cms.TopContentType) =>
       this.delivery.getEntries<CommonEntryFields>(context, {
+        ...paging,
         // eslint-disable-next-line @typescript-eslint/naming-convention
         content_type: contentType,
         'fields.keywords[exists]': true,

--- a/packages/botonic-plugin-contentful/src/search/search-by-keywords.ts
+++ b/packages/botonic-plugin-contentful/src/search/search-by-keywords.ts
@@ -1,4 +1,5 @@
 import * as cms from '../cms'
+import { PagingOptions } from '../cms'
 import {
   checkLocale,
   KeywordsOptions,
@@ -24,10 +25,14 @@ export class SearchByKeywords {
   async searchContentsFromInput(
     inputText: NormalizedUtterance,
     matchType: MatchType,
-    context: cms.ContextWithLocale
+    context: cms.ContextWithLocale,
+    paging?: PagingOptions
   ): Promise<SearchResult[]> {
     checkLocale(context.locale)
-    const contentsWithKeywords = await this.cms.contentsWithKeywords(context)
+    const contentsWithKeywords = await this.cms.contentsWithKeywords(
+      context,
+      paging
+    )
     const options =
       this.keywordsOptions[context.locale] ||
       this.keywordsOptions[languageFromLocale(context.locale)] ||

--- a/packages/botonic-plugin-contentful/src/search/search.ts
+++ b/packages/botonic-plugin-contentful/src/search/search.ts
@@ -5,6 +5,7 @@ import {
   ContentType,
   Context,
   ContextWithLocale,
+  PagingOptions,
   Text,
 } from '../cms'
 import { checkLocale, KeywordsOptions, MatchType, Normalizer } from '../nlp'
@@ -28,14 +29,16 @@ export class Search {
   async searchByKeywords(
     inputText: string,
     matchType: MatchType,
-    context: ContextWithLocale
+    context: ContextWithLocale,
+    paging: PagingOptions = new PagingOptions()
   ): Promise<SearchResult[]> {
     const locale = checkLocale(context.locale)
     const utterance = this.normalizer.normalize(locale, inputText)
     const results = await this.search.searchContentsFromInput(
       utterance,
       matchType,
-      context
+      context,
+      paging
     )
     return this.search.filterChitchat(utterance.words, results)
   }

--- a/packages/botonic-plugin-contentful/src/util/measurer/node-performance-measurer.ts
+++ b/packages/botonic-plugin-contentful/src/util/measurer/node-performance-measurer.ts
@@ -6,6 +6,7 @@ class PerformanceFactory {
       return performance
     } catch {
       //TODO: investigate why a normal require breaks the bot when compiling with webpack
+      //To solve the issue we're executing eval('require') instead of using a direct require (https://stackoverflow.com/a/67288823/3982733)
       return eval('require')('perf_hooks').performance
     }
   }
@@ -14,6 +15,7 @@ class PerformanceFactory {
       return PerformanceObserver
     } catch {
       //TODO: investigate why a normal require breaks the bot when compiling with webpack
+      //To solve the issue we're executing eval('require') instead of using a direct require (https://stackoverflow.com/a/67288823/3982733)
       return eval('require')('perf_hooks').PerformanceObserver
     }
   }

--- a/packages/botonic-plugin-contentful/src/util/measurer/node-performance-measurer.ts
+++ b/packages/botonic-plugin-contentful/src/util/measurer/node-performance-measurer.ts
@@ -5,16 +5,16 @@ class PerformanceFactory {
     try {
       return performance
     } catch {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      return require('perf_hooks').performance
+      //TODO: investigate why a normal require breaks the bot when compiling with webpack
+      return eval('require')('perf_hooks').performance
     }
   }
   static getObserver(): typeof PerformanceObserver {
     try {
       return PerformanceObserver
     } catch {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      return require('perf_hooks').PerformanceObserver
+      //TODO: investigate why a normal require breaks the bot when compiling with webpack
+      return eval('require')('perf_hooks').PerformanceObserver
     }
   }
 }
@@ -22,7 +22,6 @@ export class NodePerformanceMeasurer extends PerformanceMeasurer {
   private performanceObserver?: PerformanceObserver
 
   constructor() {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     super(PerformanceFactory.getPerformance())
   }
 

--- a/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
@@ -1,6 +1,6 @@
 import 'jest-extended'
 
-import { deepEqual, instance, mock, when } from 'ts-mockito'
+import { anything, deepEqual, instance, mock, when } from 'ts-mockito'
 
 import {
   CommonFields,
@@ -134,9 +134,9 @@ export function keywordsWithMockCms(
   stemBlackList: { [locale: string]: StemmingBlackList[] } = {}
 ): SearchByKeywords {
   const mockCms = mock(DummyCMS)
-  when(mockCms.contentsWithKeywords(deepEqual(context), undefined)).thenResolve(
-    allContents
-  )
+  when(
+    mockCms.contentsWithKeywords(deepEqual(context), anything())
+  ).thenResolve(allContents)
   const normalizer = new Normalizer(stemBlackList)
   return new SearchByKeywords(instance(mockCms), normalizer)
 }

--- a/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
+++ b/packages/botonic-plugin-contentful/tests/search/search-by-keywords.test.ts
@@ -134,7 +134,7 @@ export function keywordsWithMockCms(
   stemBlackList: { [locale: string]: StemmingBlackList[] } = {}
 ): SearchByKeywords {
   const mockCms = mock(DummyCMS)
-  when(mockCms.contentsWithKeywords(deepEqual(context))).thenResolve(
+  when(mockCms.contentsWithKeywords(deepEqual(context), undefined)).thenResolve(
     allContents
   )
   const normalizer = new Normalizer(stemBlackList)


### PR DESCRIPTION
## Description

- Adding `paging` parameter in `searchByKeywords` the same way it's done with `topContents`.
- Fixed an error with the `perf_hooks` dependency that was making the bot's webpack to fail when compiling.

## Context
Contentful requests have a limit of 100 contents and some times there's a need to obtain more than 100 contents when searching by keywords.

## Approach taken / Explain the design
If no paging object is passed to `searchByKeywords` the default one (with a limit of 1000) wil be set.

## To document / Usage example

## Testing

The pull request has no tests.