### PR TITLE
chore(core/react): bump versions to 0.20.3

### DIFF
--- a/packages/botonic-core/package-lock.json
+++ b/packages/botonic-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1503,9 +1503,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "fs-readdir-recursive": {
       "version": "1.1.0",

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1215,9 +1215,9 @@
       }
     },
     "@botonic/core": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.20.2.tgz",
-      "integrity": "sha512-cl1Ifxac10IELMMWR1Co3K4cKqOi6HvthDsHAuYjnD0pJ0e8m1hKh+/IJ5xqCE9pyna/Wh5FM8vBycygPjY2GQ==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.20.3.tgz",
+      "integrity": "sha512-aif7IDsG7mpxk1OYymye2F0lbNH4FRht8H9ehejihlHuH+xY7bkwfAzV7EEpwuukcCEN5LkHAjTyhlzsy2Q7SA==",
       "requires": {
         "aws-sdk": "^2.997.0",
         "axios": "^0.24.0",
@@ -1472,9 +1472,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1078.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1078.0.tgz",
-      "integrity": "sha512-eJuiiCE4tomYzsxqfsjERmQ1WQkNAe5RUhOXUwJbGTEfwmbiQqq/HgVYrwcMswOHoURbtKpB5SSrTLNOBuyurA==",
+      "version": "2.1080.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1080.0.tgz",
+      "integrity": "sha512-CI3ovrQ7WarYuSliDCihpA5w+LoBWEvgBayRMgrZzGmAIEP9pNtXYWQ/wSjVYOyYtU1ilOFyhQBNExX3Kz1pXw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@botonic/core": "^0.20.2",
+    "@botonic/core": "^0.20.3",
     "axios": "^0.24.0",
     "emoji-picker-react": "^3.2.3",
     "framer-motion": "^3.1.1",


### PR DESCRIPTION
## Description
Bump `@botonic/react` and `@botonic/core` packages to version `0.20.3` to englobe these changes:
- Fixed class names for buttons (#2220)
- User input preprocess in BlockInputs (#2219)
- Set auto idle message in HandoffBuilder (#2218)

## Context
Publish new patch version `0.20.3` for `@botonic/core` and `@botonic/react`

## Approach taken / Explain the design


## To document / Usage example

## Testing

The pull request has no tests.