### PR TITLE
feat(core/api): allow accessing dataProvider within Actions and plugins

### DIFF
--- a/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
@@ -10,6 +10,7 @@ import {
   getUserEventsTable,
   GLOBAL_SECONDARY_INDEX_NAME,
   SORT_KEY_NAME,
+  USER_PREFIX,
 } from './dynamodb-utils'
 
 export class DynamoDBDataProvider implements DataProvider {
@@ -56,7 +57,15 @@ export class DynamoDBDataProvider implements DataProvider {
   }
 
   // @ts-ignore
-  async getUsers(limit = 10, offset = 0): Promise<User[]> {} // TODO: Implement
+  async getUsers(limit = 10, offset = 0): Promise<User[]> {
+    // TODO: offset really needed here?
+    const result = await this.userEventsTable.scan({
+      filters: { attr: SORT_KEY_NAME, beginsWith: USER_PREFIX },
+      limit,
+    })
+    if (result.Count === 0) return []
+    return result.Items
+  }
 
   async getUser(id: string): Promise<User | undefined> {
     const userById = {

--- a/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
+++ b/packages/botonic-api/src/data-provider/dynamodb-data-provider.ts
@@ -63,7 +63,6 @@ export class DynamoDBDataProvider implements DataProvider {
       filters: { attr: SORT_KEY_NAME, beginsWith: USER_PREFIX },
       limit,
     })
-    if (result.Count === 0) return []
     return result.Items
   }
 

--- a/packages/botonic-api/src/rest/routes/bot-input.ts
+++ b/packages/botonic-api/src/rest/routes/bot-input.ts
@@ -4,7 +4,7 @@ import { MessageEventFrom } from '@botonic/core/lib/models/events/message'
 import { BotonicEvent } from '@botonic/core/src/models/events'
 import { MessageEventAck } from '@botonic/core/src/models/events/message'
 import { User } from '@botonic/core/src/models/user'
-import { NodeApp } from '@botonic/react'
+import { NodeApp } from '@botonic/react/src/experimental'
 import { Request, Router } from 'express'
 import { ulid } from 'ulid'
 import { v4 } from 'uuid'
@@ -72,6 +72,9 @@ async function createUser(providerId: string): Promise<User> {
     isOnline: true,
     route: '/',
     session: {} as Session,
+    // TODO: fill information
+    websocketId: '',
+    locationInfo: '',
   }
   return dp.saveUser(user)
 }

--- a/packages/botonic-api/src/rest/routes/bot-input.ts
+++ b/packages/botonic-api/src/rest/routes/bot-input.ts
@@ -1,10 +1,9 @@
 import { Session } from '@botonic/core'
-import { BotonicOutputParser } from '@botonic/core/lib'
 import { MessageEventFrom } from '@botonic/core/lib/models/events/message'
+import { BotonicOutputParser } from '@botonic/core/lib/output-parser'
 import { BotonicEvent } from '@botonic/core/src/models/events'
 import { MessageEventAck } from '@botonic/core/src/models/events/message'
 import { User } from '@botonic/core/src/models/user'
-import { NodeApp } from '@botonic/react/src/experimental'
 import { Request, Router } from 'express'
 import { ulid } from 'ulid'
 import { v4 } from 'uuid'
@@ -13,7 +12,8 @@ import { dataProviderFactory } from '../../data-provider'
 
 const dp = dataProviderFactory(process.env.DATA_PROVIDER_URL)
 
-export default function botInputRouter(bot: NodeApp): Router {
+export default function botInputRouter(bot: any): Router {
+  // TODO: bot was typed like bot: NodeApp, but this requires to add @botonic/react as an extra dependency. We should rethink how to handle this
   const router = Router()
   const botonicOutputParser = new BotonicOutputParser()
 

--- a/packages/botonic-api/src/rest/routes/bot-input.ts
+++ b/packages/botonic-api/src/rest/routes/bot-input.ts
@@ -27,6 +27,7 @@ export default function botInputRouter(bot: any): Router {
       input: req.body.input,
       session: { user },
       lastRoutePath: user.route,
+      dataProvider: dp,
     })
 
     const parsedUserEvent = botonicOutputParser.parseFromUserInput(

--- a/packages/botonic-api/src/rest/routes/index.ts
+++ b/packages/botonic-api/src/rest/routes/index.ts
@@ -1,11 +1,11 @@
-import { NodeApp } from '@botonic/react'
 import { Router } from 'express'
 
 import botInputRouter from './bot-input'
 import events from './events'
 import users from './users'
 
-export const routes = (bot: NodeApp) => {
+export const routes = (bot: any) => {
+  // TODO: bot was typed like bot: NodeApp, but this requires to add @botonic/react as an extra dependency. We should rethink how to handle this
   const router = Router()
   router.use('/users', users)
   router.use('/events', events)

--- a/packages/botonic-core/src/core-bot.js
+++ b/packages/botonic-core/src/core-bot.js
@@ -17,10 +17,8 @@ export class CoreBot {
     defaultDelay,
     defaultRoutes,
     inspector,
-    dataProvider,
   }) {
     this.renderer = renderer
-    this.dataProvider = dataProvider
     this.plugins = loadPlugins(plugins)
     this.theme = theme || {}
     this.defaultTyping =
@@ -51,7 +49,7 @@ export class CoreBot {
     session.__locale = locale
   }
 
-  async input({ input, session, lastRoutePath }) {
+  async input({ input, session, lastRoutePath, dataProvider }) {
     session = session || {}
     if (!session.__locale) session.__locale = 'en'
 
@@ -64,7 +62,7 @@ export class CoreBot {
         lastRoutePath,
         undefined,
         undefined,
-        this.dataProvider
+        dataProvider
       )
     }
 
@@ -90,7 +88,7 @@ export class CoreBot {
       defaultTyping: this.defaultTyping,
       defaultDelay: this.defaultDelay,
       lastRoutePath,
-      dataProvider: this.dataProvider,
+      dataProvider,
     }
 
     const actions = [output.action, output.retryAction, output.defaultAction]
@@ -111,7 +109,7 @@ export class CoreBot {
         lastRoutePath,
         response,
         parsedResponse,
-        this.dataProvider
+        dataProvider
       )
     }
 

--- a/packages/botonic-core/src/core-bot.js
+++ b/packages/botonic-core/src/core-bot.js
@@ -17,8 +17,10 @@ export class CoreBot {
     defaultDelay,
     defaultRoutes,
     inspector,
+    dataProvider,
   }) {
     this.renderer = renderer
+    this.dataProvider = dataProvider
     this.plugins = loadPlugins(plugins)
     this.theme = theme || {}
     this.defaultTyping =
@@ -54,7 +56,16 @@ export class CoreBot {
     if (!session.__locale) session.__locale = 'en'
 
     if (this.plugins) {
-      await runPlugins(this.plugins, 'pre', input, session, lastRoutePath)
+      await runPlugins(
+        this.plugins,
+        'pre',
+        input,
+        session,
+        lastRoutePath,
+        undefined,
+        undefined,
+        this.dataProvider
+      )
     }
 
     if (isFunction(this.routes)) {
@@ -79,6 +90,7 @@ export class CoreBot {
       defaultTyping: this.defaultTyping,
       defaultDelay: this.defaultDelay,
       lastRoutePath,
+      dataProvider: this.dataProvider,
     }
 
     const actions = [output.action, output.retryAction, output.defaultAction]
@@ -98,7 +110,8 @@ export class CoreBot {
         session,
         lastRoutePath,
         response,
-        parsedResponse
+        parsedResponse,
+        this.dataProvider
       )
     }
 

--- a/packages/botonic-core/src/output-parser/parsers.ts
+++ b/packages/botonic-core/src/output-parser/parsers.ts
@@ -13,11 +13,11 @@ import {
   ImageMessageEvent,
   VideoMessageEvent,
 } from '../models/events/message/media'
+import { PostbackMessageEvent } from '../models/events/message/postback'
 import { Reply, WithReplies } from '../models/events/message/replies'
 import { TextMessageEvent } from '../models/events/message/text'
 import { TEXT_NODE_NAME } from '.'
 import { parseBoolean, parseNumber } from './util'
-import { PostbackMessageEvent } from 'src/models/events/message/postback'
 
 export type ParseFunction<Out> = (args: {
   toParse: any

--- a/packages/botonic-core/src/plugins.js
+++ b/packages/botonic-core/src/plugins.js
@@ -23,12 +23,14 @@ export async function runPlugins(
   session,
   lastRoutePath,
   response = null,
-  parsedResponse = null
+  parsedResponse = null,
+  dataProvider = null
 ) {
   for (const key in plugins) {
     const p = await plugins[key]
     try {
-      if (mode == 'pre') await p.pre({ input, session, lastRoutePath })
+      if (mode == 'pre')
+        await p.pre({ input, session, lastRoutePath, dataProvider })
       if (mode == 'post')
         await p.post({
           input,
@@ -36,6 +38,7 @@ export async function runPlugins(
           lastRoutePath,
           response,
           parsedResponse,
+          dataProvider,
         })
     } catch (e) {
       console.log(e)

--- a/packages/botonic-core/src/plugins.js
+++ b/packages/botonic-core/src/plugins.js
@@ -29,9 +29,9 @@ export async function runPlugins(
   for (const key in plugins) {
     const p = await plugins[key]
     try {
-      if (mode == 'pre')
+      if (mode === 'pre')
         await p.pre({ input, session, lastRoutePath, dataProvider })
-      if (mode == 'post')
+      if (mode === 'post')
         await p.post({
           input,
           session,

--- a/packages/botonic-core/src/types/index.d.ts
+++ b/packages/botonic-core/src/types/index.d.ts
@@ -211,6 +211,7 @@ export interface BotRequest {
   input: Input
   lastRoutePath: string
   session: Session
+  dataProvider: any // TODO: Should data provider be typed in core and used in @botonic/api?
 }
 
 /** The response of the bot for the triggered actions, which can be
@@ -219,6 +220,7 @@ export interface BotRequest {
  * */
 export interface BotResponse extends BotRequest {
   response: any
+  parsedResponse?: any
 }
 
 export type PluginPreRequest = BotRequest

--- a/packages/botonic-core/src/types/models/events/connections/index.d.ts
+++ b/packages/botonic-core/src/types/models/events/connections/index.d.ts
@@ -1,0 +1,9 @@
+import { BaseEvent, EventTypes } from '..'
+export declare enum ConnectionEventStatuses {
+  CONNECTED = 'connected',
+  DISCONNECTED = 'disconnected',
+}
+export interface ConnectionEvent extends BaseEvent {
+  eventType: EventTypes.CONNECTION
+  status: ConnectionEventStatuses
+}

--- a/packages/botonic-core/src/types/models/events/index.d.ts
+++ b/packages/botonic-core/src/types/models/events/index.d.ts
@@ -1,0 +1,36 @@
+import { ConnectionEvent } from './connections'
+import { CarouselMessageEvent } from './message/carousel'
+import { CustomMessageEvent } from './message/custom'
+import { LocationMessageEvent } from './message/location'
+import {
+  AudioMessageEvent,
+  DocumentMessageEvent,
+  ImageMessageEvent,
+  VideoMessageEvent,
+} from './message/media'
+import { PostbackMessageEvent } from './message/postback'
+import { TextMessageEvent } from './message/text'
+export declare enum EventTypes {
+  CONNECTION = 'connection',
+  MESSAGE = 'message',
+  ACK = 'ack',
+  TRACK = 'track',
+}
+export interface BaseEvent {
+  eventId: string
+  userId: string
+  eventType: EventTypes
+  createdAt: string
+  modifiedAt?: string
+}
+export declare type BotonicEvent =
+  | TextMessageEvent
+  | PostbackMessageEvent
+  | AudioMessageEvent
+  | DocumentMessageEvent
+  | ImageMessageEvent
+  | VideoMessageEvent
+  | LocationMessageEvent
+  | CarouselMessageEvent
+  | CustomMessageEvent
+  | ConnectionEvent

--- a/packages/botonic-core/src/types/models/events/message/buttons.d.ts
+++ b/packages/botonic-core/src/types/models/events/message/buttons.d.ts
@@ -1,0 +1,18 @@
+export interface BaseButton {
+  title: string
+}
+export interface WebviewButton extends BaseButton {
+  webview: any
+  params?: any
+}
+export interface UrlButton extends BaseButton {
+  url: string
+  target?: string
+}
+export interface PayloadButton extends BaseButton {
+  payload: string
+}
+export declare type Button = PayloadButton | UrlButton | WebviewButton
+export interface WithButtons {
+  buttons?: Button[]
+}

--- a/packages/botonic-core/src/types/models/events/message/carousel.d.ts
+++ b/packages/botonic-core/src/types/models/events/message/carousel.d.ts
@@ -1,0 +1,11 @@
+import { BotonicMessageEvent, MessageEventTypes } from '.'
+import { WithButtons } from './buttons'
+export interface CarouselElement extends WithButtons {
+  pic: string
+  title: string
+  subtitle?: string
+}
+export interface CarouselMessageEvent extends BotonicMessageEvent {
+  type: MessageEventTypes.CAROUSEL
+  elements: CarouselElement[]
+}

--- a/packages/botonic-core/src/types/models/events/message/custom.d.ts
+++ b/packages/botonic-core/src/types/models/events/message/custom.d.ts
@@ -1,0 +1,6 @@
+import { BotonicMessageEvent, MessageEventTypes } from '.'
+import { WithReplies } from './replies'
+export interface CustomMessageEvent extends BotonicMessageEvent, WithReplies {
+  type: MessageEventTypes.CUSTOM
+  customTypeName: string
+}

--- a/packages/botonic-core/src/types/models/events/message/index.d.ts
+++ b/packages/botonic-core/src/types/models/events/message/index.d.ts
@@ -1,0 +1,30 @@
+import { BaseEvent } from '..'
+export declare enum MessageEventTypes {
+  AUDIO = 'audio',
+  CAROUSEL = 'carousel',
+  CUSTOM = 'custom',
+  DOCUMENT = 'document',
+  IMAGE = 'image',
+  LOCATION = 'location',
+  TEXT = 'text',
+  POSTBACK = 'postback',
+  VIDEO = 'video',
+}
+export declare enum MessageEventAck {
+  DRAFT = 'draft',
+  READ = 'read',
+  RECEIVED = 'received',
+  SENT = 'sent',
+}
+export declare enum MessageEventFrom {
+  AGENT = 'agent',
+  BOT = 'bot',
+  USER = 'user',
+}
+export interface BotonicMessageEvent extends BaseEvent {
+  ack: MessageEventAck
+  from: MessageEventFrom
+  type: MessageEventTypes
+  typing: number
+  delay: number
+}

--- a/packages/botonic-core/src/types/models/events/message/location.d.ts
+++ b/packages/botonic-core/src/types/models/events/message/location.d.ts
@@ -1,0 +1,6 @@
+import { BotonicMessageEvent, MessageEventTypes } from '.'
+export interface LocationMessageEvent extends BotonicMessageEvent {
+  type: MessageEventTypes.LOCATION
+  lat: number
+  long: number
+}

--- a/packages/botonic-core/src/types/models/events/message/media.d.ts
+++ b/packages/botonic-core/src/types/models/events/message/media.d.ts
@@ -1,0 +1,18 @@
+import { BotonicMessageEvent, MessageEventTypes } from '.'
+import { WithButtons } from './buttons'
+export declare const MEDIA_TYPES: MessageEventTypes[]
+export interface MediaMessageEvent extends BotonicMessageEvent, WithButtons {
+  src: string
+}
+export interface AudioMessageEvent extends MediaMessageEvent {
+  type: MessageEventTypes.AUDIO
+}
+export interface ImageMessageEvent extends MediaMessageEvent {
+  type: MessageEventTypes.IMAGE
+}
+export interface DocumentMessageEvent extends MediaMessageEvent {
+  type: MessageEventTypes.DOCUMENT
+}
+export interface VideoMessageEvent extends MediaMessageEvent {
+  type: MessageEventTypes.VIDEO
+}

--- a/packages/botonic-core/src/types/models/events/message/postback.d.ts
+++ b/packages/botonic-core/src/types/models/events/message/postback.d.ts
@@ -1,0 +1,4 @@
+import { BotonicMessageEvent } from '.'
+export interface PostbackMessageEvent extends BotonicMessageEvent {
+  payload: string
+}

--- a/packages/botonic-core/src/types/models/events/message/replies.d.ts
+++ b/packages/botonic-core/src/types/models/events/message/replies.d.ts
@@ -1,0 +1,7 @@
+export interface Reply {
+  title: string
+  payload: string
+}
+export interface WithReplies {
+  replies?: Reply[]
+}

--- a/packages/botonic-core/src/types/models/events/message/text.d.ts
+++ b/packages/botonic-core/src/types/models/events/message/text.d.ts
@@ -1,0 +1,11 @@
+import { BotonicMessageEvent, MessageEventTypes } from '.'
+import { WithButtons } from './buttons'
+import { WithReplies } from './replies'
+export interface TextMessageEvent
+  extends BotonicMessageEvent,
+    WithReplies,
+    WithButtons {
+  type: MessageEventTypes.TEXT
+  markdown: boolean
+  text: string
+}

--- a/packages/botonic-core/src/types/output-parser/factory.d.ts
+++ b/packages/botonic-core/src/types/output-parser/factory.d.ts
@@ -1,0 +1,4 @@
+import { BotonicEvent } from '../models/events'
+export declare class MessageParsingFactory {
+  parse(msgToParse: any): Partial<BotonicEvent>
+}

--- a/packages/botonic-core/src/types/output-parser/index.d.ts
+++ b/packages/botonic-core/src/types/output-parser/index.d.ts
@@ -1,0 +1,16 @@
+import { BotonicEvent } from '../models/events'
+import { MessageParsingFactory } from './factory'
+export declare const TEXT_NODE_NAME = 'text'
+export declare class BotonicOutputParser {
+  private readonly factory
+  private static OPTIONS
+  constructor(factory?: MessageParsingFactory)
+  xmlToMessageEvents(html: string): Partial<BotonicEvent>[]
+  /**
+   * Right now, when saving BotonicEvents to DataProvider, we need the standarized Botonic event
+   * to be saved. This is, converting a botonic input like: '{id: 'msgId', data: 'rawData', payload: 'somePayload'}'
+   * into a BotonicEvent with the expected properties.
+   */
+  parseFromUserInput(input: any): Partial<BotonicEvent>
+  private xmlToJSONMessages
+}

--- a/packages/botonic-core/src/types/output-parser/parsers.d.ts
+++ b/packages/botonic-core/src/types/output-parser/parsers.d.ts
@@ -1,0 +1,41 @@
+import { BotonicMessageEvent } from '../models/events/message'
+import { Button, WithButtons } from '../models/events/message/buttons'
+import {
+  CarouselElement,
+  CarouselMessageEvent,
+} from '../models/events/message/carousel'
+import { CustomMessageEvent } from '../models/events/message/custom'
+import { LocationMessageEvent } from '../models/events/message/location'
+import {
+  AudioMessageEvent,
+  DocumentMessageEvent,
+  ImageMessageEvent,
+  VideoMessageEvent,
+} from '../models/events/message/media'
+import { PostbackMessageEvent } from '../models/events/message/postback'
+import { Reply, WithReplies } from '../models/events/message/replies'
+import { TextMessageEvent } from '../models/events/message/text'
+export declare type ParseFunction<Out> = (args: {
+  toParse: any
+  parsed?: any
+}) => {
+  toParse: any
+  parsed: Partial<Out>
+}
+export declare const parseMessage: ParseFunction<BotonicMessageEvent>
+export declare const parseButton: (button: any) => Button
+export declare const parseButtons: ParseFunction<WithButtons>
+export declare const parseReply: (reply: any) => Reply
+export declare const parseReplies: ParseFunction<WithReplies>
+export declare const parseText: ParseFunction<TextMessageEvent>
+export declare const parsePostback: ParseFunction<PostbackMessageEvent>
+export declare const parseMedia: ParseFunction<
+  | AudioMessageEvent
+  | DocumentMessageEvent
+  | ImageMessageEvent
+  | VideoMessageEvent
+>
+export declare const parseLocation: ParseFunction<LocationMessageEvent>
+export declare const parseElement: (element: any) => CarouselElement
+export declare const parseCarousel: ParseFunction<CarouselMessageEvent>
+export declare const parseCustom: ParseFunction<CustomMessageEvent>

--- a/packages/botonic-core/src/types/output-parser/util.d.ts
+++ b/packages/botonic-core/src/types/output-parser/util.d.ts
@@ -1,0 +1,2 @@
+export declare function parseNumber(strNumber: string): number
+export declare function parseBoolean(strNumber: string): boolean

--- a/packages/botonic-eslint-config/index.js
+++ b/packages/botonic-eslint-config/index.js
@@ -77,6 +77,7 @@ module.exports = {
     'import/default': 'warn', // syntax "export = xxxx" is not supported
     'node/no-extraneous-import': 'warn', // otherwise it does not find ts-mockito if only defined in parent project
     'array-callback-return': 'error',
+    eqeqeq: 'error',
     // special for TYPESCRIPT
     '@typescript-eslint/ban-ts-comment': 'warn',
     '@typescript-eslint/explicit-function-return-type': 'off', // annoying for tests


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Passing dataProvider to NodeApp in order to allow accessing DB information within Actions and plugins.
* Added implementation of `getUsers` for dynamo data provider.
* Generated missing type declarations in @botonic/core (now that we are using the compiled lib folder of core, we can migrate the package to TS and solve the types approach)
## Context
We need a way to access database from Actions or Plugins if we want to do extra operations when bot gets executed.

## Approach taken / Explain the design
Passing already instantiated dataProviders in `websocket` and `rest` apis through `input` function.
Then they can be passed through the `request` object and plugins.
```
const dp = ...
const output = await app.input({
    input: message,
    session: JSON.parse(user.session),
    lastRoutePath: user.route,
    dataProvider: dp,
  })
```
```
async input({ input, session, lastRoutePath, dataProvider }) {
...
// also the same for post mode
await runPlugins(
        this.plugins,
        'pre', 
        input,
        session,
        lastRoutePath,
        undefined,
        undefined,
        dataProvider
      )
```
and attach it to the `request`:
```
const request = {
      getString: stringId => this.getString(stringId, session),
      setLocale: locale => this.setLocale(locale, session),
      session: session || {},
      params: output.params || {},
      input: input,
     ...,
      dataProvider,
    }
```
so it will be accessible from actions' requests and plugins' requests.
## To document / Usage example

**Using dataProvider within a class:**
```
import React from 'react'
import { Text } from '@botonic/react/src/experimental'

export default class extends React.Component {
  static async botonicInit({ dataProvider }) {
    const users = await dataProvider.getUsers()
    return { users: users }
  }
  render() {
    return (
      <>
        <Text>Welcome to Botonic!</Text>
        <Text>{JSON.stringify(this.props.users)}</Text>
      </>
    )
  }
}
```

**Using dataProvider within a plugin:**
```
async pre(request: PluginPreRequest): Promise<void> {
    const users = await request.dataProvider.getUsers()
    try {
    } catch (e) {}
  }
```
## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
