### PR TITLE
fix(react): add mouse wheel event to scrollable content

### DIFF
--- a/packages/botonic-react/src/util/dom.js
+++ b/packages/botonic-react/src/util/dom.js
@@ -1,10 +1,12 @@
 import { WEBCHAT } from '../constants'
 
+export const getScrollableContent = webchatElement => {
+  return webchatElement.querySelector(WEBCHAT.SELECTORS.SCROLLABLE_CONTENT)
+}
+
 export const getScrollableArea = webchatElement => {
   const getArea = area => {
-    const botonicScrollableContent = webchatElement.querySelector(
-      WEBCHAT.SELECTORS.SCROLLABLE_CONTENT
-    )
+    const botonicScrollableContent = getScrollableContent(webchatElement)
     const scrollableArea =
       botonicScrollableContent && botonicScrollableContent.querySelector(area)
     return scrollableArea

--- a/packages/botonic-react/src/webchat/devices/scrollbar-controller.js
+++ b/packages/botonic-react/src/webchat/devices/scrollbar-controller.js
@@ -1,4 +1,8 @@
-import { getScrollableArea, getWebchatElement } from '../../util/dom'
+import {
+  getScrollableArea,
+  getScrollableContent,
+  getWebchatElement,
+} from '../../util/dom'
 import { DEVICES, isMobileDevice } from '.'
 
 const debounced = (delay, fn) => {
@@ -28,7 +32,7 @@ export class ScrollbarController {
 
   handleScrollEvents() {
     /*
-      It handles scroll events for Mobile/Desktop. 
+      It handles scroll events for Mobile/Desktop.
       "ontouchmove" is the phone equivalent for "onmouseover"
     */
     if (isMobileDevice()) {
@@ -61,11 +65,12 @@ export class ScrollbarController {
   }
 
   toggleOnMouseWheelEvents() {
+    const scrollableContent = getScrollableContent(this.webchat)
     if (this.hasScrollbar()) {
-      this.webchat.onmousewheel = {}
+      scrollableContent.onmousewheel = {}
       return
     }
-    this.webchat.onmousewheel = e => e.preventDefault()
+    scrollableContent.onmousewheel = e => e.preventDefault()
   }
 
   handleOnTouchMoveEvents(e) {


### PR DESCRIPTION
## Description

Changes:
- Add mouse wheel event to scroll content element.

## Context

Emoji panel and cover component cannot scroll if scroll content element without scrollbar.
Because mouse wheel event added to web chat element.

## Approach taken / Explain the design

## To document / Usage example

## Testing

The pull request...

- doesn't need tests 
