### PR TITLE
feat(core): Add plugins as an argument in pre and post calls of a plugin

### DIFF
--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -218,12 +218,16 @@ export interface BotResponse extends BotRequest {
   messageEvents: Partial<BotonicEvent>[] | null
 }
 
-export type PluginPreRequest = BotRequest
-export type PluginPostRequest = BotResponse
+export interface PluginPreRequest extends BotRequest {
+  plugins: Plugin[]
+}
+export interface PluginPostRequest extends BotResponse {
+  plugins: Plugin[]
+}
 
 export interface Plugin {
-  post(_: PluginPostRequest): void
-  pre(pluginRequest: PluginPreRequest): void
+  post(request: PluginPostRequest): void
+  pre(request: PluginPreRequest): void
 }
 
 export interface Params {

--- a/packages/botonic-core/src/plugins.ts
+++ b/packages/botonic-core/src/plugins.ts
@@ -35,7 +35,7 @@ export async function runPlugins(
     const p = await plugins[key]
     try {
       if (mode === 'pre')
-        await p.pre({ input, session, lastRoutePath, dataProvider })
+        await p.pre({ input, session, lastRoutePath, dataProvider, plugins })
       if (mode === 'post')
         await p.post({
           input,
@@ -44,6 +44,7 @@ export async function runPlugins(
           response,
           messageEvents,
           dataProvider,
+          plugins,
         })
     } catch (e) {
       console.log(e)


### PR DESCRIPTION
## Description
Add all initialized plugins as an extra argument in `pre` and `post` calls of the plugins in `runPlugins` function.
Also, update declarations of `pre` and `post` functions.

## Context
In some situations it may be useful to use the initialized plugins inside a plugin instead of creating a new instance. This way we can take advantage of caches or initial processes of the plugins that are already done.

## Approach taken / Explain the design

## To document / Usage example

## Testing

The pull request has no tests.