### PR TITLE
chore(ci): fix failing pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,8 +134,8 @@ repos:
         language: system
         files: ^packages/botonic-plugin-intent-classification/
 
-  - repo: git://github.com/Yelp/detect-secrets
-    rev: v1.1.0
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.2.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline','--exclude-files ', .*/tests/.*'] 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.2.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

Fix failing pre-commit config for [yelp's detect-secrets
](https://github.com/Yelp/detect-secrets)
## Context

Current config is failing because github is not accepting cloning repos with  `git:/...`

## Approach taken / Explain the design

Use https to clone detect-secrets repo in .pre-commit-config.yaml

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
