### PR TITLE
feat(react): Allow user input preprocess in blockInputs

### DIFF
--- a/packages/botonic-core/src/core-bot.ts
+++ b/packages/botonic-core/src/core-bot.ts
@@ -17,7 +17,7 @@ import { BotonicOutputParser } from './output-parser'
 import { loadPlugins, runPlugins } from './plugins'
 import { getComputedRoutes, Router } from './routing'
 
-interface CoreBotConfig {
+export interface CoreBotConfig {
   appId?: string
   defaultDelay?: number
   defaultRoutes?: Route[]

--- a/packages/botonic-react/src/components/index.d.ts
+++ b/packages/botonic-react/src/components/index.d.ts
@@ -102,7 +102,11 @@ export interface PersistentMenuProps {
   options: any
 }
 
-export type BlockInputOption = { match: RegExp[]; message: string }
+export type BlockInputOption = {
+  preprocess?: (message: string) => string
+  match: RegExp[]
+  message: string
+}
 
 export interface BlobProps {
   blobTick?: boolean

--- a/packages/botonic-react/src/index.d.ts
+++ b/packages/botonic-react/src/index.d.ts
@@ -25,10 +25,6 @@ export interface Route extends core.Route {
 }
 type Routes = core.Routes<Route>
 
-export interface BotOptions extends core.BotOptions {
-  routes: Routes
-}
-
 export class ReactBot extends core.CoreBot {
   renderReactActions({
     actions,
@@ -37,7 +33,7 @@ export class ReactBot extends core.CoreBot {
 }
 
 export class NodeApp {
-  constructor(options: Omit<BotOptions, 'renderer'>)
+  constructor(options: Omit<core.CoreBotConfig, 'renderer'>)
   bot: ReactBot
   input(request: core.BotRequest): Promise<BotResponse>
   renderNode(args): string

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -405,9 +405,13 @@ export const Webchat = forwardRef((props, ref) => {
   )
 
   const getBlockInputs = (rule, inputData) => {
+    const processedInput = rule.preprocess
+      ? rule.preprocess(inputData)
+      : inputData
+
     return rule.match.some(regex => {
       if (typeof regex === 'string') regex = deserializeRegex(regex)
-      return regex.test(inputData)
+      return regex.test(processedInput)
     })
   }
 


### PR DESCRIPTION
## Description
Allow user input preprocess in the `blockInputs` configuration in order to sanitize the user input if needed.

Also, removed `BotOptions` interface to use `CoreBotConfig` instead.

## Context
Some text detection through regular expressions are easier if you can remove certain characters from the text before searching for matches (for example phone or credit card numbers)

## Approach taken / Explain the design
Added a `preprocess` attribute in `blockInputs` option in webchat configuration that will be executed before doing the matches of the regular expressions to detect blocking words.

## To document / Usage example

## Testing

The pull request has no tests.