### PR TITLE
chore(core): cjs and esm distribution of core, enable @botonic/core tree-shaking

### DIFF
--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -3,13 +3,14 @@
   "version": "0.19.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
   "scripts": {
     "test": "../../node_modules/.bin/jest --coverage",
     "prepare": "node ../../preinstall.js",
     "lint": "npm run lint_ci -- --fix",
     "lint_ci": "../../node_modules/.bin/eslint_d --cache --quiet '*.js' 'src/**/*.ts*'",
-    "build": "rm -rf lib && ../../node_modules/.bin/tsc",
+    "build": "rm -rf lib && ../../node_modules/.bin/tsc -p tsconfig.json && ../../node_modules/.bin/tsc -p tsconfig.esm.json",
     "build:watch": "../../node_modules/.bin/tsc --watch",
     "cloc": "../../scripts/qa/cloc-package.sh ."
   },
@@ -57,5 +58,6 @@
   "eslintConfig": {
     "extends": "../.eslintrc.js",
     "root": true
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/botonic-core/tsconfig.esm.json
+++ b/packages/botonic-core/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "./lib/esm",
+    "target": "ES2017",
+    "module": "ES2020",
+    "moduleResolution": "node"
+  }
+}

--- a/packages/botonic-core/tsconfig.json
+++ b/packages/botonic-core/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["src/"],
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "./lib",
+    "outDir": "./lib/cjs",
     "esModuleInterop": true
   }
 }


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

* Distribute `@botonic/core` package as  `/lib/cjs` and `lib/esm`. (ref: https://blog.logrocket.com/publishing-node-modules-typescript-es-modules/)
* Added `sideEffects` flag to false to facilitate webpack to tree-shake the library.

Distributing it with CJS will allow us to use it in environments like Node.js, whereas esm will allow us to use it in browser and applications using webpack.

Despite having the following two lines declared @botonic/core:
```
"main": "./lib/cjs/index.js",
"module": "./lib/esm/index.js",
```
when using webpack, the resolved library will depend on how we import the code.
**e.g.:**

```
import { isFunction } from '@botonic/core' // --> will load automatically /lib/esm version of the code.
console.log(isFunction)
```
by compiling this with webpack in production mode: `npx webpack` we end up with a minified file of **`4.0KB`**.
**reason:** ESM packages are tree-shakeable and will only bundle the `isFunction` method.

```
const { isFunction } = require('@botonic/core') // --> will load automatically /lib/cjs version of the code.
console.log(isFunction)
```
whereas by compiling this with webpack in production mode: `npx webpack` we end up with a minified file of **`216.0KB`**.
**reason:** CJS packages are not tree-shakeable and will bundle the `isFunction` along with the rest of the code exported in core's index.
