### PR TITLE
chore(contentful): downgrade escape-string-regexp to version 4.0.0

### DIFF
--- a/packages/botonic-plugin-contentful/jest.config.js
+++ b/packages/botonic-plugin-contentful/jest.config.js
@@ -14,9 +14,7 @@ module.exports = {
   testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.(ts|tsx)$',
   testPathIgnorePatterns: ['lib', '.*.d.ts', 'tests/helpers', '.*.helper.ts'],
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
-  transformIgnorePatterns: [
-    'node_modules/(?!@botonic|escape-string-regexp).+\\.(js|jsx)$',
-  ],
+  transformIgnorePatterns: ['node_modules/(?!@botonic).+\\.(js|jsx)$'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   snapshotSerializers: [],
   setupFilesAfterEnv: [

--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -409,12 +409,6 @@
       "integrity": "sha512-qJezGqoi3pW9Pset2w1Gfv8jATvmHHHnpO9Dq8x8pJGyYIpiUZJqRU0NM7xenmN0AcXEe7vqshI8H98KeFLYcg==",
       "dev": true
     },
-    "@types/node": {
-      "version": "16.4.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
-      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg==",
-      "dev": true
-    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -2423,9 +2417,9 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "esprima": {
       "version": "4.0.1",

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -59,7 +59,7 @@
     "contentful-management": "^7.24.0",
     "csv-parse": "^4.16.0",
     "csv-stringify": "^5.6.2",
-    "escape-string-regexp": "^5.0.0",
+    "escape-string-regexp": "^4.0.0",
     "marked": "^2.1.1",
     "memoizee": "^0.4.15",
     "moment": "^2.29.1",


### PR DESCRIPTION
## Description
Downgrade `escape-string-regexp` package to version `4.0.0` to avoid various execution and compiling problems (see [this issue](https://github.com/sindresorhus/escape-string-regexp/issues/34)).

## Context
The version `5.0.0` of this package [breaks compatibility](https://github.com/sindresorhus/escape-string-regexp/releases/tag/v5.0.0) with the previous version because now is a pure ESM. 

With version `5.0.0` of `escape-string-regexp`, to be able to execute Contentful plugin's code in jest or through webpack there's a need to transpile it and it can't be executed through ts-node because it throws an error.

## Approach taken / Explain the design


## To document / Usage example

## Testing

The pull request has no tests.