### PR TITLE
ci: configure detect-secrets #PLA-673

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,3 +133,12 @@ repos:
         entry: scripts/qa/lint-package.sh packages/botonic-plugin-intent-classification
         language: system
         files: ^packages/botonic-plugin-intent-classification/
+
+  - repo: git://github.com/Yelp/detect-secrets
+    rev: v1.1.0
+    hooks:
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline'] 
+        exclude: package.lock.json
+        name: Detect secrets
+        description: Detects high entropy strings that are likely to be passwords.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67,6 +67,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -123,7 +127,8 @@
         "filename": "docs/docs/plugins/plugin-dashbot.md",
         "hashed_secret": "2597a2198a5d4336759e79d651729d1d1532626a",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 31,
+        "is_secret": false
       }
     ],
     "docs/docs/plugins/plugin-dynamoDB.md": [
@@ -132,7 +137,8 @@
         "filename": "docs/docs/plugins/plugin-dynamoDB.md",
         "hashed_secret": "f115d0a4b6123a34f1f88ca351608c578e05e5c8",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 35,
+        "is_secret": false
       }
     ],
     "docs/docs/plugins/plugin-inbenta.md": [
@@ -141,7 +147,8 @@
         "filename": "docs/docs/plugins/plugin-inbenta.md",
         "hashed_secret": "bdefb58b0ab801e7cc1939828145cd7d1c98dc3e",
         "is_verified": false,
-        "line_number": 57
+        "line_number": 57,
+        "is_secret": false
       }
     ],
     "docs/docs/plugins/plugin-watson.md": [
@@ -150,7 +157,8 @@
         "filename": "docs/docs/plugins/plugin-watson.md",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
-        "line_number": 63
+        "line_number": 63,
+        "is_secret": false
       }
     ],
     "packages/botonic-cli/scripts/postinstall.js": [
@@ -213,7 +221,8 @@
         "filename": "packages/botonic-plugin-dashbot/README.md",
         "hashed_secret": "2597a2198a5d4336759e79d651729d1d1532626a",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 22,
+        "is_secret": false
       }
     ],
     "packages/botonic-plugin-dialogflow/tests/index.test.ts": [
@@ -222,7 +231,8 @@
         "filename": "packages/botonic-plugin-dialogflow/tests/index.test.ts",
         "hashed_secret": "a9674b19f8c56f785c91a555d0a144522bb318e6",
         "is_verified": false,
-        "line_number": 11
+        "line_number": 11,
+        "is_secret": false
       }
     ],
     "packages/botonic-plugin-dynamodb/README.md": [
@@ -231,7 +241,8 @@
         "filename": "packages/botonic-plugin-dynamodb/README.md",
         "hashed_secret": "f115d0a4b6123a34f1f88ca351608c578e05e5c8",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 26,
+        "is_secret": false
       }
     ],
     "packages/botonic-plugin-inbenta/README.md": [
@@ -240,7 +251,8 @@
         "filename": "packages/botonic-plugin-inbenta/README.md",
         "hashed_secret": "bdefb58b0ab801e7cc1939828145cd7d1c98dc3e",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 48,
+        "is_secret": false
       }
     ],
     "packages/botonic-plugin-watson/README.md": [
@@ -249,9 +261,10 @@
         "filename": "packages/botonic-plugin-watson/README.md",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 54,
+        "is_secret": false
       }
     ]
   },
-  "generated_at": "2021-08-31T10:52:42Z"
+  "generated_at": "2021-08-31T11:10:00Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,257 @@
+{
+  "version": "1.1.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "docs/docs/concepts/10.actions.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/concepts/10.actions.md",
+        "hashed_secret": "cf2df5963beaaef991ef44382c6eeda2291dd3ac",
+        "is_verified": false,
+        "line_number": 88
+      }
+    ],
+    "docs/docs/concepts/13.dynamic-carousel.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/concepts/13.dynamic-carousel.md",
+        "hashed_secret": "cf2df5963beaaef991ef44382c6eeda2291dd3ac",
+        "is_verified": false,
+        "line_number": 30
+      }
+    ],
+    "docs/docs/plugins/plugin-dashbot.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/plugins/plugin-dashbot.md",
+        "hashed_secret": "2597a2198a5d4336759e79d651729d1d1532626a",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
+    "docs/docs/plugins/plugin-dynamoDB.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/plugins/plugin-dynamoDB.md",
+        "hashed_secret": "f115d0a4b6123a34f1f88ca351608c578e05e5c8",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ],
+    "docs/docs/plugins/plugin-inbenta.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/plugins/plugin-inbenta.md",
+        "hashed_secret": "bdefb58b0ab801e7cc1939828145cd7d1c98dc3e",
+        "is_verified": false,
+        "line_number": 57
+      }
+    ],
+    "docs/docs/plugins/plugin-watson.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/docs/plugins/plugin-watson.md",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 63
+      }
+    ],
+    "packages/botonic-cli/scripts/postinstall.js": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "packages/botonic-cli/scripts/postinstall.js",
+        "hashed_secret": "62c19b749bb14de79da4077e9e7971f197665271",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "packages/botonic-cli/src/botonic-api-service.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "packages/botonic-cli/src/botonic-api-service.ts",
+        "hashed_secret": "24335a91ee41d6bbef10490becbdf3aa1843750b",
+        "is_verified": false,
+        "line_number": 23
+      }
+    ],
+    "packages/botonic-cli/src/constants.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "packages/botonic-cli/src/constants.ts",
+        "hashed_secret": "62c19b749bb14de79da4077e9e7971f197665271",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "packages/botonic-core/src/hubtype-service.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "packages/botonic-core/src/hubtype-service.ts",
+        "hashed_secret": "c2eb2eb7f85ce9e0e986e19415b6e106b0d7d8d6",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "packages/botonic-plugin-contentful/tests/contentful/contents/button.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "packages/botonic-plugin-contentful/tests/contentful/contents/button.test.ts",
+        "hashed_secret": "4a943ffd66e9864b46f74dc2d152a662ec0bb5a8",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "packages/botonic-plugin-contentful/tests/contentful/performance.integration.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "packages/botonic-plugin-contentful/tests/contentful/performance.integration.test.ts",
+        "hashed_secret": "266d2b4c42039e0084e66f294587cdfd48a621ba",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "packages/botonic-plugin-dashbot/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packages/botonic-plugin-dashbot/README.md",
+        "hashed_secret": "2597a2198a5d4336759e79d651729d1d1532626a",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "packages/botonic-plugin-dialogflow/tests/index.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packages/botonic-plugin-dialogflow/tests/index.test.ts",
+        "hashed_secret": "a9674b19f8c56f785c91a555d0a144522bb318e6",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "packages/botonic-plugin-dynamodb/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packages/botonic-plugin-dynamodb/README.md",
+        "hashed_secret": "f115d0a4b6123a34f1f88ca351608c578e05e5c8",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "packages/botonic-plugin-inbenta/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packages/botonic-plugin-inbenta/README.md",
+        "hashed_secret": "bdefb58b0ab801e7cc1939828145cd7d1c98dc3e",
+        "is_verified": false,
+        "line_number": 48
+      }
+    ],
+    "packages/botonic-plugin-watson/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packages/botonic-plugin-watson/README.md",
+        "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
+        "is_verified": false,
+        "line_number": 54
+      }
+    ]
+  },
+  "generated_at": "2021-08-31T10:52:42Z"
+}


### PR DESCRIPTION
## Description
- Configure [detect-secrets](https://github.com/Yelp/detect-secrets) in a pre-commit hook so that it checks for secrets in Git


## Context
it is useful to check that we don't commit secrets to github accidentally


## Approach taken / Explain the design

Configured in the pre-commit to avoid committing NEW secrets both locally and in ci.
We also include a baseline (.secrets.baseline) that contains all secrets that currently exist in the repo and which should be checked. 

## Checklist

The pull request...

- [ ] has the Linear issue number in the title so the issue and the PR are linked
- [ ] adds the entry in the CHANGELOG.md (with the link to the Linear issue)
  - no because... **[provide a reason]**
- [ ] has tests
  - has unit tests
  - has integration tests
  - doesn't need tests because... **[provide a reason]**
- [ ] creates new component and includes specific selectors to help with integration tests
