### PR TITLE
ci: use codecovV2 #PLA-722

### DIFF
--- a/.github/workflows/botonic-cli-tests.yml
+++ b/.github/workflows/botonic-cli-tests.yml
@@ -49,7 +49,7 @@ jobs:
         run: (cd ./packages/$PACKAGE && npm run lint_ci)
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-core-tests.yml
+++ b/.github/workflows/botonic-core-tests.yml
@@ -40,7 +40,7 @@ jobs:
       run: scripts/qa/lint-d-ts.sh packages/$PACKAGE
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-nlp-tests.yml
+++ b/.github/workflows/botonic-nlp-tests.yml
@@ -42,7 +42,7 @@ jobs:
         run: (cd ./packages/$PACKAGE && npm run lint)
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{env.PACKAGE}}

--- a/.github/workflows/botonic-nlu-tests.yml
+++ b/.github/workflows/botonic-nlu-tests.yml
@@ -45,7 +45,7 @@ jobs:
         files: ./packages/${{env.PACKAGE}}/junit.xml
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-contentful-tests.yml
+++ b/.github/workflows/botonic-plugin-contentful-tests.yml
@@ -42,7 +42,7 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run lint_ci)
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-dialogflow-tests.yml
+++ b/.github/workflows/botonic-plugin-dialogflow-tests.yml
@@ -45,7 +45,7 @@ jobs:
         files: ./packages/${{env.PACKAGE}}/junit.xml
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-dynamo-tests.yml
+++ b/.github/workflows/botonic-plugin-dynamo-tests.yml
@@ -51,7 +51,7 @@ jobs:
       run: (cd ./packages/$PACKAGE && npm run test)
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-intent-classification-tests.yml
+++ b/.github/workflows/botonic-plugin-intent-classification-tests.yml
@@ -45,7 +45,7 @@ jobs:
           files: ./packages/${{env.PACKAGE}}/junit.xml
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-ner-tests.yml
+++ b/.github/workflows/botonic-plugin-ner-tests.yml
@@ -45,7 +45,7 @@ jobs:
           files: ./packages/${{env.PACKAGE}}/junit.xml
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-plugin-nlu-tests.yml
+++ b/.github/workflows/botonic-plugin-nlu-tests.yml
@@ -45,7 +45,7 @@ jobs:
         files: ./packages/${{env.PACKAGE}}/junit.xml
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/botonic-react-tests.yml
+++ b/.github/workflows/botonic-react-tests.yml
@@ -40,7 +40,7 @@ jobs:
       run: scripts/qa/lint-d-ts.sh ./packages/$PACKAGE
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

Since [codecov V1 will be deprecated,](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1) start using V2


## Approach taken / Explain the design

Update to v2 in all workflows



## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
