### PR TITLE
feat(core): Handoff improvements (autoAssignOnWaiting and forceAssignIfNotAvailable)

### DIFF
--- a/packages/botonic-core/src/handoff.ts
+++ b/packages/botonic-core/src/handoff.ts
@@ -183,7 +183,7 @@ async function _humanHandOff(
   onFinish: string,
   agentEmail = '',
   agentId = '',
-  forceAssignIfNotAvailable: boolean,
+  forceAssignIfNotAvailable = true,
   autoAssignOnWaiting = false,
   caseInfo = '',
   note = '',
@@ -191,6 +191,9 @@ async function _humanHandOff(
   shadowing = false
 ) {
   const params: HubtypeHandoffParams = {}
+
+  params.force_assign_if_not_available = forceAssignIfNotAvailable
+
   if (queueNameOrId) {
     params.queue = queueNameOrId
   }
@@ -199,9 +202,6 @@ async function _humanHandOff(
   }
   if (agentId) {
     params.agent_id = agentId
-  }
-  if (forceAssignIfNotAvailable !== undefined) {
-    params.force_assign_if_not_available = forceAssignIfNotAvailable
   }
   if (autoAssignOnWaiting) {
     params.auto_assign_on_waiting = autoAssignOnWaiting

--- a/packages/botonic-core/src/handoff.ts
+++ b/packages/botonic-core/src/handoff.ts
@@ -63,6 +63,7 @@ export class HandOffBuilder {
   _email: string
   _agentId: string
   _forceAssignIfNotAvailable: boolean
+  _autoAssignOnWaiting: boolean
   _note: string
   _caseInfo: string
   _autoIdleMessage: string
@@ -102,6 +103,11 @@ export class HandOffBuilder {
     return this
   }
 
+  withAutoAssignOnWaiting(autoAssignOnWaiting: boolean): this {
+    this._autoAssignOnWaiting = autoAssignOnWaiting
+    return this
+  }
+
   withNote(note: string): this {
     this._note = note
     return this
@@ -130,6 +136,7 @@ export class HandOffBuilder {
       this._email,
       this._agentId,
       this._forceAssignIfNotAvailable,
+      this._autoAssignOnWaiting,
       this._caseInfo,
       this._note,
       this._autoIdleMessage,
@@ -163,6 +170,7 @@ interface HubtypeHandoffParams {
   agent_email?: string
   agent_id?: string
   force_assign_if_not_available?: boolean
+  auto_assign_on_waiting?: boolean
   case_info?: string
   note?: string
   auto_idle_message?: string
@@ -176,6 +184,7 @@ async function _humanHandOff(
   agentEmail = '',
   agentId = '',
   forceAssignIfNotAvailable: boolean,
+  autoAssignOnWaiting = false,
   caseInfo = '',
   note = '',
   autoIdleMessage = '',
@@ -193,6 +202,9 @@ async function _humanHandOff(
   }
   if (forceAssignIfNotAvailable !== undefined) {
     params.force_assign_if_not_available = forceAssignIfNotAvailable
+  }
+  if (autoAssignOnWaiting) {
+    params.auto_assign_on_waiting = autoAssignOnWaiting
   }
   if (caseInfo) {
     params.case_info = caseInfo

--- a/packages/botonic-core/src/handoff.ts
+++ b/packages/botonic-core/src/handoff.ts
@@ -62,6 +62,7 @@ export class HandOffBuilder {
   _onFinish: string
   _email: string
   _agentId: string
+  _forceAssignIfNotAvailable: boolean
   _note: string
   _caseInfo: string
   _autoIdleMessage: string
@@ -96,6 +97,11 @@ export class HandOffBuilder {
     return this
   }
 
+  withForceAssignIfNotAvailable(forceAssign: boolean): this {
+    this._forceAssignIfNotAvailable = forceAssign
+    return this
+  }
+
   withNote(note: string): this {
     this._note = note
     return this
@@ -123,6 +129,7 @@ export class HandOffBuilder {
       this._onFinish,
       this._email,
       this._agentId,
+      this._forceAssignIfNotAvailable,
       this._caseInfo,
       this._note,
       this._autoIdleMessage,
@@ -155,6 +162,7 @@ interface HubtypeHandoffParams {
   queue?: string
   agent_email?: string
   agent_id?: string
+  force_assign_if_not_available?: boolean
   case_info?: string
   note?: string
   auto_idle_message?: string
@@ -167,6 +175,7 @@ async function _humanHandOff(
   onFinish: string,
   agentEmail = '',
   agentId = '',
+  forceAssignIfNotAvailable: boolean,
   caseInfo = '',
   note = '',
   autoIdleMessage = '',
@@ -181,6 +190,9 @@ async function _humanHandOff(
   }
   if (agentId) {
     params.agent_id = agentId
+  }
+  if (forceAssignIfNotAvailable !== undefined) {
+    params.force_assign_if_not_available = forceAssignIfNotAvailable
   }
   if (caseInfo) {
     params.case_info = caseInfo

--- a/packages/botonic-core/tests/handoff.test.ts
+++ b/packages/botonic-core/tests/handoff.test.ts
@@ -75,7 +75,7 @@ describe('Handoff', () => {
   })
 
   test.each([undefined, true, false])(
-    'sends the force assign if not available parameter',
+    'sends the force_assign_if_not_available parameter',
     (forceAssign: boolean | undefined) => {
       const builder = new HandOffBuilder({}).withForceAssignIfNotAvailable(
         forceAssign
@@ -87,6 +87,19 @@ describe('Handoff', () => {
           : {
               force_assign_if_not_available: forceAssign,
             }
+      const expectedBotonicAction = 'create_case:' + JSON.stringify(params)
+      expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
+    }
+  )
+
+  test.each([undefined, true, false])(
+    'sends the auto_assign_on_waiting parameter',
+    (autoAssignOnWaiting: boolean | undefined) => {
+      const builder = new HandOffBuilder({}).withAutoAssignOnWaiting(
+        autoAssignOnWaiting
+      )
+      builder.handOff()
+      const params = autoAssignOnWaiting ? { auto_assign_on_waiting: true } : {}
       const expectedBotonicAction = 'create_case:' + JSON.stringify(params)
       expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
     }

--- a/packages/botonic-core/tests/handoff.test.ts
+++ b/packages/botonic-core/tests/handoff.test.ts
@@ -73,4 +73,22 @@ describe('Handoff', () => {
       })
     expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
   })
+
+  test.each([undefined, true, false])(
+    'sends the force assign if not available parameter',
+    (forceAssign: boolean | undefined) => {
+      const builder = new HandOffBuilder({}).withForceAssignIfNotAvailable(
+        forceAssign
+      )
+      builder.handOff()
+      const params =
+        forceAssign === undefined
+          ? {}
+          : {
+              force_assign_if_not_available: forceAssign,
+            }
+      const expectedBotonicAction = 'create_case:' + JSON.stringify(params)
+      expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
+    }
+  )
 })

--- a/packages/botonic-core/tests/handoff.test.ts
+++ b/packages/botonic-core/tests/handoff.test.ts
@@ -6,6 +6,7 @@ describe('Handoff', () => {
   test.each([
     [
       `create_case:{
+        "force_assign_if_not_available":true,
         "queue":"q1",
         "on_finish":"payload1"
        }`,
@@ -14,6 +15,7 @@ describe('Handoff', () => {
     ],
     [
       `create_case:{
+        "force_assign_if_not_available":true,
         "on_finish":"${PATH_PAYLOAD_IDENTIFIER}path1"
        }`,
       '',
@@ -29,6 +31,7 @@ describe('Handoff', () => {
     [
       `create_case:` +
         JSON.stringify({
+          force_assign_if_not_available: true,
           queue: 'q1',
           agent_email: 'email1',
           case_info: '{}{:::: m"ho menjo tot}',
@@ -45,6 +48,7 @@ describe('Handoff', () => {
     [
       `create_case:` +
         JSON.stringify({
+          force_assign_if_not_available: true,
           on_finish: `${PATH_PAYLOAD_IDENTIFIER}path1`,
         }),
       new HandOffBuilder({}).withOnFinishPath('path1'),
@@ -52,6 +56,7 @@ describe('Handoff', () => {
     [
       `create_case:` +
         JSON.stringify({
+          force_assign_if_not_available: true,
           agent_id: '1234',
         }),
       new HandOffBuilder({}).withAgentId('1234'),
@@ -69,6 +74,7 @@ describe('Handoff', () => {
     const expectedBotonicAction =
       'create_case:' +
       JSON.stringify({
+        force_assign_if_not_available: true,
         auto_idle_message: 'the case is in IDLE status',
       })
     expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
@@ -77,17 +83,15 @@ describe('Handoff', () => {
   test.each([undefined, true, false])(
     'sends the force_assign_if_not_available parameter',
     (forceAssign: boolean | undefined) => {
-      const builder = new HandOffBuilder({}).withForceAssignIfNotAvailable(
-        forceAssign
-      )
+      const builder =
+        forceAssign !== undefined
+          ? new HandOffBuilder({}).withForceAssignIfNotAvailable(forceAssign)
+          : new HandOffBuilder({})
+      const value = forceAssign ?? true
       builder.handOff()
-      const params =
-        forceAssign === undefined
-          ? {}
-          : {
-              force_assign_if_not_available: forceAssign,
-            }
-      const expectedBotonicAction = 'create_case:' + JSON.stringify(params)
+      const expectedBotonicAction =
+        'create_case:' +
+        JSON.stringify({ force_assign_if_not_available: value })
       expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
     }
   )
@@ -95,11 +99,15 @@ describe('Handoff', () => {
   test.each([undefined, true, false])(
     'sends the auto_assign_on_waiting parameter',
     (autoAssignOnWaiting: boolean | undefined) => {
-      const builder = new HandOffBuilder({}).withAutoAssignOnWaiting(
-        autoAssignOnWaiting
-      )
+      const builder =
+        autoAssignOnWaiting !== undefined
+          ? new HandOffBuilder({}).withAutoAssignOnWaiting(autoAssignOnWaiting)
+          : new HandOffBuilder({})
       builder.handOff()
-      const params = autoAssignOnWaiting ? { auto_assign_on_waiting: true } : {}
+      const defaultParams = { force_assign_if_not_available: true }
+      const params = autoAssignOnWaiting
+        ? { ...defaultParams, auto_assign_on_waiting: true }
+        : defaultParams
       const expectedBotonicAction = 'create_case:' + JSON.stringify(params)
       expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
     }


### PR DESCRIPTION
## Description
Added 2 new functions in `HandoffBuilder`:
- `withForceAssignIfNotAvailable`: `True` by default. Allow to not assign the case (and set it in waiting status) to the selected agent if he is not available.
- `withAutoAssignOnWaiting`: `False` by default. Allow to assign the case automatically to an agent when the case is in the waiting queue.

## Context
We want to be able to:
- Not assign cases to away/busy agents (`forceAssignIfNotAvailable`)
- Allow the agents to not assign the cases in waiting queue manually and let the system assign them automatically.

## Approach taken / Explain the design


## To document / Usage example
- `forceAssignIfNotAvailable`: `new HandoffBuilder(session).withForceAssignIfNotAvailable(false)`
- `autoAssignOnWaiting`: `new HandoffBuilder(session).withAutoAssignOnWaiting(true)`

## Testing

The pull request has unit tests.