### PR TITLE
feat(core): Allow to set an auto idle message in Handoff Builder

### DIFF
--- a/packages/botonic-core/src/handoff.ts
+++ b/packages/botonic-core/src/handoff.ts
@@ -64,6 +64,7 @@ export class HandOffBuilder {
   _agentId: string
   _note: string
   _caseInfo: string
+  _autoIdleMessage: string
   _shadowing: boolean
 
   constructor(session: SessionWithBotonicAction) {
@@ -105,6 +106,11 @@ export class HandOffBuilder {
     return this
   }
 
+  withAutoIdleMessage(message: string): this {
+    this._autoIdleMessage = message
+    return this
+  }
+
   withShadowing(shadowing = true): this {
     this._shadowing = shadowing
     return this
@@ -119,6 +125,7 @@ export class HandOffBuilder {
       this._agentId,
       this._caseInfo,
       this._note,
+      this._autoIdleMessage,
       this._shadowing
     )
   }
@@ -150,6 +157,7 @@ interface HubtypeHandoffParams {
   agent_id?: string
   case_info?: string
   note?: string
+  auto_idle_message?: string
   shadowing?: boolean
   on_finish?: string
 }
@@ -161,6 +169,7 @@ async function _humanHandOff(
   agentId = '',
   caseInfo = '',
   note = '',
+  autoIdleMessage = '',
   shadowing = false
 ) {
   const params: HubtypeHandoffParams = {}
@@ -178,6 +187,9 @@ async function _humanHandOff(
   }
   if (note) {
     params.note = note
+  }
+  if (autoIdleMessage) {
+    params.auto_idle_message = autoIdleMessage
   }
   if (shadowing) {
     params.shadowing = shadowing

--- a/packages/botonic-core/tests/handoff.test.ts
+++ b/packages/botonic-core/tests/handoff.test.ts
@@ -2,7 +2,7 @@
 import { PATH_PAYLOAD_IDENTIFIER } from '../src'
 import { HandOffBuilder, humanHandOff } from '../src/handoff'
 
-describe('handOff', () => {
+describe('Handoff', () => {
   test.each([
     [
       `create_case:{
@@ -59,5 +59,18 @@ describe('handOff', () => {
   ])('HandOffBuilder', (expected, builder) => {
     builder.handOff()
     expect(builder._session._botonic_action).toEqual(expected)
+  })
+
+  test('receives the auto idle message', () => {
+    const builder = new HandOffBuilder({}).withAutoIdleMessage(
+      'the case is in IDLE status'
+    )
+    builder.handOff()
+    const expectedBotonicAction =
+      'create_case:' +
+      JSON.stringify({
+        auto_idle_message: 'the case is in IDLE status',
+      })
+    expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
   })
 })


### PR DESCRIPTION
## Description
Added a new function (`withAutoIdleMessage`) in `HandoffBuilder` in order to allow the developer to set the automatic message to be displayed once the case has been set to IDLE status.

## Context
A case is set to IDLE status if the user is not responding to the agent and we want to allow the bot to be able to set an automatic message to be displayed to the user once the case is set to IDLE so the user will be notified about the status change and the agent can be focused in other cases meanwhile.

## Approach taken / Explain the design


## To document / Usage example
`new HandoffBuilder(session).withAutoIdleMessage('messate to be displayed in IDLE status')`

## Testing

The pull request has unit tests.