### PR TITLE
Fix/dx botonic app config

### DIFF
--- a/packages/botonic-dx/botonic-app-config/webpack/api-ws.js
+++ b/packages/botonic-dx/botonic-app-config/webpack/api-ws.js
@@ -21,10 +21,10 @@ module.exports = ({
   output: {
     path: path.resolve(projectPath, 'dist/websocket'),
     filename: 'server.js',
-    libraryTarget: 'commonjs',
+    libraryTarget: 'umd',
   },
   module: {
-    rules: [transpilingLoaderConfig('babel'), nullLoaderConfig],
+    rules: [transpilingLoaderConfig('esbuild'), nullLoaderConfig],
   },
   resolve: {
     extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],

--- a/packages/botonic-dx/package.json
+++ b/packages/botonic-dx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx",
-  "version": "0.19.0",
+  "version": "1.0.0-alpha.0",
   "description": "Continuous integration for botonic packages",
   "scripts": {},
   "author": "",


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Change api-ws config to use the same working config as api-rest config.
* Bump and publish 1.0.0-alpha.0 version.

## Context
After including typescript code of outputParser in `@botonic/core`, the botonic 1.0 project started failing with current configs imported from dx.