### PR TITLE
feat(pulumi): cache invalidations for updated static assets

### DIFF
--- a/packages/botonic-pulumi/jest.config.js
+++ b/packages/botonic-pulumi/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testTimeout: 1000000,
+  roots: ['<rootDir>'],
+  testMatch: [
+    '**/tests/**/*.+(ts|tsx|js)',
+    '**/+(*.)+(spec|test).+(ts|tsx|js)',
+  ],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
+  testPathIgnorePatterns: [
+    'lib',
+    '.*.d.ts',
+    'tests/helpers',
+    '.*.helper.js',
+    'tests/__mocks__',
+  ],
+}

--- a/packages/botonic-pulumi/package-lock.json
+++ b/packages/botonic-pulumi/package-lock.json
@@ -4,6 +4,998 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.1.tgz",
+      "integrity": "sha512-nS4vdan97It6HcweV58WXtjPbPSc0JXd3sAwlw3Ou5Mc3WllSycAS32Tv2LRn8butNQoU9AE3jEQAOgiMdNC1Q==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.23.0.tgz",
+      "integrity": "sha512-M69Sdoi6TH2UrnXKKNJNDaW6iCqpras7w274CZq4NjFOGwrb23KO2Aexgxr3g3hsUidfjuA38oFbHgC8odFrIQ==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/client-cloudfront": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.24.0.tgz",
+      "integrity": "sha512-q8D6uZmwab1bLuBKkohXAAnkMJf97hLjxT1GY1MScMqj96wvVRiqkpyYttSukSbqMDoq16neCtu6SwkLO8FBoA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.24.0",
+        "@aws-sdk/config-resolver": "3.23.0",
+        "@aws-sdk/credential-provider-node": "3.24.0",
+        "@aws-sdk/fetch-http-handler": "3.23.0",
+        "@aws-sdk/hash-node": "3.23.0",
+        "@aws-sdk/invalid-dependency": "3.23.0",
+        "@aws-sdk/middleware-content-length": "3.23.0",
+        "@aws-sdk/middleware-host-header": "3.23.0",
+        "@aws-sdk/middleware-logger": "3.23.0",
+        "@aws-sdk/middleware-retry": "3.23.0",
+        "@aws-sdk/middleware-serde": "3.23.0",
+        "@aws-sdk/middleware-signing": "3.23.0",
+        "@aws-sdk/middleware-stack": "3.23.0",
+        "@aws-sdk/middleware-user-agent": "3.23.0",
+        "@aws-sdk/node-config-provider": "3.23.0",
+        "@aws-sdk/node-http-handler": "3.23.0",
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/smithy-client": "3.24.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.23.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.23.0",
+        "@aws-sdk/util-user-agent-node": "3.23.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "@aws-sdk/util-waiter": "3.23.0",
+        "@aws-sdk/xml-builder": "3.23.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.24.0.tgz",
+      "integrity": "sha512-gee+zjIUiDayRhDsUakB/9h1crH419pgDWdZ91s/jXkOVXlCRoVaArmYPUBBWkVvGMoSvM6BVvojf2cWViA5FA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.23.0",
+        "@aws-sdk/fetch-http-handler": "3.23.0",
+        "@aws-sdk/hash-node": "3.23.0",
+        "@aws-sdk/invalid-dependency": "3.23.0",
+        "@aws-sdk/middleware-content-length": "3.23.0",
+        "@aws-sdk/middleware-host-header": "3.23.0",
+        "@aws-sdk/middleware-logger": "3.23.0",
+        "@aws-sdk/middleware-retry": "3.23.0",
+        "@aws-sdk/middleware-serde": "3.23.0",
+        "@aws-sdk/middleware-stack": "3.23.0",
+        "@aws-sdk/middleware-user-agent": "3.23.0",
+        "@aws-sdk/node-config-provider": "3.23.0",
+        "@aws-sdk/node-http-handler": "3.23.0",
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/smithy-client": "3.24.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.23.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.23.0",
+        "@aws-sdk/util-user-agent-node": "3.23.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.24.0.tgz",
+      "integrity": "sha512-GifVktvnDQlEJfspoERAFhS+vm7b0OmK3ACN/a6/wFc3hXEGIcS/WRzfRERXJfYg8Ial4Sr8bxDXMW30jPk3fQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.23.0",
+        "@aws-sdk/credential-provider-node": "3.24.0",
+        "@aws-sdk/fetch-http-handler": "3.23.0",
+        "@aws-sdk/hash-node": "3.23.0",
+        "@aws-sdk/invalid-dependency": "3.23.0",
+        "@aws-sdk/middleware-content-length": "3.23.0",
+        "@aws-sdk/middleware-host-header": "3.23.0",
+        "@aws-sdk/middleware-logger": "3.23.0",
+        "@aws-sdk/middleware-retry": "3.23.0",
+        "@aws-sdk/middleware-sdk-sts": "3.23.0",
+        "@aws-sdk/middleware-serde": "3.23.0",
+        "@aws-sdk/middleware-signing": "3.23.0",
+        "@aws-sdk/middleware-stack": "3.23.0",
+        "@aws-sdk/middleware-user-agent": "3.23.0",
+        "@aws-sdk/node-config-provider": "3.23.0",
+        "@aws-sdk/node-http-handler": "3.23.0",
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/smithy-client": "3.24.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/url-parser": "3.23.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-node": "3.23.0",
+        "@aws-sdk/util-body-length-browser": "3.23.0",
+        "@aws-sdk/util-body-length-node": "3.23.0",
+        "@aws-sdk/util-user-agent-browser": "3.23.0",
+        "@aws-sdk/util-user-agent-node": "3.23.0",
+        "@aws-sdk/util-utf8-browser": "3.23.0",
+        "@aws-sdk/util-utf8-node": "3.23.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.23.0.tgz",
+      "integrity": "sha512-acCxrAymwx81XELBO/d1VBWaHOldxqbmxDAMfvOfUYN+CYXWIFYpY1VCWuAeWig7Dy18QEJQ2pHwQlFxmilA7w==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.23.0.tgz",
+      "integrity": "sha512-ljYkVATha4BdecVvYeW1WuzoAAwfM/i7p9Wmx1RY3Rb0AGwIFX2GjtoBPhS3EbCRTzQIhUr4zfIelVVVxIS6bA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.23.0.tgz",
+      "integrity": "sha512-jD1EkoVDApKZJwOLACTrnxhDmQiVF1qMM+GMnoY4bMk1p1sfZYNKs6VkaY2LGUWXxkesj1aiMFxbwyWmu8SQbQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.24.0.tgz",
+      "integrity": "sha512-EwXEo0MqOjF28lIk1S2wo0HwIioUDC1LbFukd7mo3lIG47yS7Qllw7HIyhLzO5ayI5AouKP9nnLElgHVz81seg==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.23.0",
+        "@aws-sdk/credential-provider-imds": "3.23.0",
+        "@aws-sdk/credential-provider-sso": "3.24.0",
+        "@aws-sdk/credential-provider-web-identity": "3.23.0",
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.24.0.tgz",
+      "integrity": "sha512-sQQDciLXYErBEIkphBlvIRh0shZe9iK6KqtpT5Sueu6ADEOIQlgF7Kw5/N9BhPQ8pYORibCH0eIabPD+u3hr9w==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.23.0",
+        "@aws-sdk/credential-provider-imds": "3.23.0",
+        "@aws-sdk/credential-provider-ini": "3.24.0",
+        "@aws-sdk/credential-provider-process": "3.23.0",
+        "@aws-sdk/credential-provider-sso": "3.24.0",
+        "@aws-sdk/credential-provider-web-identity": "3.23.0",
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.23.0.tgz",
+      "integrity": "sha512-xba0u86nS5MtH3FQKSbTOEaoHjqpoj6NyonZEy0O5i9KO0NHf+bZwlmI/pe54SOE9uSrDKHfXB6dsftVIqXtFQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.24.0.tgz",
+      "integrity": "sha512-HZomNXn1kw/5M1AHFY7Rcnayl/7tXKG+67m7W3V9+G9+xzEjW5229y8VeZkoNUhVHh5rwvqd3fKKHx1g9sZsUA==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.24.0",
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-credentials": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.23.0.tgz",
+      "integrity": "sha512-GbDw2izWfb4KG62V6MBTOKmDAhbexbemxJsR0rMlZxW/dEYQh/r8Nk+m7evAUakNMJGm4fcAZGxey+orReq1VQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.23.0.tgz",
+      "integrity": "sha512-gjToPkLlVOO8bHKhyw+d4mIX4OJEabqIFYbRFRDSm11LVLAAEc4pIFPYpMNWzrmDEnCxoGAcqfzP0m+0jChVCw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/querystring-builder": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-base64-browser": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.23.0.tgz",
+      "integrity": "sha512-yah+vNhKv6jpJR5qHYGc/AIAWwR9Ah9NplAq8cltMsPuI38u/aSlbcEIDwsRz3V1MDA89f/+qY3OHBfQw5kLVw==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-buffer-from": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.23.0.tgz",
+      "integrity": "sha512-5VqL7crIEtXj+lBwh3kKdMMlejjumjJQ5uLYNSCE/jNS5YjnbhAfO+fyzMO50IhcSuG4Ev6i1DEezN9BmYdeXA==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.23.0.tgz",
+      "integrity": "sha512-XN20/scFthok0lCbjtinW77CoIBoar8cbOzmu+HkYTnBBpJrF6Ai5g9sgglO8r+X+OLn4PrDrTP+BxdpNuIh9g==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.23.0.tgz",
+      "integrity": "sha512-ooyNeXZUtI16Qh/HfcwLWn7NB2HvM/XEajaQmVIJXbVy/D2+N82+0Jo2hY3DouuIJjoEv/KZ5Uia/cgCdfHrHQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.23.0.tgz",
+      "integrity": "sha512-bHqQbwY3guUr+AWcrerHIh1ONgqhV8W85+H7MYlt0V5/Kom0+ectR7yZZRt90PDMZ8OsW4+f5jTIURFMLtPbDA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.23.0.tgz",
+      "integrity": "sha512-0z0ULcxllHO6xz1VeX/ekmg/LpNFL8nFbRH067s2KaimBeCUZ0CA2RwTpi9IY74tikmZAjerASb8eMgI+L/d7A==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.23.0.tgz",
+      "integrity": "sha512-NimiKrP90+aW62QmkOrhQAZjrwjOQuWye2POzdetSrBHpnwj2KQWNBjcRwjkGt53krPcDyCySjIw+ivTRYdxWw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/service-error-classification": "3.22.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.23.0.tgz",
+      "integrity": "sha512-Rufzuqp4neVsyll9Ya9j+zpoK1fXrujBX6XRR5fRU3SsoAh5YWiUMrkxYxzTN+TLeXmyhCzmH/RuX2hgjMK0VQ==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.23.0",
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/signature-v4": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.23.0.tgz",
+      "integrity": "sha512-gNNMOo6Phm/BAnLsXvFfu4PHxKzN1saT3lNkODY2qKB1b4IoFNdMfHMo3jH4sbx7QYoM81qMXKr7aLp1BzTHtw==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.23.0.tgz",
+      "integrity": "sha512-cTozWnc8HLxLjHYU10+uqE4RqXYmmCJqoEKiSzJH7f8n20Pr9ly3rv3/9AfbqPth1PXsg0xHYq/ovCvq6RiaYA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/signature-v4": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.23.0.tgz",
+      "integrity": "sha512-lk4u8wDajJ+VBXVWpzqaRUUJibt1YxsIciwLeZymilAZW5L9VtchUW9fmRpaZX8QHFGGkGuwZjtxlX6MeGXK4w==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.23.0.tgz",
+      "integrity": "sha512-cwOypi0no2Nsrw1N3VGe/0XgbNl487Wn4jgKZvj+nxdSWh4HQMWpoTLB3YZtzro+J7uVK6X7W+QxBU20+Ypg1g==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.23.0.tgz",
+      "integrity": "sha512-OyhyqTXUy5HxPu2c1aCYFHKQGjf4uzjby9AteMhRJfa6cehuVODi3KEv7PyZmJQcYI0Pw9ZnoHqVrTNsUEC2YQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.23.0",
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.23.0.tgz",
+      "integrity": "sha512-amvf0lwldUrr+CFtIeMZoNVmv34Fx3zwqobT5WuxtfRWbvSRALMw0LW/oXwoT+4WayM6sIwcIwSG1ZVGCjD0fA==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.23.0",
+        "@aws-sdk/protocol-http": "3.23.0",
+        "@aws-sdk/querystring-builder": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.23.0.tgz",
+      "integrity": "sha512-GjFtmFHVzO4BeLRselGirt32cyorP1aRbD+ID4Zhz4RLxa9Nun766s8lqp7EcR/v9pSGdP1Xec3no8ALV3lXmw==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.23.0.tgz",
+      "integrity": "sha512-JTsq/UU/wTyeCMPVar2xSsMVFf72IK0L7dXbbS7ZHcBV6JAfM/wVTym8/s3mQGM6Kx/c6Wtn+J/5syDx56CV2g==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.23.0.tgz",
+      "integrity": "sha512-MfQknhgMT9tul0VrxmLBDKlV7Ls2/kEJyprWXUWzCUBMUZ6M+FtOMJhjP90qTbsNvlsEVQgTlS/cDsNVrAUR3A==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-uri-escape": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.23.0.tgz",
+      "integrity": "sha512-pMEN+rE08QhixRfWEBuQwnOGuGiRjH5++mmyQTUIvEgKk/rnyAkUlrySv775jvrEQlCXH8yqMuHdutF8rHkHGA==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.22.0.tgz",
+      "integrity": "sha512-6ytFFoU8guAljwpmQTvZNf//cTurdumeLlAmQ8RJsbX3y5DGlpG2dfq7mpYJudtJtCQTwPYtaG5Xva460T2CqA=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.23.0.tgz",
+      "integrity": "sha512-YUp46l6E3dLKHp1cKMkZI4slTjsVc/Lm7nPCTVc3oQvZ1MvC99N/jMCmZ7X5YYofuAUSdc9eJ8sYiF2BnUww9g==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.23.0.tgz",
+      "integrity": "sha512-3smgG/6LcK8SjVqWzroAgSFOF8HKp4/LtOQQBtPkI04nTMVP4zmE5hsVQEZv33h5UKWkUpwQRBTCtfFZTq/Jvw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "@aws-sdk/util-hex-encoding": "3.23.0",
+        "@aws-sdk/util-uri-escape": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.24.0.tgz",
+      "integrity": "sha512-HFoRcO8eqnaN5+r5dPqP3t8ks0gBDhn0ClzTN8BloFwVVc0Wu7N1yZYp/NxLviwqC9X+R+ZbAJn+zjac24zgdw==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-dGJBPbWm+YT+D5YIiqK3Z1xWzWShWgSxL1gPS9+vKNY2ld2TvtoiRhFy8NQG2jnC+eG/+WNeZS6ZxzLvEbQyTQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.23.0.tgz",
+      "integrity": "sha512-uU4BDX0eilGlMuz8qDlNzcH3k4WTZWgMnBuJ9+TdxTXNiLvC+X9HBjVmB2Nr+3mEJhhrRc/8mTrleJvcl60Pyg==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.23.0.tgz",
+      "integrity": "sha512-xlI/qw+uhLJWa3k0mRtRHQ42v5QzsMFEUXScredQMfJ/34qzXyocsG6OHPOTV1I8WSANrxnHR5m1Ae3iU6JuVw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.23.0.tgz",
+      "integrity": "sha512-Kf8JIAUtjrPcD5CJzrig2B5CtegWswUNpW4zBarww/UJhHlp8WzKlCxxA+yNS1ghT0ZMjrRvxPabKDGpkyUfmQ==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.23.0.tgz",
+      "integrity": "sha512-Bi6u/5omQbOBSB5BxqVvaPgVplLRjhhSuqK3XAukbeBPh7lcibIBdy7YvbhQyl4i8Hb2QjFnqqfzA0lNBe5eiw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.23.0.tgz",
+      "integrity": "sha512-8kSczloA78mikPaJ742SU9Wpwfcz3HOruoXiP/pOy69UZEsMe4P7zTZI1bo8BAp7j6IFUPCXth9E3UAtkbz+CQ==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.23.0.tgz",
+      "integrity": "sha512-axXy1FvEOM1uECgMPmyHF1S3Hd7JI+BerhhcAlGig0bbqUsZVQUNL9yhOsWreA+nf1v08Ucj8P2SHPCT9Hvpgg==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-credentials": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.23.0.tgz",
+      "integrity": "sha512-6TDGZnFa0kZr+vSsWXXMfWt347jbMGKtzGnBxbrmiQgZMijz9s/wLYxsjglZ+CyqI/QrSMOTtqy6mEgJxdnGWQ==",
+      "requires": {
+        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.23.0.tgz",
+      "integrity": "sha512-RFDCwNrJMmmPSMVRadxRNePqTXGwtL9s4844x44D0bbGg1TdC42rrg0PRKYkxFL7wd1FbibVQOzciZAvzF+Z+w==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.23.0.tgz",
+      "integrity": "sha512-mM8kWW7SWIxCshkNllpYqCQi5SzwJ+sv5nURhtquOB5/H3qGqZm0V5lUE3qpE1AYmqKwk6qbGUy1woFn1T5nrw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.23.0.tgz",
+      "integrity": "sha512-SvQx2E/FDlI5vLT67wwn/k1j2R/G58tYj4Te6GNgEwPGL43X2+7c0+d/WTgndMaRvxSBHZMUTxBYh1HOeU7loA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.23.0.tgz",
+      "integrity": "sha512-FIjcCdvnUuOBMQgvPZ04Hk28Qy+xJDrtXeWm/7xKJ1K7NRucJWjmC+0OU0uw9A7VOCHf08nk9xniZhAGXs1wJg==",
+      "requires": {
+        "@aws-sdk/types": "3.22.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.23.0.tgz",
+      "integrity": "sha512-6okok4u13uYRIYdgFZ4dCsowf5vKh+ZxkfVSwvnZO3XAaGEhmIkM3+JKIQjcxLJ+Mt0ssMSJwNMz5oOBSlXPeQ==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
+      "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.23.0.tgz",
+      "integrity": "sha512-yao8+8okyfCxRvxZe3GBdO7lJnQEBf3P6rDgleOQD/0DZmMjOQGXCvDd42oagE2TegXhkUnJfVOZU2GqdoR0hg==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.23.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.23.0.tgz",
+      "integrity": "sha512-TtCw6OoSrgXLbi1mBn/eicaa3RcJLVm4RdiV1lBQxSX22wyriFP+b1BXRkS9G49rBMciwWu/Xpg8E0Pi79pOnQ==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.23.0",
+        "@aws-sdk/types": "3.22.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.23.0.tgz",
+      "integrity": "sha512-5LEGdhQIJtGTwg4dIYyNtpz5QvPcQoxsqJygmj+VB8KLd+mWorH1IOpiL74z0infeK9N+ZFUUPKIzPJa9xLPqw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -393,6 +1385,11 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -769,6 +1766,11 @@
         "once": "^1.4.0"
       }
     },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -846,6 +1848,11 @@
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
       }
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "fd-slicer": {
       "version": "1.1.0",

--- a/packages/botonic-pulumi/package.json
+++ b/packages/botonic-pulumi/package.json
@@ -4,11 +4,11 @@
   "scripts": {
     "build": "rm -rf lib && ../../node_modules/.bin/tsc",
     "build:watch": "rm -rf lib && ../../node_modules/.bin/tsc -w",
-    "lint": "npm run lint_core -- --fix",
-    "lint_ci": "npm run lint_core -- -c ../.eslintrc_slow.js",
-    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'",
+    "lint": "npm run lint-core -- --fix",
+    "lint-ci": "npm run lint-core -- -c ../.eslintrc_slow.js",
+    "lint-core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'",
     "test": "../../node_modules/.bin/jest --coverage",
-    "test_ci": "../../node_modules/.bin/jest --coverage --ci --reporters=default --reporters=jest-junit"
+    "test-ci": "../../node_modules/.bin/jest --coverage --ci --reporters=default --reporters=jest-junit"
   },
   "devDependencies": {
     "@types/concurrently": "^6.2.0",

--- a/packages/botonic-pulumi/package.json
+++ b/packages/botonic-pulumi/package.json
@@ -3,7 +3,12 @@
   "version": "1.0.0-alpha.2",
   "scripts": {
     "build": "rm -rf lib && ../../node_modules/.bin/tsc",
-    "build:watch": "rm -rf lib && ../../node_modules/.bin/tsc -w"
+    "build:watch": "rm -rf lib && ../../node_modules/.bin/tsc -w",
+    "lint": "npm run lint_core -- --fix",
+    "lint_ci": "npm run lint_core -- -c ../.eslintrc_slow.js",
+    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'",
+    "test": "../../node_modules/.bin/jest --coverage",
+    "test_ci": "../../node_modules/.bin/jest --coverage --ci --reporters=default --reporters=jest-junit"
   },
   "devDependencies": {
     "@types/concurrently": "^6.2.0",

--- a/packages/botonic-pulumi/package.json
+++ b/packages/botonic-pulumi/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudfront": "^3.24.0",
+    "@aws-sdk/types": "^3.22.0",
     "@pulumi/aws": "^4.14.0",
     "@pulumi/awsx": "^0.30.0",
     "@pulumi/pulumi": "^3.9.1",

--- a/packages/botonic-pulumi/package.json
+++ b/packages/botonic-pulumi/package.json
@@ -18,6 +18,7 @@
     "node": ">=12"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudfront": "^3.24.0",
     "@pulumi/aws": "^4.14.0",
     "@pulumi/awsx": "^0.30.0",
     "@pulumi/pulumi": "^3.9.1",

--- a/packages/botonic-pulumi/src/aws/cache-invalidator.ts
+++ b/packages/botonic-pulumi/src/aws/cache-invalidator.ts
@@ -2,6 +2,8 @@ import { CloudFront, CloudFrontClientConfig } from '@aws-sdk/client-cloudfront'
 import { Credentials } from '@aws-sdk/types'
 
 import { AWSCredentials } from '../pulumi-runner'
+
+export const INVALIDATION_PATH_PREFIX = '/'
 export class CacheInvalidator {
   client: CloudFront
   constructor(awsConfig: AWSCredentials) {
@@ -30,7 +32,7 @@ export class CacheInvalidator {
 
   async invalidateBucketObjects(
     distributionId: string,
-    pathPrefix = '/',
+    pathPrefix = INVALIDATION_PATH_PREFIX,
     bucketObjects: string[]
   ): Promise<void> {
     const itemsToInvalidate = bucketObjects.map(e => `${pathPrefix}${e}`)

--- a/packages/botonic-pulumi/src/aws/cache-invalidator.ts
+++ b/packages/botonic-pulumi/src/aws/cache-invalidator.ts
@@ -1,0 +1,35 @@
+import { CloudFront } from '@aws-sdk/client-cloudfront'
+
+import { AWSCredentials } from '../pulumi-runner'
+
+export class CacheInvalidator {
+  awsConfig: AWSCredentials
+  client: CloudFront
+
+  constructor(awsConfig: AWSCredentials) {
+    this.awsConfig = awsConfig
+    // TODO: What more credentials have to be used here?
+    this.client = new CloudFront({
+      region: awsConfig.region,
+    })
+  }
+
+  async invalidateBucketObjects(
+    distributionId: string,
+    pathPrefix = '/',
+    bucketObjects: string[]
+  ): Promise<void> {
+    const itemsToInvalidate = bucketObjects.map(e => `${pathPrefix}${e}`)
+    console.log('Running cache invalidations on updated files...')
+    await this.client.createInvalidation({
+      DistributionId: distributionId,
+      InvalidationBatch: {
+        CallerReference: new Date().toISOString(),
+        Paths: {
+          Items: itemsToInvalidate,
+          Quantity: itemsToInvalidate.length,
+        },
+      },
+    })
+  }
+}

--- a/packages/botonic-pulumi/src/aws/deployment-stacks.ts
+++ b/packages/botonic-pulumi/src/aws/deployment-stacks.ts
@@ -61,6 +61,7 @@ interface FrontendDeployResults {
   websocketUrl: pulumi.Output<string>
   apiUrl: pulumi.Output<string>
   webchatUrl: pulumi.Output<string>
+  cloudfrontId: pulumi.Output<string>
 }
 
 export const deployFrontendStack = async (
@@ -86,5 +87,6 @@ export const deployFrontendStack = async (
     websocketUrl: staticWebchatContents.websocketUrl,
     apiUrl: staticWebchatContents.apiUrl,
     webchatUrl: staticWebchatContents.webchatUrl,
+    cloudfrontId: staticWebchatContents.cloudfrontId,
   }
 }

--- a/packages/botonic-pulumi/src/aws/rest-server.ts
+++ b/packages/botonic-pulumi/src/aws/rest-server.ts
@@ -95,6 +95,7 @@ export class RestServer extends AWSComponentResource<RestServerArgs> {
       const API_PATH_NAME = REST_SERVER_ENDPOINT_PATH_NAME // TODO: Make it configurable?
 
       // Create the Swagger spec for a proxy which forwards all HTTP requests through to the Lambda function.
+      // eslint-disable-next-line no-inner-declarations
       function swaggerSpec(lambdaArn: string, region: string): string {
         const swaggerSpec = {
           swagger: '2.0',
@@ -109,6 +110,7 @@ export class RestServer extends AWSComponentResource<RestServerArgs> {
 
       // Create a single Swagger spec route handler for a Lambda function.
 
+      // eslint-disable-next-line no-inner-declarations
       function swaggerRouteHandler(lambdaArn: string, region: string) {
         return {
           'x-amazon-apigateway-any-method': {

--- a/packages/botonic-pulumi/src/aws/static-webchat-contents.ts
+++ b/packages/botonic-pulumi/src/aws/static-webchat-contents.ts
@@ -161,6 +161,7 @@ export class StaticWebchatContents extends AWSComponentResource<StaticWebchatCon
   apiUrl: pulumi.Output<string>
   webchatUrl: pulumi.Output<string>
   // webviewsUrl: pulumi.Output<string>
+  cloudfrontId: pulumi.Output<string>
 
   constructor(args: StaticWebchatContentsArgs, opts: AWSResourceOptions) {
     super('static-webchat-contents', args, opts)
@@ -367,7 +368,9 @@ export class StaticWebchatContents extends AWSComponentResource<StaticWebchatCon
     this.websocketUrl = pulumi.interpolate`wss://${domainName}/${WEBSOCKET_ENDPOINT_PATH_NAME}/`
     this.apiUrl = pulumi.interpolate`https://${domainName}/${REST_SERVER_ENDPOINT_PATH_NAME}/`
     this.webchatUrl = pulumi.interpolate`https://${domainName}/`
+    this.cloudfrontId = cdn.id
     this.registerOutputs({
+      cloudfrontId: this.cloudfrontId,
       nlpModelsUrl: this.nlpModelsUrl,
       websocketUrl: this.websocketUrl,
       apiUrl: this.apiUrl,

--- a/packages/botonic-pulumi/src/pulumi-runner.ts
+++ b/packages/botonic-pulumi/src/pulumi-runner.ts
@@ -14,6 +14,7 @@ import { WEBCHAT_BOTONIC_PATH, WEBSOCKET_ENDPOINT_PATH_NAME } from './'
 import {
   CacheInvalidator,
   getUpdatedObjectsFromPreview,
+  INVALIDATION_PATH_PREFIX,
 } from './aws/cache-invalidator'
 import {
   deployBackendStack,
@@ -249,17 +250,13 @@ export class PulumiRunner {
     updatedBucketObjects: string[]
   ): Promise<void> {
     try {
-      const cacheInvalidator = new CacheInvalidator({
-        region: this.projectConfig.region,
-        profile: this.projectConfig.profile,
-        accessKey: this.projectConfig.accessKey,
-        secretKey: this.projectConfig.secretKey,
-        token: this.projectConfig.token,
-      })
+      const cacheInvalidator = new CacheInvalidator(
+        this.projectConfig as AWSCredentials
+      )
       const cloudfrontId = updateResults.outputs['cloudfrontId'].value
       await cacheInvalidator.invalidateBucketObjects(
         cloudfrontId,
-        '/',
+        INVALIDATION_PATH_PREFIX,
         updatedBucketObjects
       )
     } catch (e) {

--- a/packages/botonic-pulumi/tests/detect-updated-objects.test.ts
+++ b/packages/botonic-pulumi/tests/detect-updated-objects.test.ts
@@ -1,0 +1,56 @@
+import { getUpdatedObjectsFromPreview } from '../src/aws/cache-invalidator'
+
+const previewOutputWithoutChanges = `
+Previewing update (frontend-dev):
+
+    pulumi:pulumi:Stack myProject-frontend-dev running
+    pulumi:providers:aws botonic-myProject-dev-aws-provider
+    static-webchat-contents botonic-myProject-dev-static-webchat-contents
+    aws:s3:Bucket botonic-myProject-dev-webchat-contents-bucket
+    pulumi:providers:aws east
+    aws:s3:BucketObject index.html  [diff: ~source]
+    aws:s3:BucketObject webchat.botonic.js.LICENSE.txt  [diff: ~source]
+    aws:s3:BucketObject webchat.botonic.js  [diff: ~source]
+    aws:acm:Certificate certificate  [diff: +__defaults]
+    aws:route53:Record bot-1.sandbox0.hubtype.com-validation  [diff: +__defaults]
+    aws:acm:CertificateValidation certificateValidation  [diff: +__defaults]
+    aws:cloudfront:Distribution botonic-myProject-dev-cdn  [diff: ~restrictions,viewerCertificate]
+    aws:route53:Record bot-1.sandbox0.hubtype.com  [diff: +__defaults~aliases]
+    pulumi:pulumi:Stack myProject-frontend-dev
+
+Resources:
+    26 unchanged
+`
+
+const previewOutputWithChanges = `
+Previewing update (frontend-dev):
+
+    pulumi:pulumi:Stack myProject-frontend-dev running
+    pulumi:providers:aws botonic-myProject-dev-aws-provider
+    static-webchat-contents botonic-myProject-dev-static-webchat-contents
+    aws:s3:Bucket botonic-myProject-dev-webchat-contents-bucket
+    pulumi:providers:aws east
+    aws:s3:BucketObject index.html  [diff: ~source]
+    aws:s3:BucketObject webchat.botonic.js.LICENSE.txt  [diff: ~source]
+ ~  aws:s3:BucketObject webchat.botonic.js update [diff: ~source]
+    aws:acm:Certificate certificate  [diff: +__defaults]
+    aws:route53:Record bot-1.sandbox0.hubtype.com-validation  [diff: +__defaults]
+    aws:acm:CertificateValidation certificateValidation  [diff: +__defaults]
+    aws:cloudfront:Distribution botonic-myProject-dev-cdn  [diff: ~restrictions,viewerCertificate]
+    aws:route53:Record bot-1.sandbox0.hubtype.com  [diff: +__defaults~aliases]
+    pulumi:pulumi:Stack myProject-frontend-dev
+
+Resources:
+    ~ 1 to update
+    25 unchanged
+`
+
+it('TEST: Returns an empty list when there are no changes', () => {
+  const sut = getUpdatedObjectsFromPreview(previewOutputWithoutChanges)
+  expect(sut).toEqual([])
+})
+
+it('TEST: Returns list with changed files on changes', () => {
+  const sut = getUpdatedObjectsFromPreview(previewOutputWithChanges)
+  expect(sut).toEqual(['webchat.botonic.js'])
+})

--- a/packages/botonic-pulumi/tsconfig.json
+++ b/packages/botonic-pulumi/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "outDir": "./lib"
-  }
+  },
+  "exclude": ["tests", "lib"]
 }


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Do invalidate cache for updated S3 objects after deploying Botonic 1.0 full-stack.


## Context
As a cache system, cloudfront caches the requested origin objects for some time. This had as a consequence that after modifying static assets (`index.html, webchat.botonic.js, ...`) the changes were not instantly applied so several time had to pass to see the effects ([outdated content](https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-serving-outdated-content-s3/)).
In order to tell cloudfront to request again these files when the web content is loaded, we have to do what is called [cache invalidation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html).
There are some different ways to solve this problem:
* Creating dynamic providers with Pulumi.
* Create an isolated lambda to detect S3 bucket changes and trigger the invalidations.
* Detecting in some other way what have been the changes applied and run the invalidation with them.


## Approach taken / Explain the design

The first two solutions seemed to me to be more complex that what we need, so I came up with:
1. Running the preview command within the automation api (`previewStack`) before deploying (with `updateStack`). This gives us an output with a log with the changed files.
2. Parsing the output by filtering the changes we are interested (filtering lines by `~` which denotes and update and `aws:s3:bucketObject`).
3. Running invalidations after the full-stack has been deployed.
