### PR TITLE
fix(pulumi): decrease deploy time when deploying without custom domain

### DIFF
--- a/packages/botonic-pulumi/src/aws/static-webchat-contents.ts
+++ b/packages/botonic-pulumi/src/aws/static-webchat-contents.ts
@@ -72,23 +72,19 @@ function getViewerCertificate(
   providedCertificateArn: pulumi.Input<string> | undefined,
   opts: pulumi.ResourceOptions
 ): pulumi.Input<aws.types.input.cloudfront.DistributionViewerCertificate> {
-  const defaultViewerCertificateOptions = {
-    minimumProtocolVersion: 'TLSv1.1_2016', // TODO: allow to customize
-  }
   if (!customDomain) {
     return {
-      ...defaultViewerCertificateOptions,
+      // If cloudfrontDefaultCertificate is specified, TLSv1 must be set. Ref: https://www.pulumi.com/docs/reference/pkg/aws/cloudfront/distribution/#minimumprotocolversion_nodejs
       cloudfrontDefaultCertificate: true,
+      minimumProtocolVersion: 'TLSv1',
     }
   }
-
   let certificateArn = providedCertificateArn
   if (certificateArn === undefined) {
     certificateArn = createCustomDomainCertificate(customDomain, opts)
   }
-
   return {
-    ...defaultViewerCertificateOptions,
+    minimumProtocolVersion: 'TLSv1.1_2016', // TODO: allow to customize
     acmCertificateArn: certificateArn,
     sslSupportMethod: 'sni-only',
   }


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
* Fixed `minimumProtocolVersion` parameter set with wrong value. 

## Context
Every time that we were deploying without a custom domain, the deployment took so much time as it was generating a new certificate on every deploy.

## Approach taken / Explain the design
Digging more into Pulumi's docs (https://www.pulumi.com/docs/reference/pkg/aws/cloudfront/distribution/#minimumprotocolversion_nodejs), it is said that when using `cloudfrontDefaultCertificate`, `TLSv1` must be set. This change has reduced the `build+deploy` time from 5 minutes approximately to 1:30 min.
