### PR TITLE
refactor(react): Allow storage other than localStorage and sessionStorage

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -2578,11 +2578,6 @@
         "prop-types": "^15.6.0"
       }
     },
-    "react-use-storage": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/react-use-storage/-/react-use-storage-0.5.1.tgz",
-      "integrity": "sha512-CUIjDuTZzJU5jpzdLuR+1uGwqQ6CnjbJYJf5eDBT5AdhHEQMSNbBAEjbN9ZculWQPiw0t5S3vyF0qoZnq7eweg=="
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.20.5",
+  "version": "0.20.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1215,9 +1215,9 @@
       }
     },
     "@botonic/core": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.20.3.tgz",
-      "integrity": "sha512-aif7IDsG7mpxk1OYymye2F0lbNH4FRht8H9ehejihlHuH+xY7bkwfAzV7EEpwuukcCEN5LkHAjTyhlzsy2Q7SA==",
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.20.5.tgz",
+      "integrity": "sha512-m3Yk8VlEKvirnvftV4KSwso2qGyO/qhIp2wIoXxF/07JCU0uZJrlV1iEkXv7nuXUG9F5pteIQoNsmFYSPbvXow==",
       "requires": {
         "aws-sdk": "^2.997.0",
         "axios": "^0.24.0",
@@ -1472,9 +1472,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1080.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1080.0.tgz",
-      "integrity": "sha512-CI3ovrQ7WarYuSliDCihpA5w+LoBWEvgBayRMgrZzGmAIEP9pNtXYWQ/wSjVYOyYtU1ilOFyhQBNExX3Kz1pXw==",
+      "version": "2.1172.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1172.0.tgz",
+      "integrity": "sha512-B3NXD1ZLfwj8oDavb3GTUkDvCioWbRrf01nNkPvdTpoMBQCGw4elTuvG7ZQ114v5V2XWMxpu+SKMkcxALHEd6Q==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -1483,14 +1483,14 @@
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.3.2",
+        "uuid": "8.0.0",
         "xml2js": "0.4.19"
       },
       "dependencies": {
         "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
         }
       }
     },
@@ -1797,7 +1797,7 @@
     "decode": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/decode/-/decode-0.3.0.tgz",
-      "integrity": "sha1-4A4S0/qy1ZsfFg1x51FHS8sZZL8=",
+      "integrity": "sha512-EObmIlvteR80byfLOe5S6XsxD1HFs0kDUVaQ+9pSj3o/gnzPh6YB86iXEZLj2ShALRF6N6fSIRjAFv5sKp6evg==",
       "requires": {
         "kung-fu": "^0.2.0"
       }
@@ -1858,7 +1858,7 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
     },
     "extend-shallow": {
       "version": "2.0.1",
@@ -2038,9 +2038,9 @@
       }
     },
     "html-entities": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
-      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -2128,7 +2128,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "jmespath": {
       "version": "0.16.0",
@@ -2157,7 +2157,7 @@
     "kung-fu": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/kung-fu/-/kung-fu-0.2.1.tgz",
-      "integrity": "sha1-HGZJKLCVZOk7mhPms9cgBw+itEk="
+      "integrity": "sha512-aVHQku/PdKruvKwQ5r8zsCtIPeNz3nwM+o1RPoS+jR7rdE6mCla5GVIqSCWJ8ATYlajaAmaMh/qxczFQ//MW8g=="
     },
     "linkify-it": {
       "version": "3.0.3",
@@ -2273,9 +2273,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node-json-db": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/node-json-db/-/node-json-db-1.4.1.tgz",
-      "integrity": "sha512-hyfnBtuN3kb88SMmDgVil53Frygx+yYkVi6t10VjpEsPseuMI8+gT+FF37DOcyGCr/1wq6qNIr5PnFimCDlzfA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-json-db/-/node-json-db-1.6.0.tgz",
+      "integrity": "sha512-Cpvuqejlx354aH5d1uqK9KB0/LOKslnexqgOrhgCqcvvzJ0I2hrAEA7eIct6hRqS9gxnuge+eXqd++za87tchA==",
       "requires": {
         "mkdirp": "~1.0.4"
       }
@@ -2428,7 +2428,7 @@
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "pusher-js": {
       "version": "5.1.1",
@@ -2453,7 +2453,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
     "react": {
       "version": "16.14.0",
@@ -2689,7 +2689,7 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "scheduler": {
       "version": "0.19.1",
@@ -2881,7 +2881,7 @@
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -2920,7 +2920,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
     }
   }
 }

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.20.5",
+  "version": "0.20.7",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@botonic/core": "^0.20.3",
+    "@botonic/core": "^0.20.5",
     "axios": "^0.24.0",
     "emoji-picker-react": "^3.2.3",
     "framer-motion": "^3.1.1",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -43,7 +43,6 @@
     "react-reveal": "^1.2.2",
     "react-router-dom": "^5.2.1",
     "react-textarea-autosize": "^7.1.2",
-    "react-use-storage": "^0.5.1",
     "reconnecting-websocket": "^4.4.0",
     "simplebar-react": "^2.3.3",
     "styled-components": "^5.3.0",

--- a/packages/botonic-react/src/webchat/use-storage-state-hook.js
+++ b/packages/botonic-react/src/webchat/use-storage-state-hook.js
@@ -1,9 +1,44 @@
-import { useLocalStorage, useSessionStorage } from 'react-use-storage'
+import { useCallback, useEffect, useState } from 'react'
 
-export function useStorageState(storage, storageKey) {
-  const [botonicLocalState, saveLocalState] = useLocalStorage(storageKey)
-  const [botonicSessionState, saveSessionState] = useSessionStorage(storageKey)
-  if (storage === null) return [undefined, undefined]
-  if (storage === sessionStorage) return [botonicSessionState, saveSessionState]
-  return [botonicLocalState, saveLocalState]
+//Code taken from https://github.com/leny/react-use-storage
+const evtTarget = new EventTarget()
+
+export function useStorageState(storage, key, defaultValue) {
+  const raw = storage?.getItem(key)
+
+  const [value, setValue] = useState(raw ? JSON.parse(raw) : defaultValue)
+
+  const updater = useCallback(
+    (updatedValue, remove = false) => {
+      setValue(updatedValue)
+      storage[remove ? 'removeItem' : 'setItem'](
+        key,
+        JSON.stringify(updatedValue)
+      )
+      evtTarget.dispatchEvent(
+        new CustomEvent('storage_change', { detail: { key } })
+      )
+    },
+    [key]
+  )
+
+  defaultValue != null && !raw && updater(defaultValue)
+
+  useEffect(() => {
+    const listener = ({ detail }) => {
+      if (detail.key === key) {
+        const lraw = storage?.getItem(key)
+
+        lraw !== raw && setValue(JSON.parse(lraw))
+      }
+    }
+
+    evtTarget.addEventListener('storage_change', listener)
+    return () => evtTarget.removeEventListener('storage_change', listener)
+  })
+
+  if (storage === null) {
+    return [undefined, undefined]
+  }
+  return [value, updater, () => updater(null, true)]
 }

--- a/packages/botonic-react/tests/helpers/in-memory-storage.js
+++ b/packages/botonic-react/tests/helpers/in-memory-storage.js
@@ -1,0 +1,27 @@
+export class InMemoryStorage {
+  items
+
+  constructor() {
+    this.items = {}
+  }
+
+  clear() {
+    this.items = {}
+  }
+
+  getItem(key) {
+    return this.items[key] ?? null
+  }
+
+  key(index) {
+    return Object.keys(this.items)[index] ?? null
+  }
+
+  removeItem(key) {
+    delete this.items[key]
+  }
+
+  setItem(key, value) {
+    this.items[key] = value
+  }
+}

--- a/packages/botonic-react/tests/webchat/storage.test.jsx
+++ b/packages/botonic-react/tests/webchat/storage.test.jsx
@@ -3,6 +3,7 @@ import TestRenderer, { act } from 'react-test-renderer'
 
 import { WEBCHAT } from '../../src/constants'
 import { Webchat } from '../../src/webchat/webchat'
+import { InMemoryStorage } from '../helpers/in-memory-storage'
 
 describe('TEST: storage', () => {
   afterEach(() => {
@@ -54,6 +55,23 @@ describe('TEST: storage', () => {
     })
     expect(localStorage.getItem('botonicState')).toBeNull()
     expect(sessionStorage.getItem('botonicState')).not.toBeNull()
+  })
+
+  it('Stores botonicState in the memory storage', async () => {
+    const inMemoryStorage = new InMemoryStorage()
+    await act(async () => {
+      TestRenderer.create(
+        <Webchat
+          storage={inMemoryStorage}
+          storageKey={WEBCHAT.DEFAULTS.STORAGE_KEY}
+        />
+      )
+    })
+    const botonicState = JSON.parse(inMemoryStorage.getItem('botonicState'))
+    expect(localStorage.getItem('botonicState')).toBeNull()
+    expect(sessionStorage.getItem('botonicState')).toBeNull()
+    expect(botonicState).not.toBeNull()
+    expect(botonicState).toHaveProperty('messages', [])
   })
 
   it('Does not store botonicState', async () => {


### PR DESCRIPTION
## Description
Refactor the `useStorageState` function to be more flexible and allow other types of storage than `localStorage` and `sessionStorage`.

## Context
There was no possibility to create a custom in-memory storage for Botonic.

## Approach taken / Explain the design
Instead of using the `useLocalStorage` and `useSessionStorage` hooks from [react-use-storage](https://github.com/leny/react-use-storage) package we've copied the `useStorage` function of this same package to be more flexible and allow other type of storages.

## To document / Usage example

## Testing

The pull request has unit tests.