### PR TITLE
Feature: Add host variable to plugin-hubtype-babel options #DAT-340

### DIFF
--- a/packages/botonic-plugin-hubtype-babel/package.json
+++ b/packages/botonic-plugin-hubtype-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-hubtype-babel",
-  "version": "0.20.4",
+  "version": "0.20.5-alpha.0",
   "license": "MIT",
   "description": "Use Hubtype Babel to predict Intents.",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-plugin-hubtype-babel/src/hubtype-babel-api-service.ts
+++ b/packages/botonic-plugin-hubtype-babel/src/hubtype-babel-api-service.ts
@@ -1,14 +1,15 @@
 import axios from 'axios'
 
 export class HubtypeBabelApiService {
-  private readonly HOST = 'https://api.hubtype.com'
-
-  constructor(readonly projectId: string) {}
+  constructor(
+    readonly projectId: string,
+    readonly host: string = 'https://api.hubtype.com'
+  ) {}
 
   async inference(text: string, accessToken: string) {
     return await axios({
       method: 'POST',
-      url: `${this.HOST}/v1/babel/projects/${this.projectId}/inference/`,
+      url: `${this.host}/v1/babel/projects/${this.projectId}/inference/`,
       headers: {
         Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json',

--- a/packages/botonic-plugin-hubtype-babel/src/index.ts
+++ b/packages/botonic-plugin-hubtype-babel/src/index.ts
@@ -13,7 +13,10 @@ export default class BotonicPluginHubtypeBabel implements Plugin {
   private readonly apiService: HubtypeBabelApiService
 
   constructor(private readonly options: PluginOptions) {
-    this.apiService = new HubtypeBabelApiService(options.projectId)
+    this.apiService = new HubtypeBabelApiService(
+      options.projectId,
+      options.host
+    )
   }
 
   async pre(request: PluginPreRequest): Promise<void> {

--- a/packages/botonic-plugin-hubtype-babel/src/options.ts
+++ b/packages/botonic-plugin-hubtype-babel/src/options.ts
@@ -1,4 +1,5 @@
 export interface PluginOptions {
   projectId: string
   authToken?: string
+  host?: string
 }


### PR DESCRIPTION
## Description

Now host where to run inference can be defined on `plugin-hubtype-babel` options.

## Context

Before this change, the plugin was always running inference on production. We also want to try the plugin in other environments.

## Approach taken / Explain the design

Defined an optional variable that allows that indicates the host where to run inference. If not defined the host used would be https://api.hubtype.com (production environment). 
