### PR TITLE
Fixing Image previewer

### DIFF
--- a/packages/botonic-react/src/components/image.jsx
+++ b/packages/botonic-react/src/components/image.jsx
@@ -31,7 +31,6 @@ export const Image = props => {
     null
   )
   if (isBrowser()) {
-    console.log(ImagePreviewer)
     content = (
       <>
         <StyledImage

--- a/packages/botonic-react/src/components/image.jsx
+++ b/packages/botonic-react/src/components/image.jsx
@@ -26,25 +26,27 @@ export const Image = props => {
   const closePreviewer = () => setIsPreviewerOpened(false)
 
   const { getThemeProperty } = useContext(WebchatContext)
-  const imagePreviewer = getThemeProperty(
+  const ImagePreviewer = getThemeProperty(
     WEBCHAT.CUSTOM_PROPERTIES.imagePreviewer,
     null
   )
   if (isBrowser()) {
+    console.log(ImagePreviewer)
     content = (
       <>
         <StyledImage
           src={props.src}
           onClick={openPreviewer}
-          hasPreviewer={Boolean(imagePreviewer)}
+          hasPreviewer={Boolean(ImagePreviewer)}
         />
-        {imagePreviewer &&
-          imagePreviewer({
-            src: props.src,
-            isPreviewerOpened,
-            openPreviewer,
-            closePreviewer,
-          })}
+        {ImagePreviewer && (
+          <ImagePreviewer
+            src={props.src}
+            isPreviewerOpened={isPreviewerOpened}
+            openPreviewer={openPreviewer}
+            closePreviewer={closePreviewer}
+          />
+        )}
       </>
     )
   }


### PR DESCRIPTION
## Description

In order to be able to display in full size an image shared within the webchat an image previewer was implemented in Botonic in order to display a modal in the middle of the screen with the image once it was clicked.

The problem is that when we tried the full solution we were getting an error of "Invalid hook call" (https://reactjs.org/warnings/invalid-hook-call-warning.html)

## Approach taken / Explain the design

What is happening because we are calling the image previewer as a function instead of as a component.

## To document / Usage example

Clicking on an image in the Bot opens a pop up with the image where we can zoom in and out, click outside the image to close the pop up or through the top bar with menus. 
