### PR TITLE
feat(plugin-contentful): add document as a followup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,7 +122,7 @@ repos:
         language: system
         files: ^packages/botonic-plugin-intent-classification/
 
-  - repo: git://github.com/Yelp/detect-secrets
+  - repo: https://github.com/Yelp/detect-secrets
     rev: v1.1.0
     hooks:
       - id: detect-secrets

--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.19.1-alpha.1",
+  "version": "0.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -17,7 +17,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.19.1-alpha.1",
+  "version": "0.20.1",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/botonic-plugin-contentful/src/cms/transform/message-content-filters.ts
+++ b/packages/botonic-plugin-contentful/src/cms/transform/message-content-filters.ts
@@ -4,6 +4,7 @@
 import {
   Button,
   Carousel,
+  Document,
   Element,
   Image,
   MessageContent,
@@ -26,6 +27,7 @@ export type FilterByMessageContentType = {
   video?: MessageContentFilter<Video>
   startUp?: MessageContentFilter<StartUp>
   text?: MessageContentFilter<Text>
+  document?: MessageContentFilter<Document>
 }
 
 export function enableDependingOnContext(
@@ -44,6 +46,7 @@ export function enableDependingOnContext(
     video: filter(inFilter.video),
     startUp: filter(inFilter.startUp),
     text: filter(inFilter.text),
+    document: filter(inFilter.document),
   }
 }
 
@@ -89,6 +92,11 @@ export class RecursiveMessageContentFilter {
     }
     if (content instanceof Video) {
       return this.filters.video && (await this.filters.video(content, context))
+    }
+    if (content instanceof Document) {
+      return (
+        this.filters.document && (await this.filters.document(content, context))
+      )
     }
     throw new CmsException(`Type '${content.contentType}' not supported`)
   }

--- a/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/cms-contentful.ts
@@ -123,7 +123,8 @@ export class Contentful implements cms.CMS {
       this._text,
       this._image,
       this._startUp,
-      this._video
+      this._video,
+      this._document
     )
     ;[
       this._document,

--- a/packages/botonic-plugin-contentful/src/contentful/contents/follow-up.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/follow-up.ts
@@ -14,6 +14,7 @@ import { ImageDelivery, ImageFields } from './image'
 import { StartUpDelivery, StartUpFields } from './startup'
 import { TextDelivery, TextFields } from './text'
 import { VideoDelivery, VideoFields } from './video'
+import { DocumentDelivery, DocumentFields } from './document'
 
 export class DeliveryWithFollowUp extends TopContentDelivery {
   followUp: FollowUpDelivery | undefined
@@ -39,7 +40,8 @@ export class FollowUpDelivery {
     private readonly text: TextDelivery,
     private readonly image: ImageDelivery,
     private readonly startUp: StartUpDelivery,
-    private readonly video: VideoDelivery
+    private readonly video: VideoDelivery,
+    private readonly document: DocumentDelivery
   ) {}
 
   async fromEntry(
@@ -79,6 +81,12 @@ export class FollowUpDelivery {
         return this.startUp.fromEntry(followUp as Entry<StartUpFields>, context)
       case cms.ContentType.VIDEO:
         return this.video.fromEntry(followUp as Entry<VideoFields>, context)
+      case cms.ContentType.DOCUMENT:
+        return this.document.fromEntry(
+          followUp as Entry<DocumentFields>,
+          context
+        )
+
       default:
         throw new Error(`Unexpected followUp type ${followUp.sys.type}`)
     }

--- a/packages/botonic-plugin-contentful/src/contentful/contents/follow-up.ts
+++ b/packages/botonic-plugin-contentful/src/contentful/contents/follow-up.ts
@@ -10,11 +10,11 @@ import {
   FollowUpFields,
 } from '../delivery-utils'
 import { CarouselDelivery } from './carousel'
+import { DocumentDelivery, DocumentFields } from './document'
 import { ImageDelivery, ImageFields } from './image'
 import { StartUpDelivery, StartUpFields } from './startup'
 import { TextDelivery, TextFields } from './text'
 import { VideoDelivery, VideoFields } from './video'
-import { DocumentDelivery, DocumentFields } from './document'
 
 export class DeliveryWithFollowUp extends TopContentDelivery {
   followUp: FollowUpDelivery | undefined

--- a/packages/botonic-plugin-contentful/src/render/botonic-converter.ts
+++ b/packages/botonic-plugin-contentful/src/render/botonic-converter.ts
@@ -195,6 +195,8 @@ export class BotonicMsgConverter {
       return this.video(followUp)
     } else if (followUp instanceof cms.StartUp) {
       return this.startUp(followUp)
+    } else if (followUp instanceof cms.Document) {
+      return this.document(followUp)
     } else {
       throw new Error('Unexpected followUp type ' + typeof followUp)
     }


### PR DESCRIPTION
## Description
Allow document content model to be used as a followup.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
Document content model was not allowed as a followup.
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- doesn't need tests
