### PR TITLE
feat(react): Wrap all message buttons into a div

### DIFF
--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -313,7 +313,9 @@ export const Message = props => {
               ) : (
                 <BlobText blob={blob}>{textChildren}</BlobText>
               )}
-              {buttons}
+              {!!buttons.length && (
+                <div className='message-buttons-container'>{buttons}</div>
+              )}
               {Boolean(blob) && hasBlobTick() && getBlobTick(6)}
               {Boolean(blob) && hasBlobTick() && getBlobTick(5)}
             </Blob>


### PR DESCRIPTION
## Description
Wrap all `<button>` elements of a message within a `<div>` element.

## Context
All message buttons are rendered as `<button>` elements alongside the `<div>` element of the message content, and to be able to apply styles to all buttons as a block (not only to the button element) a wrapper element is needed.

## Approach taken / Explain the design
Add the class `botonic-buttons-container` to this new wrapper `div` to be able to change its style easily.

## To document / Usage example

## Testing

The pull request has no tests.