### PR TITLE
Contentful: Allow document as a follow-up

### DIFF
--- a/packages/botonic-plugin-contentful/src/cms/transform/message-content-filters.ts
+++ b/packages/botonic-plugin-contentful/src/cms/transform/message-content-filters.ts
@@ -4,12 +4,12 @@
 import {
   Button,
   Carousel,
+  Document,
   Element,
   Image,
   MessageContent,
   StartUp,
   Text,
-  Document,
 } from '../contents'
 import { Context } from '../context'
 import { CmsException } from '../exceptions'

--- a/packages/botonic-plugin-contentful/src/cms/transform/message-content-filters.ts
+++ b/packages/botonic-plugin-contentful/src/cms/transform/message-content-filters.ts
@@ -9,6 +9,7 @@ import {
   MessageContent,
   StartUp,
   Text,
+  Document,
 } from '../contents'
 import { Context } from '../context'
 import { CmsException } from '../exceptions'
@@ -24,6 +25,7 @@ export type FilterByMessageContentType = {
   image?: MessageContentFilter<Image>
   startUp?: MessageContentFilter<StartUp>
   text?: MessageContentFilter<Text>
+  document?: MessageContentFilter<Document>
 }
 
 export function enableDependingOnContext(
@@ -41,6 +43,7 @@ export function enableDependingOnContext(
     image: filter(inFilter.image),
     startUp: filter(inFilter.startUp),
     text: filter(inFilter.text),
+    document: filter(inFilter.document),
   }
 }
 
@@ -83,6 +86,11 @@ export class RecursiveMessageContentFilter {
     }
     if (content instanceof Image) {
       return this.filters.image && (await this.filters.image(content, context))
+    }
+    if (content instanceof Document) {
+      return (
+        this.filters.document && (await this.filters.document(content, context))
+      )
     }
     throw new CmsException(`Type '${content.contentType}' not supported`)
   }

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -110,7 +110,8 @@ export class Contentful implements cms.CMS {
       this._carousel,
       this._text,
       this._image,
-      this._startUp
+      this._startUp,
+      this._document
     )
     ;[
       this._document,

--- a/packages/botonic-plugin-contentful/src/contentful/contents/follow-up.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/follow-up.ts
@@ -10,6 +10,7 @@ import {
   FollowUpFields,
 } from '../delivery-utils'
 import { CarouselDelivery } from './carousel'
+import { DocumentDelivery, DocumentFields } from './document'
 import { ImageDelivery, ImageFields } from './image'
 import { StartUpDelivery, StartUpFields } from './startup'
 import { TextDelivery, TextFields } from './text'
@@ -37,7 +38,8 @@ export class FollowUpDelivery {
     private readonly carousel: CarouselDelivery,
     private readonly text: TextDelivery,
     private readonly image: ImageDelivery,
-    private readonly startUp: StartUpDelivery
+    private readonly startUp: StartUpDelivery,
+    private readonly document: DocumentDelivery
   ) {}
 
   async fromEntry(
@@ -75,6 +77,11 @@ export class FollowUpDelivery {
         return this.image.fromEntry(followUp as Entry<ImageFields>, context)
       case cms.ContentType.STARTUP:
         return this.startUp.fromEntry(followUp as Entry<StartUpFields>, context)
+      case cms.ContentType.DOCUMENT:
+        return this.document.fromEntry(
+          followUp as Entry<DocumentFields>,
+          context
+        )
       default:
         throw new Error(`Unexpected followUp type ${followUp.sys.type}`)
     }

--- a/packages/botonic-plugin-contentful/src/render/botonic-converter.ts
+++ b/packages/botonic-plugin-contentful/src/render/botonic-converter.ts
@@ -179,6 +179,8 @@ export class BotonicMsgConverter {
       return this.image(followUp)
     } else if (followUp instanceof cms.StartUp) {
       return this.startUp(followUp)
+    } else if (followUp instanceof cms.Document) {
+      return this.document(followUp)
     } else {
       throw new Error('Unexpected followUp type ' + typeof followUp)
     }


### PR DESCRIPTION
- Added Document as an option of the follow-up entries of Text.
- Add converter for document
Support for botonic Document (PDF) components in Contentful plugin as follow-up