### PR TITLE
add two missing packages

### DIFF
--- a/docs/docs/create-convapp.md
+++ b/docs/docs/create-convapp.md
@@ -170,7 +170,7 @@ export const routes = [
 
 ## Add NLU
 
-1. In the bot directory, enter `npm install @botonic/plugin-nlu`.
+1. In the bot directory, enter `npm install @botonic/plugin-nlu @botonic/plugin-ner @botonic/plugin-intent-classification`.
 
 2. Create two types of `intents`, i.e. two text files called `chitchat.txt` and `help.txt` in `src/nlu/utterances/en` containing utterances related to an intent. You must create at least **two files** to make the NLU plugin work.
 


### PR DESCRIPTION
## Description
Add **Missing Two missing packages** in Create a Conversational App from Scratch
It leads to error when try `botonic train` so we can install these packages at once 
fixes #2261 
## Context
So when someone Add NLU from Create a Conversational App from Scratch **_Documentation_** then they not lead any error

## Approach taken / Explain the design

I added those packages which are required when you try botonic train


## To document / Usage example

Before
`npm install @botonic/plugin-nlu `

After
`npm install @botonic/plugin-nlu @botonic/plugin-ner @botonic/plugin-intent-classification`

## Testing

The pull request...

- doesn't need tests because... **Its a Documentation update**
