### PR TITLE
ci: do not fail even that publish test reports fails #PLA-719

### DIFF
--- a/.github/workflows/botonic-cli-tests.yml
+++ b/.github/workflows/botonic-cli-tests.yml
@@ -38,7 +38,8 @@ jobs:
         run: (cd ./packages/$PACKAGE && npm run test_ci)
 
       - name: Publish Unit Test Results
-        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:latest
+        uses: EnricoMi/publish-unit-test-result-action@v1.19
+        continue-on-error: true
         if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/botonic-nlu-tests.yml
+++ b/.github/workflows/botonic-nlu-tests.yml
@@ -37,7 +37,8 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run test_ci)
 
     - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1.6
+      uses: EnricoMi/publish-unit-test-result-action@v1.19
+      continue-on-error: true
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/botonic-plugin-dialogflow-tests.yml
+++ b/.github/workflows/botonic-plugin-dialogflow-tests.yml
@@ -37,7 +37,8 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run test_ci)
 
     - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1.9
+      uses: EnricoMi/publish-unit-test-result-action@v1.19
+      continue-on-error: true
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/botonic-plugin-intent-classification-tests.yml
+++ b/.github/workflows/botonic-plugin-intent-classification-tests.yml
@@ -37,7 +37,8 @@ jobs:
         run: (cd ./packages/$PACKAGE && npm run test_ci)
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.9
+        uses: EnricoMi/publish-unit-test-result-action@v1.19
+        continue-on-error: true
         if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/botonic-plugin-ner-tests.yml
+++ b/.github/workflows/botonic-plugin-ner-tests.yml
@@ -37,7 +37,8 @@ jobs:
         run: (cd ./packages/$PACKAGE && npm run test_ci)
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.9
+        uses: EnricoMi/publish-unit-test-result-action@v1.19
+        continue-on-error: true
         if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -37,7 +37,8 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run test_ci)
 
     - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1.9
+      uses: EnricoMi/publish-unit-test-result-action@v1.19
+      continue-on-error: true
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Sometimes publish-unit-test-result-action fails when dependabot opens the PR. See [example](https://github.com/hubtype/botonic/pull/1872/checks?check_run_id=3590602290): 



## Approach taken / Explain the design
mark 'Publish Unit Test Results' step with `continue-on-error: true` so that ci workflow continues even test results step fails.

## To document / Usage example



## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
