### PR TITLE
feat(babel): Adapt Botonic Babel plugin to multiple intents #DAT-87

### DIFF
--- a/packages/botonic-plugin-hubtype-babel/README.md
+++ b/packages/botonic-plugin-hubtype-babel/README.md
@@ -21,10 +21,23 @@ Example of the same `input` object after being processed by this plugin:
 ```
 {
     "type": "text",
-    "data": "Where's my order?"
-    "intent": "order-location"
+    "data": "I want to talk with an agent"
+    "intent": "help"
     "confidence": 0.9987
-    "intents": []  // The raw response from Hubtype Babel API
+    "intents": [
+      {
+        "intent": "help",
+        "confidence": 0.9987
+      },
+      {
+        "intent": "greeting",
+        "confidence": 0.0010
+      },
+      {
+        "intent": "insult",
+        "confidence": 0.0003
+      }
+    ]
     "entities": []  // Currently not supported
 }
 ```

--- a/packages/botonic-plugin-hubtype-babel/src/index.ts
+++ b/packages/botonic-plugin-hubtype-babel/src/index.ts
@@ -40,8 +40,12 @@ export default class BotonicPluginHubtypeBabel implements Plugin {
         const text = request.input.data
         const response = await this.apiService.inference(text, authToken)
 
-        request.input.intent = response.data['label']
-        request.input.confidence = response.data['score']
+        request.input.intent = response.data['predictions'][0]['label']
+        request.input.confidence = response.data['predictions'][0]['confidence']
+        request.input.intents = response.data['predictions'].map(x => ({
+          intent: x['label'],
+          confidence: x['confidence'],
+        }))
       }
     } catch (e) {
       console.error('Error during inference with Hubtype Babel', e)


### PR DESCRIPTION
## Description
The Inference endpoint now returns all predicted intents with their corresponding confidences, so we need to readapt the `plugin-hubtype-babel` to:
- Correctly get the intent and confidence.
- Add all intents to request input.
