### PR TITLE
feat(api): implement /users endpoint

### DIFF
--- a/packages/botonic-api/package-lock.json
+++ b/packages/botonic-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/api",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-api/package.json
+++ b/packages/botonic-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/api",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
@@ -89,6 +89,9 @@ export class DynamoDBDataProvider implements DataProvider {
     return user
   }
   // @ts-ignore
+  async deleteUser(id: string): Promise<User | undefined> {} // TODO: Implement
+
+  // @ts-ignore
   async getEvents(limit = 10, offset = 0): Promise<BotonicEvent[]> {} // TODO: Implement
 
   // @ts-ignore

--- a/packages/botonic-api/src/data-provider/index.ts
+++ b/packages/botonic-api/src/data-provider/index.ts
@@ -22,6 +22,7 @@ export interface DataProvider {
   ): User | Promise<User | undefined> | undefined
   saveUser(user: User): User | Promise<User>
   updateUser(user: User): User | Promise<User>
+  deleteUser(id: string): User | Promise<User | undefined> | undefined
   getEvents(
     limit?: number,
     offset?: number

--- a/packages/botonic-api/src/data-provider/local-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/local-data-provider.ts
@@ -67,6 +67,19 @@ export class LocalDevDataProvider implements DataProvider {
     return user
   }
 
+  deleteUser(id: string): User | undefined {
+    const path = this.createPath([this.paths.USERS, id])
+    this.db.reload()
+    const user = this.db.exists(path)
+      ? this.db.getObject<User>(path)
+      : undefined
+    if (user) {
+      this.db.delete(path)
+      return user
+    }
+    return undefined
+  }
+
   getEvents(limit = 10, offset = 0): BotonicEvent[] {
     const path = this.paths.EVENTS
     this.db.reload()

--- a/packages/botonic-api/src/rest/routes/events.ts
+++ b/packages/botonic-api/src/rest/routes/events.ts
@@ -36,7 +36,7 @@ router
     }
   )
   .post(async (req, res) => {
-    const errors = await validateBotonicEventData(req)
+    const errors = await validateBotonicEventData({ request: req })
     if (!errors.isEmpty()) {
       res.status(400).send({ errors: errors.array({ onlyFirstError: true }) })
       return
@@ -82,7 +82,11 @@ router
     }
   })
   .put(async (req, res) => {
-    const errors = await validateBotonicEventData(req, false, true)
+    const errors = await validateBotonicEventData({
+      request: req,
+      allFieldsOptional: false,
+      withParamEventId: true,
+    })
     if (!errors.isEmpty()) {
       res.status(400).send({ errors: errors.array({ onlyFirstError: true }) })
       return
@@ -102,12 +106,8 @@ router
           .send({ error: `Event with ID '${params.eventId}' not found` })
         return
       }
-      if (event.eventId !== updatedEvent.eventId) {
-        res
-          .status(400)
-          .send({ error: `Both event ID (params and body) must match` })
-        return
-      }
+
+      updatedEvent.eventId = event.eventId
       await dp.updateEvent(updatedEvent)
       res.status(200).send(updatedEvent)
     } catch (e) {
@@ -115,7 +115,11 @@ router
     }
   })
   .patch(async (req, res) => {
-    const errors = await validateBotonicEventData(req, true, true)
+    const errors = await validateBotonicEventData({
+      request: req,
+      allFieldsOptional: true,
+      withParamEventId: true,
+    })
     if (!errors.isEmpty()) {
       res.status(400).send({ errors: errors.array({ onlyFirstError: true }) })
       return
@@ -135,12 +139,8 @@ router
           .send({ error: `Event with ID '${params.eventId}' not found` })
         return
       }
-      if (newEventData.eventId && event.eventId !== newEventData.eventId) {
-        res
-          .status(400)
-          .send({ error: `Both user ID (params and body) must match` })
-        return
-      }
+
+      newEventData.eventId = event.eventId
       const updatedEvent = { ...event, ...newEventData } as BotonicEvent
       await dp.updateEvent(updatedEvent)
       res.status(200).send(updatedEvent)

--- a/packages/botonic-api/src/rest/routes/events.ts
+++ b/packages/botonic-api/src/rest/routes/events.ts
@@ -102,6 +102,12 @@ router
           .send({ error: `Event with ID '${params.eventId}' not found` })
         return
       }
+      if (event.eventId !== updatedEvent.eventId) {
+        res
+          .status(400)
+          .send({ error: `Both event ID (params and body) must match` })
+        return
+      }
       await dp.updateEvent(updatedEvent)
       res.status(200).send(updatedEvent)
     } catch (e) {
@@ -127,6 +133,12 @@ router
         res
           .status(404)
           .send({ error: `Event with ID '${params.eventId}' not found` })
+        return
+      }
+      if (newEventData.eventId && event.eventId !== newEventData.eventId) {
+        res
+          .status(400)
+          .send({ error: `Both user ID (params and body) must match` })
         return
       }
       const updatedEvent = { ...event, ...newEventData } as BotonicEvent

--- a/packages/botonic-api/src/rest/routes/events.ts
+++ b/packages/botonic-api/src/rest/routes/events.ts
@@ -3,10 +3,9 @@ import { Router } from 'express'
 import { checkSchema, matchedData, validationResult } from 'express-validator'
 
 import { dataProviderFactory } from '../../data-provider'
+import { limitParamSchema, offsetParamSchema } from './validation/common'
 import {
   eventIdParamSchema,
-  limitParamSchema,
-  offsetParamSchema,
   validateBotonicEventData,
 } from './validation/events'
 

--- a/packages/botonic-api/src/rest/routes/events.ts
+++ b/packages/botonic-api/src/rest/routes/events.ts
@@ -60,13 +60,13 @@ router
 router
   .route('/:eventId')
   .get(checkSchema({ eventId: eventIdParamSchema }), async (req, res) => {
-    try {
-      const errors = validationResult(req)
-      if (!errors.isEmpty()) {
-        res.status(400).send({ errors: errors.array() })
-        return
-      }
+    const errors = validationResult(req)
+    if (!errors.isEmpty()) {
+      res.status(400).send({ errors: errors.array() })
+      return
+    }
 
+    try {
       const params = matchedData(req, { locations: ['params'] })
       const dp = dataProviderFactory(process.env.DATA_PROVIDER_URL)
       const event = await dp.getEvent(params.eventId)
@@ -81,20 +81,14 @@ router
       res.status(500).send({ error: e.message })
     }
   })
-  .put(checkSchema({ eventId: eventIdParamSchema }), async (req, res) => {
-    const errors = await validateBotonicEventData(req)
+  .put(async (req, res) => {
+    const errors = await validateBotonicEventData(req, false, true)
     if (!errors.isEmpty()) {
       res.status(400).send({ errors: errors.array({ onlyFirstError: true }) })
       return
     }
 
     try {
-      const errors = validationResult(req)
-      if (!errors.isEmpty()) {
-        res.status(400).send({ errors: errors.array() })
-        return
-      }
-
       const params = matchedData(req, { locations: ['params'] })
       const updatedEvent = matchedData(req, {
         locations: ['body'],
@@ -114,20 +108,14 @@ router
       res.status(500).send({ error: e.message })
     }
   })
-  .patch(checkSchema({ eventId: eventIdParamSchema }), async (req, res) => {
-    const errors = await validateBotonicEventData(req, true)
+  .patch(async (req, res) => {
+    const errors = await validateBotonicEventData(req, true, true)
     if (!errors.isEmpty()) {
       res.status(400).send({ errors: errors.array({ onlyFirstError: true }) })
       return
     }
 
     try {
-      const errors = validationResult(req)
-      if (!errors.isEmpty()) {
-        res.status(400).send({ errors: errors.array() })
-        return
-      }
-
       const params = matchedData(req, { locations: ['params'] })
       const newEventData = matchedData(req, {
         locations: ['body'],

--- a/packages/botonic-api/src/rest/routes/users.ts
+++ b/packages/botonic-api/src/rest/routes/users.ts
@@ -107,12 +107,8 @@ router
           .send({ error: `User with ID '${params.userId}' not found` })
         return
       }
-      if (user.id !== updatedUser.id) {
-        res
-          .status(400)
-          .send({ error: `Both user ID (params and body) must match` })
-        return
-      }
+
+      updatedUser.id = user.id
       await dp.updateUser(updatedUser)
       res.status(200).send(updatedUser)
     } catch (e) {
@@ -142,12 +138,8 @@ router
             .send({ error: `User with ID '${params.userId}' not found` })
           return
         }
-        if (newUserData.id && user.id !== newUserData.id) {
-          res
-            .status(400)
-            .send({ error: `Both user ID (params and body) must match` })
-          return
-        }
+
+        newUserData.id = user.id
         const updatedUser = { ...user, ...newUserData }
         await dp.updateUser(updatedUser)
         res.status(200).send(updatedUser)

--- a/packages/botonic-api/src/rest/routes/validation/common.ts
+++ b/packages/botonic-api/src/rest/routes/validation/common.ts
@@ -1,4 +1,4 @@
-import { ParamSchema } from 'express-validator'
+import { ParamSchema, Schema } from 'express-validator'
 
 export const inQuery: ParamSchema = { in: ['query'] }
 export const inParams: ParamSchema = { in: ['params'] }
@@ -36,3 +36,14 @@ export const limitParamSchema: ParamSchema = {
   ...toInt,
 }
 export const offsetParamSchema = limitParamSchema
+
+export function getOptionalSchema(schema: Schema): Schema {
+  for (const field of Object.keys(schema)) {
+    const validations = schema[field]
+    delete validations.notEmpty
+    if (!('optional' in validations)) {
+      schema[field] = { ...validations, ...isOptional }
+    }
+  }
+  return schema
+}

--- a/packages/botonic-api/src/rest/routes/validation/common.ts
+++ b/packages/botonic-api/src/rest/routes/validation/common.ts
@@ -1,0 +1,38 @@
+import { ParamSchema } from 'express-validator'
+
+export const inQuery: ParamSchema = { in: ['query'] }
+export const inParams: ParamSchema = { in: ['params'] }
+export const inBody: ParamSchema = { in: ['body'] }
+export const isRequired: ParamSchema = { notEmpty: true }
+export const isOptional: ParamSchema = {
+  optional: { options: { nullable: true } },
+}
+export const isNaturalNumber: ParamSchema = {
+  isNumeric: { options: { no_symbols: true } },
+}
+export const isNumeric: ParamSchema = { isNumeric: true }
+export const isBoolean: ParamSchema = { isBoolean: true }
+export const isDateTime: ParamSchema = {
+  isISO8601: { options: { strict: true, strictSeparator: true } },
+}
+export const isIn = (valueList: string[]): ParamSchema => {
+  return {
+    isIn: { options: [valueList] },
+    errorMessage: `Invalid value. Allowed values: ${valueList}`,
+  }
+}
+export const equals = (text: string): ParamSchema => {
+  return {
+    equals: { options: [text] },
+    errorMessage: `Invalid value. Value should be '${text}'`,
+  }
+}
+export const toInt: ParamSchema = { toInt: true }
+
+export const limitParamSchema: ParamSchema = {
+  ...inQuery,
+  ...isOptional,
+  ...isNaturalNumber,
+  ...toInt,
+}
+export const offsetParamSchema = limitParamSchema

--- a/packages/botonic-api/src/rest/routes/validation/events.ts
+++ b/packages/botonic-api/src/rest/routes/validation/events.ts
@@ -163,24 +163,24 @@ export const botonicEventValidationChains = [
   checkSchema(connectionEventSchema),
 ]
 
-export async function validateBotonicEventData(
-  req: Request,
+export async function validateBotonicEventData({
+  request,
   allFieldsOptional = false,
-  withParamEventId = false
-): Promise<Result> {
+  withParamEventId = false,
+}): Promise<Result> {
   const opt = allFieldsOptional
   const e = withParamEventId
-  await checkSchema(getSchema(baseEventSchema, opt, e)).run(req)
-  const errors = validationResult(req)
+  await checkSchema(getSchema(baseEventSchema, opt, e)).run(request)
+  const errors = validationResult(request)
   if (!errors.isEmpty()) {
     return errors
   }
 
   let schema
-  if (req.body.eventType === EventTypes.CONNECTION) {
+  if (request.body.eventType === EventTypes.CONNECTION) {
     schema = getSchema(connectionEventSchema, opt, e)
   } else {
-    switch (req.body.type) {
+    switch (request.body.type) {
       case MessageEventTypes.TEXT:
         schema = getSchema(textMessageEventSchema, opt, e)
         break
@@ -213,8 +213,8 @@ export async function validateBotonicEventData(
         break
     }
   }
-  await checkSchema(schema).run(req)
-  return validationResult(req)
+  await checkSchema(schema).run(request)
+  return validationResult(request)
 }
 
 export async function validateEventType(req: Request): Promise<Result> {
@@ -237,7 +237,7 @@ function getSchema(
   withParamEventId = false
 ): Schema {
   if (withParamEventId) {
-    schema = { eventId: eventIdParamSchema, ...schema }
+    schema = { ...schema, eventId: eventIdParamSchema }
   }
   if (allFieldsOptional) {
     schema = getOptionalSchema(schema)

--- a/packages/botonic-api/src/rest/routes/validation/events.ts
+++ b/packages/botonic-api/src/rest/routes/validation/events.ts
@@ -14,42 +14,20 @@ import {
   Schema,
   validationResult,
 } from 'express-validator'
-import { ValidatorsSchema } from 'express-validator/src/middlewares/schema'
 
-const inQuery: ParamSchema = { in: ['query'] }
-const inParams: ParamSchema = { in: ['params'] }
-const inBody: ParamSchema = { in: ['body'] }
-const isRequired: ValidatorsSchema = { notEmpty: true }
-const isOptional: ParamSchema = { optional: { options: { nullable: true } } }
-const isNaturalNumber: ParamSchema = {
-  isNumeric: { options: { no_symbols: true } },
-}
-const isNumeric: ParamSchema = { isNumeric: true }
-const isBoolean: ParamSchema = { isBoolean: true }
-const isDateTime: ParamSchema = {
-  isISO8601: { options: { strict: true, strictSeparator: true } },
-}
-const isIn = (valueList: string[]): ParamSchema => {
-  return {
-    isIn: { options: [valueList] },
-    errorMessage: `Invalid value. Allowed values: ${valueList}`,
-  }
-}
-const equals = (text: string): ParamSchema => {
-  return {
-    equals: { options: [text] },
-    errorMessage: `Invalid value. Value should be '${text}'`,
-  }
-}
-const toInt: ParamSchema = { toInt: true }
-
-export const limitParamSchema: ParamSchema = {
-  ...inQuery,
-  ...isOptional,
-  ...isNaturalNumber,
-  ...toInt,
-}
-export const offsetParamSchema = limitParamSchema
+import {
+  equals,
+  inBody,
+  inParams,
+  isBoolean,
+  isDateTime,
+  isIn,
+  isNaturalNumber,
+  isNumeric,
+  isOptional,
+  isRequired,
+  toInt,
+} from './common'
 
 export const eventIdParamSchema: ParamSchema = { ...inParams, ...isRequired }
 

--- a/packages/botonic-api/src/rest/routes/validation/events.ts
+++ b/packages/botonic-api/src/rest/routes/validation/events.ts
@@ -17,6 +17,7 @@ import {
 
 import {
   equals,
+  getOptionalSchema,
   inBody,
   inParams,
   isBoolean,
@@ -238,15 +239,8 @@ function getSchema(
   if (withParamEventId) {
     schema = { eventId: eventIdParamSchema, ...schema }
   }
-  if (!allFieldsOptional) {
-    return schema
-  }
-  for (const field of Object.keys(schema)) {
-    const validations = schema[field]
-    delete validations.notEmpty
-    if (!('optional' in validations)) {
-      schema[field] = { ...validations, ...isOptional }
-    }
+  if (allFieldsOptional) {
+    schema = getOptionalSchema(schema)
   }
   return schema
 }

--- a/packages/botonic-api/src/rest/routes/validation/users.ts
+++ b/packages/botonic-api/src/rest/routes/validation/users.ts
@@ -25,4 +25,5 @@ export const userSchema: Schema = {
 export const userWithUserIdParamSchema: Schema = {
   userId: userIdParamSchema,
   ...userSchema,
+  id: { ...inBody, ...isOptional },
 }

--- a/packages/botonic-api/src/rest/routes/validation/users.ts
+++ b/packages/botonic-api/src/rest/routes/validation/users.ts
@@ -1,0 +1,28 @@
+import { ParamSchema, Schema } from 'express-validator'
+
+import {
+  inBody,
+  inParams,
+  isBoolean,
+  isDateTime,
+  isOptional,
+  isRequired,
+} from './common'
+
+export const userIdParamSchema: ParamSchema = { ...inParams, ...isRequired }
+
+export const userSchema: Schema = {
+  id: { ...inBody, ...isRequired },
+  websocketId: { ...inBody, ...isOptional },
+  providerId: { ...inBody, ...isOptional },
+  //TODO: determine session schema
+  session: { ...inBody, ...isRequired },
+  route: { ...inBody, ...isRequired },
+  isOnline: { ...inBody, ...isRequired, ...isBoolean },
+  locationInfo: { ...inBody, ...isOptional },
+}
+
+export const userWithUserIdParamSchema: Schema = {
+  userId: userIdParamSchema,
+  ...userSchema,
+}


### PR DESCRIPTION
## Description
- Implementation of users routes for CRUD operations. No authentication is done so far.
- Added validations to the parameters received in the requests using `express-validator`.
- Added missing method `deleteUser` in the `DataProvider` interface and its implementations.
- Add validation in patch and put routes to ensure the ID received in the param is the same as the one received in the body.
- Refactor validations to unify common validations for events and users endpoints.

## Context
The api endpoint of users were not implemented yet.

## Approach taken / Explain the design
The same way it has been done with events endpoint, all the data validation has been done based on the user type declaration.
For the `patch` request, in order to take advantage of all the validantions done, a method has been implemented to transform all fields to optional fields but still keep all the other validations.

## To document / Usage example

## Testing

The pull request has no tests.
