### PR TITLE
fix(pulumi): throw error when exceeding name chars threshold

### DIFF
--- a/packages/botonic-pulumi/src/aws/deployment-stacks.ts
+++ b/packages/botonic-pulumi/src/aws/deployment-stacks.ts
@@ -1,7 +1,7 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
 
-import { getNamePrefix } from '..'
+import { getProjectStackNamePrefix } from '..'
 import { ProgramConfig } from '../pulumi-runner'
 import { AWSProvider, getAwsProviderConfig } from '.'
 import { DynamoDB } from './dynamodb'
@@ -19,10 +19,13 @@ interface BackendDeployResults {
 export const deployBackendStack = async (
   config: ProgramConfig
 ): Promise<BackendDeployResults> => {
-  const awsProvider = new aws.Provider(`${getNamePrefix()}-aws-provider`, {
-    ...getAwsProviderConfig(),
-    defaultTags: { tags: config.tags || {} },
-  }) as AWSProvider
+  const awsProvider = new aws.Provider(
+    `${getProjectStackNamePrefix()}-aws-provider`,
+    {
+      ...getAwsProviderConfig(),
+      defaultTags: { tags: config.tags || {} },
+    }
+  ) as AWSProvider
   const awsResourceOptions = { provider: awsProvider, parent: awsProvider }
 
   const nlpModelsBucket = new NLPModelsBucket({}, awsResourceOptions)
@@ -67,10 +70,13 @@ interface FrontendDeployResults {
 export const deployFrontendStack = async (
   config: ProgramConfig
 ): Promise<FrontendDeployResults> => {
-  const awsProvider = new aws.Provider(`${getNamePrefix()}-aws-provider`, {
-    ...getAwsProviderConfig(),
-    defaultTags: { tags: config.tags || {} },
-  }) as AWSProvider
+  const awsProvider = new aws.Provider(
+    `${getProjectStackNamePrefix()}-aws-provider`,
+    {
+      ...getAwsProviderConfig(),
+      defaultTags: { tags: config.tags || {} },
+    }
+  ) as AWSProvider
   const awsResourceOptions = { provider: awsProvider, parent: awsProvider }
 
   const staticWebchatContents = new StaticWebchatContents(

--- a/packages/botonic-pulumi/src/aws/index.ts
+++ b/packages/botonic-pulumi/src/aws/index.ts
@@ -1,7 +1,7 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
 
-import { getNamePrefix } from '..'
+import { getProjectStackNamePrefix } from '..'
 
 // DynamoDB
 export const BOTONIC_SINGLE_TABLE_NAME = 'user_events'
@@ -18,9 +18,9 @@ export class AWSComponentResource<
   namePrefix: string
   provider: AWSProvider
   constructor(type: string, args: ComponentArgs, opts: AWSResourceOptions) {
-    super(type, `${getNamePrefix()}-${type}`, args, opts)
+    super(type, `${getProjectStackNamePrefix()}-${type}`, args, opts)
     this.provider = opts.provider
-    this.namePrefix = getNamePrefix()
+    this.namePrefix = getProjectStackNamePrefix()
   }
 }
 

--- a/packages/botonic-pulumi/src/aws/websocket-server.ts
+++ b/packages/botonic-pulumi/src/aws/websocket-server.ts
@@ -31,9 +31,9 @@ export class WebSocketServer extends AWSComponentResource<WebSocketServerArgs> {
     // Check that path exists so pulumi do not throw an exception in runtime when previewing the update
     if (existsSync(websocketLambdaPath)) {
       const websocketApiGateway = new aws.apigatewayv2.Api(
-        `${this.namePrefix}-api-gateway`,
+        `${this.namePrefix}-ws-api`,
         {
-          name: `${this.namePrefix}-api-gateway`,
+          name: `${this.namePrefix}-ws-api`,
           protocolType: 'WEBSOCKET',
           routeSelectionExpression: '$request.body.action',
         },

--- a/packages/botonic-pulumi/src/index.ts
+++ b/packages/botonic-pulumi/src/index.ts
@@ -2,10 +2,27 @@ import { Config } from '@pulumi/pulumi'
 import { join } from 'path'
 import { cwd } from 'process'
 
-export const getNamePrefix = (): string => {
+export function getNamePrefix(): string {
   const config = new Config()
-  return `botonic-${config.get('projectName')}-${config.get('stackName')}`
+  const prefix = generatePrefix(
+    config.get('projectName') as string,
+    config.get('stackName') as string
+  )
+  return prefix
 }
+
+export function generatePrefix(projectName: string, stackName: string): string {
+  const SEPARATOR = '-'
+  const prefix = `${projectName}${SEPARATOR}${stackName}`
+  const MAX_LENGTH = 30
+  if (prefix.length > MAX_LENGTH + 1) {
+    throw new Error(
+      `The combination of 'projectName' and 'stackName' names can not exceed ${MAX_LENGTH} chars.`
+    )
+  }
+  return prefix
+}
+
 export const NLP_MODELS_PATH = join(cwd(), 'bot', 'src', 'nlp', 'tasks')
 export const WEBSOCKET_SERVER_PATH = join(cwd(), 'api', 'dist', 'websocket')
 export const REST_SERVER_PATH = join(cwd(), 'api', 'dist', 'rest')

--- a/packages/botonic-pulumi/src/index.ts
+++ b/packages/botonic-pulumi/src/index.ts
@@ -2,22 +2,22 @@ import { Config } from '@pulumi/pulumi'
 import { join } from 'path'
 import { cwd } from 'process'
 
+export const PROJECT_NAME_SEPARATOR = '-'
+export const MAX_PROJECT_NAME_LENGTH = 30
+
 export function getNamePrefix(): string {
   const config = new Config()
-  const prefix = generatePrefix(
+  return generatePrefix(
     config.get('projectName') as string,
     config.get('stackName') as string
   )
-  return prefix
 }
 
 export function generatePrefix(projectName: string, stackName: string): string {
-  const SEPARATOR = '-'
-  const prefix = `${projectName}${SEPARATOR}${stackName}`
-  const MAX_LENGTH = 30
-  if (prefix.length > MAX_LENGTH + 1) {
+  const prefix = `${projectName}${PROJECT_NAME_SEPARATOR}${stackName}`
+  if (prefix.length > MAX_PROJECT_NAME_LENGTH + PROJECT_NAME_SEPARATOR.length) {
     throw new Error(
-      `The combination of 'projectName' and 'stackName' names can not exceed ${MAX_LENGTH} chars.`
+      `The combination of 'projectName' and 'stackName' names can not exceed ${MAX_PROJECT_NAME_LENGTH} chars.`
     )
   }
   return prefix

--- a/packages/botonic-pulumi/src/index.ts
+++ b/packages/botonic-pulumi/src/index.ts
@@ -5,19 +5,24 @@ import { cwd } from 'process'
 export const PROJECT_NAME_SEPARATOR = '-'
 export const MAX_PROJECT_NAME_LENGTH = 30
 
-export function getNamePrefix(): string {
+export function getProjectStackNamePrefix(): string {
   const config = new Config()
-  return generatePrefix(
+  return generateProjectStackNamePrefix(
     config.get('projectName') as string,
     config.get('stackName') as string
   )
 }
 
-export function generatePrefix(projectName: string, stackName: string): string {
+export function generateProjectStackNamePrefix(
+  projectName: string,
+  stackName: string
+): string {
   const prefix = `${projectName}${PROJECT_NAME_SEPARATOR}${stackName}`
   if (prefix.length > MAX_PROJECT_NAME_LENGTH + PROJECT_NAME_SEPARATOR.length) {
     throw new Error(
-      `The combination of 'projectName' and 'stackName' names can not exceed ${MAX_PROJECT_NAME_LENGTH} chars.`
+      `Provided projectName "${projectName}" and stackName "${stackName}" that combined exceed the max allowed length: ${
+        prefix.length - PROJECT_NAME_SEPARATOR.length
+      } / ${MAX_PROJECT_NAME_LENGTH}`
     )
   }
   return prefix

--- a/packages/botonic-pulumi/src/pulumi-runner.ts
+++ b/packages/botonic-pulumi/src/pulumi-runner.ts
@@ -10,7 +10,11 @@ import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { env } from 'process'
 
-import { WEBCHAT_BOTONIC_PATH, WEBSOCKET_ENDPOINT_PATH_NAME } from './'
+import {
+  generatePrefix,
+  WEBCHAT_BOTONIC_PATH,
+  WEBSOCKET_ENDPOINT_PATH_NAME,
+} from './'
 import {
   CacheInvalidator,
   getUpdatedObjectsFromPreview,
@@ -99,9 +103,10 @@ export class PulumiRunner {
   ): Promise<Stack> {
     const projectName = this.projectConfig?.projectName || 'botonic'
     const stackName = this.projectConfig?.stackName || 'full-stack'
+    const prefix = generatePrefix(projectName, stackName)
     const args: InlineProgramArgs = {
       projectName,
-      stackName: `${stackToDeploy}-${stackName}`,
+      stackName: `${prefix}-${stackToDeploy}`,
       program: async () => {
         return stackToDeploy === 'backend'
           ? await deployBackendStack(this.programConfig)

--- a/packages/botonic-pulumi/src/pulumi-runner.ts
+++ b/packages/botonic-pulumi/src/pulumi-runner.ts
@@ -12,6 +12,7 @@ import { env } from 'process'
 
 import {
   generatePrefix,
+  PROJECT_NAME_SEPARATOR,
   WEBCHAT_BOTONIC_PATH,
   WEBSOCKET_ENDPOINT_PATH_NAME,
 } from './'
@@ -106,7 +107,7 @@ export class PulumiRunner {
     const prefix = generatePrefix(projectName, stackName)
     const args: InlineProgramArgs = {
       projectName,
-      stackName: `${prefix}-${stackToDeploy}`,
+      stackName: `${prefix}${PROJECT_NAME_SEPARATOR}${stackToDeploy}`,
       program: async () => {
         return stackToDeploy === 'backend'
           ? await deployBackendStack(this.programConfig)

--- a/packages/botonic-pulumi/src/pulumi-runner.ts
+++ b/packages/botonic-pulumi/src/pulumi-runner.ts
@@ -11,7 +11,7 @@ import { join } from 'path'
 import { env } from 'process'
 
 import {
-  generatePrefix,
+  generateProjectStackNamePrefix,
   PROJECT_NAME_SEPARATOR,
   WEBCHAT_BOTONIC_PATH,
   WEBSOCKET_ENDPOINT_PATH_NAME,
@@ -104,7 +104,7 @@ export class PulumiRunner {
   ): Promise<Stack> {
     const projectName = this.projectConfig?.projectName || 'botonic'
     const stackName = this.projectConfig?.stackName || 'full-stack'
-    const prefix = generatePrefix(projectName, stackName)
+    const prefix = generateProjectStackNamePrefix(projectName, stackName)
     const args: InlineProgramArgs = {
       projectName,
       stackName: `${prefix}${PROJECT_NAME_SEPARATOR}${stackToDeploy}`,


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Limited the amount of valid characters for combinations of `projectName` + `stackName`.

## Context
Some of AWS components (buckets, lambdas, ...) has a limitation in their names length of ~64 characters. As we append a generated prefix (combination of project name + stack name) to name the components and make them easy to identify, sometimes this maximum was hit.

## Approach taken / Explain the design
Define a reasonable total maximum string length of 30 (30 + 1 from separator) and throw asap to not continue propagating this error when deploying in Botonic 1.0.