### PR TITLE
feat(api): add proper pagination to endpoints

### DIFF
--- a/packages/botonic-api/src/rest/routes/validation/common.ts
+++ b/packages/botonic-api/src/rest/routes/validation/common.ts
@@ -29,13 +29,13 @@ export const equals = (text: string): ParamSchema => {
 }
 export const toInt: ParamSchema = { toInt: true }
 
-export const limitParamSchema: ParamSchema = {
+export const pageParamSchema: ParamSchema = {
   ...inQuery,
   ...isOptional,
   ...isNaturalNumber,
   ...toInt,
 }
-export const offsetParamSchema = limitParamSchema
+export const pageSizeParamSchema = pageParamSchema
 
 export function getOptionalSchema(schema: Schema): Schema {
   for (const field of Object.keys(schema)) {

--- a/packages/botonic-api/src/rest/utils/paginator.ts
+++ b/packages/botonic-api/src/rest/utils/paginator.ts
@@ -50,6 +50,7 @@ export class Paginator {
     return {
       previous: this.page > FIRST_PAGE ? this.previousUrl : undefined,
       next: items.length === this.pageSize ? this.nextUrl : undefined,
+      //TODO: count should be the total amount of items, not only the number of items of the actual page
       count: items.length,
       results: items,
     }

--- a/packages/botonic-api/src/rest/utils/paginator.ts
+++ b/packages/botonic-api/src/rest/utils/paginator.ts
@@ -1,0 +1,59 @@
+import { Request } from 'express'
+
+export const FIRST_PAGE = 1
+export const DEFAULT_PAGE_SIZE = 10
+export const MAX_PAGE_SIZE = 100
+
+type JsonResponse<T> = {
+  previous?: string
+  next?: string
+  count: number
+  results: T[]
+}
+
+export class Paginator {
+  private readonly baseUrl: string
+  private readonly page: number
+  private readonly pageSize: number
+
+  constructor(
+    request: Request,
+    page = FIRST_PAGE,
+    pageSize = DEFAULT_PAGE_SIZE
+  ) {
+    this.baseUrl = this.getBaseUrl(request)
+    this.page = page < FIRST_PAGE ? FIRST_PAGE : page
+    this.pageSize = pageSize > MAX_PAGE_SIZE ? MAX_PAGE_SIZE : pageSize
+  }
+
+  get limit(): number {
+    return this.pageSize
+  }
+
+  get offset(): number {
+    return (this.page - 1) * this.pageSize
+  }
+
+  get previousUrl(): string {
+    const previousPage = this.page - 1
+    return `${this.baseUrl}/?page=${previousPage}&pageSize=${this.pageSize}`
+  }
+
+  get nextUrl(): string {
+    const nextPage = this.page + 1
+    return `${this.baseUrl}/?page=${nextPage}&pageSize=${this.pageSize}`
+  }
+
+  generateResponse<T>(items: T[]): JsonResponse<T> {
+    return {
+      previous: this.page > FIRST_PAGE ? this.previousUrl : undefined,
+      next: items.length === this.pageSize ? this.nextUrl : undefined,
+      count: items.length,
+      results: items,
+    }
+  }
+
+  private getBaseUrl(request: Request): string {
+    return `${request.protocol}://${request.get('host')}${request.baseUrl}`
+  }
+}

--- a/packages/botonic-api/src/rest/utils/paginator.ts
+++ b/packages/botonic-api/src/rest/utils/paginator.ts
@@ -3,6 +3,7 @@ import { Request } from 'express'
 export const FIRST_PAGE = 1
 export const DEFAULT_PAGE_SIZE = 10
 export const MAX_PAGE_SIZE = 100
+export const MIN_PAGE_SIZE = 1
 
 type JsonResponse<T> = {
   previous?: string
@@ -23,7 +24,8 @@ export class Paginator {
   ) {
     this.baseUrl = this.getBaseUrl(request)
     this.page = page < FIRST_PAGE ? FIRST_PAGE : page
-    this.pageSize = pageSize > MAX_PAGE_SIZE ? MAX_PAGE_SIZE : pageSize
+    pageSize = pageSize > MAX_PAGE_SIZE ? MAX_PAGE_SIZE : pageSize
+    this.pageSize = pageSize < MIN_PAGE_SIZE ? DEFAULT_PAGE_SIZE : pageSize
   }
 
   get limit(): number {


### PR DESCRIPTION
## Description
Add proper pagination to GET method in `/users` and `/events` endpoints:
- Refactor pagination params: use `page/pageSize` instead of `limit/offset`.
- Return a paginated response using an object like this one:
```
{
  "previous": "<link to previous page>",
  "next": "<link to next page>",
  "count": <total number of records>,
  "results": [{...record1}, {...record2}, ...]
}
```

## Context
`/users` and `/events` endpoints had pagination but were not returning a proper paginated response.

## Approach taken / Explain the design
Create a `Paginator` class that handles all the pagination logic.

## To document / Usage example

## Testing

The pull request has no tests.
