### PR TITLE
feat(core): Add Contact Message Event type

### DIFF
--- a/packages/botonic-core/package-lock.json
+++ b/packages/botonic-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-core/src/models/events/message/contact.ts
+++ b/packages/botonic-core/src/models/events/message/contact.ts
@@ -1,0 +1,8 @@
+import { BotonicMessageEvent } from './message-event'
+
+export interface ContactMessageEvent extends BotonicMessageEvent {
+  phone_number: string
+  first_name: string
+  last_name: string
+  vcard: any
+}

--- a/packages/botonic-core/src/models/events/message/message-event.ts
+++ b/packages/botonic-core/src/models/events/message/message-event.ts
@@ -14,7 +14,7 @@ export enum MessageEventTypes {
   MISSED = 'missed',
   FORM = 'form',
   /**
-   * TODO: contact, buttonmessage?, webchatsettings, whatsapp template
+   * TODO: buttonmessage?, webchatsettings, whatsapp template
    */
 }
 

--- a/packages/botonic-core/src/models/events/message/message-event.ts
+++ b/packages/botonic-core/src/models/events/message/message-event.ts
@@ -3,6 +3,7 @@ import { BaseEvent } from '../base-event'
 export enum MessageEventTypes {
   AUDIO = 'audio',
   CAROUSEL = 'carousel',
+  CONTACT = 'contact',
   CUSTOM = 'custom',
   DOCUMENT = 'document',
   IMAGE = 'image',

--- a/packages/botonic-core/src/output-parser/factory.ts
+++ b/packages/botonic-core/src/output-parser/factory.ts
@@ -16,7 +16,6 @@ import {
 
 export class MessageParsingFactory {
   parse(msgToParse: any): Partial<BotonicEvent> {
-    console.log('msgToParse', msgToParse)
     const type = msgToParse.type
     const parsedMessage = parseMessage({ toParse: msgToParse })
     if (MEDIA_TYPES.includes(type)) {

--- a/packages/botonic-core/src/output-parser/factory.ts
+++ b/packages/botonic-core/src/output-parser/factory.ts
@@ -2,6 +2,7 @@ import { BotonicEvent, MEDIA_TYPES, MessageEventTypes } from '../models'
 import {
   parseButtons,
   parseCarousel,
+  parseContact,
   parseCustom,
   parseForm,
   parseLocation,
@@ -15,6 +16,7 @@ import {
 
 export class MessageParsingFactory {
   parse(msgToParse: any): Partial<BotonicEvent> {
+    console.log('msgToParse', msgToParse)
     const type = msgToParse.type
     const parsedMessage = parseMessage({ toParse: msgToParse })
     if (MEDIA_TYPES.includes(type)) {
@@ -34,6 +36,8 @@ export class MessageParsingFactory {
         return parseCustom(parseReplies(parsedMessage)).parsed
       case MessageEventTypes.FORM:
         return parseForm(parsedMessage).parsed
+      case MessageEventTypes.CONTACT:
+        return parseContact(parsedMessage).parsed
       case MessageEventTypes.MISSED:
         return parseMissed(parsedMessage).parsed
     }

--- a/packages/botonic-core/src/output-parser/parsers.ts
+++ b/packages/botonic-core/src/output-parser/parsers.ts
@@ -18,6 +18,7 @@ import {
   WithButtons,
   WithReplies,
 } from '../models'
+import { ContactMessageEvent } from '../models/events/message/contact'
 import { TEXT_NODE_NAME } from './botonic-output-parser'
 
 export function parseNumber(strNumber: string): number {
@@ -220,6 +221,20 @@ export const parseForm: ParseFunction<FormMessageEvent> = args => {
       ...args.parsed,
       form_title: args.toParse.form_title,
       form_answers: args.toParse.form_answers,
+    },
+  }
+}
+
+// CONTACT
+export const parseContact: ParseFunction<ContactMessageEvent> = args => {
+  return {
+    toParse: args.toParse,
+    parsed: {
+      ...args.parsed,
+      phone_number: args.toParse.phone_number,
+      first_name: args.toParse.first_name,
+      last_name: args.toParse.last_name,
+      vcard: args.toParse.vcard,
     },
   }
 }

--- a/packages/botonic-core/tests/parsing/contact.test.tsx
+++ b/packages/botonic-core/tests/parsing/contact.test.tsx
@@ -1,0 +1,25 @@
+import { BotonicOutputParserTester } from '../helpers/parsing'
+
+const tester = new BotonicOutputParserTester()
+describe('Parsing Contact responses', () => {
+  it.only('TEST: Contact', () => {
+    const botResponse = `
+    <message typing="0" delay="0" markdown="1" type="contact" phone_number="34654321000" first_name="Test" last_name="Tester" vcard=null></message>
+`
+    const expected = [
+      {
+        ack: undefined,
+        from: undefined,
+        typing: 0,
+        delay: 0,
+        eventType: 'message',
+        type: 'contact',
+        phone_number: '34654321000',
+        first_name: 'Test',
+        last_name: 'Tester',
+        vcard: undefined,
+      },
+    ]
+    tester.parseResponseAndAssert(botResponse, expected)
+  })
+})


### PR DESCRIPTION
## Description
Add a new Message Event Type for Contact messages (comming from WhatsApp channel for example).

Bump version to `0.21.2`.

## Context
The MessageParsingFactory was throwing an error for Contact messages because were unknown by the parser.

## Approach taken / Explain the design

## To document / Usage example

## Testing

The pull request has unit tests.