### PR TITLE
Feat: custom user input buttons

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.21.0",
+  "version": "0.21.2-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.21.2-alpha.0",
+  "version": "0.21.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.21.2-alpha.0",
+  "version": "0.21.2",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.21.0",
+  "version": "0.21.2-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "src/index.js",
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@botonic/core": "0.21.0",
+    "@botonic/core": "~0.21.0",
     "axios": "^0.24.0",
     "emoji-picker-react": "^3.2.3",
     "framer-motion": "^3.1.1",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -10,6 +10,7 @@
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepare": "node ../../preinstall.js",
     "build": "rm -rf lib && babel src --out-dir lib --source-maps --copy-files",
+    "build:watch": "npm run build -- --watch",
     "lint": "npm run lint_core -- --fix",
     "lint_ci": "npm run lint_core",
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' '*.js' 'src/**/*.js*' 'src/**/*.d.ts' 'tests/**/*.js' 'tests/**/*.jsx'"

--- a/packages/botonic-react/src/components/index.d.ts
+++ b/packages/botonic-react/src/components/index.d.ts
@@ -174,10 +174,10 @@ export interface ThemeProps extends StyleProp {
   markdownStyle?: string // string template with css styles
   scrollbar?: ScrollbarProps & EnableProp
   userInput?: {
-    attachments?: EnableProp
+    attachments?: EnableProp & CustomProp
     blockInputs?: BlockInputOption[]
     box?: { placeholder: string } & StyleProp
-    emojiPicker?: EnableProp
+    emojiPicker?: EnableProp & CustomProp
     menu?: { darkBackground?: boolean } & {
       custom?: React.ComponentType<PersistentMenuProps>
     }

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -130,6 +130,8 @@ export const WEBCHAT = {
     documentDownload: 'documentDownload',
     customMenuButton: 'userInput.menuButton.custom',
     customPersistentMenu: 'userInput.menu.custom',
+    customEmojiPicker: 'userInput.emojiPicker.custom',
+    customAttachments: 'userInput.attachments.custom',
     customSendButton: 'userInput.sendButton.custom',
     darkBackgroundMenu: 'userInput.menu.darkBackground',
     enableAttachments: 'userInput.attachments.enable',

--- a/packages/botonic-react/src/webchat/components/attachment.jsx
+++ b/packages/botonic-react/src/webchat/components/attachment.jsx
@@ -1,21 +1,34 @@
-import React from 'react'
+import React, { useContext } from 'react'
 
 import AttachmentIcon from '../../assets/attachment-icon.svg'
-import { ROLES } from '../../constants'
+import { ROLES, WEBCHAT } from '../../constants'
+import { WebchatContext } from '../../contexts'
 import { Icon, IconContainer } from './common'
 
-export const Attachment = ({ onChange, accept }) => (
-  <IconContainer role={ROLES.ATTACHMENT_ICON}>
-    <label htmlFor='attachment' style={{ marginTop: 4 }}>
-      <Icon src={AttachmentIcon} />
-    </label>
-    <input
-      type='file'
-      name='file'
-      id='attachment'
-      style={{ display: 'none' }}
-      onChange={onChange}
-      accept={accept}
-    ></input>
-  </IconContainer>
-)
+export const Attachment = ({ onChange, accept, customAttacments }) => {
+  const { getThemeProperty } = useContext(WebchatContext)
+
+  const CustomAttachments = getThemeProperty(
+    WEBCHAT.CUSTOM_PROPERTIES.customAttachments,
+    undefined
+  )
+  return (
+    <IconContainer role={ROLES.ATTACHMENT_ICON}>
+      <label htmlFor='attachment' style={{ marginTop: 4 }}>
+        {CustomAttachments ? (
+          <CustomAttachments />
+        ) : (
+          <Icon src={AttachmentIcon} />
+        )}
+      </label>
+      <input
+        type='file'
+        name='file'
+        id='attachment'
+        style={{ display: 'none' }}
+        onChange={onChange}
+        accept={accept}
+      />
+    </IconContainer>
+  )
+}

--- a/packages/botonic-react/src/webchat/components/attachment.jsx
+++ b/packages/botonic-react/src/webchat/components/attachment.jsx
@@ -3,32 +3,51 @@ import React, { useContext } from 'react'
 import AttachmentIcon from '../../assets/attachment-icon.svg'
 import { ROLES, WEBCHAT } from '../../constants'
 import { WebchatContext } from '../../contexts'
-import { Icon, IconContainer } from './common'
+import { ConditionalAnimation } from '../components/conditional-animation'
+import { Icon } from './common'
 
-export const Attachment = ({ onChange, accept, customAttacments }) => {
+export const Attachment = ({ onChange, accept, enableAttachments }) => {
   const { getThemeProperty } = useContext(WebchatContext)
 
   const CustomAttachments = getThemeProperty(
     WEBCHAT.CUSTOM_PROPERTIES.customAttachments,
     undefined
   )
+
+  const isAttachmentsEnabled = () => {
+    const hasCustomAttachments = !!CustomAttachments
+    return (
+      getThemeProperty(
+        WEBCHAT.CUSTOM_PROPERTIES.enableAttachments,
+        enableAttachments
+      ) ?? hasCustomAttachments
+    )
+  }
+  const attachmentsEnabled = isAttachmentsEnabled()
+
   return (
-    <IconContainer role={ROLES.ATTACHMENT_ICON}>
-      <label htmlFor='attachment' style={{ marginTop: 4 }}>
-        {CustomAttachments ? (
-          <CustomAttachments />
-        ) : (
-          <Icon src={AttachmentIcon} />
-        )}
-      </label>
-      <input
-        type='file'
-        name='file'
-        id='attachment'
-        style={{ display: 'none' }}
-        onChange={onChange}
-        accept={accept}
-      />
-    </IconContainer>
+    <>
+      {attachmentsEnabled ? (
+        <ConditionalAnimation>
+          <div role={ROLES.ATTACHMENT_ICON}>
+            <label htmlFor='attachment' style={{ marginTop: 4 }}>
+              {CustomAttachments ? (
+                <CustomAttachments />
+              ) : (
+                <Icon src={AttachmentIcon} />
+              )}
+            </label>
+            <input
+              type='file'
+              name='file'
+              id='attachment'
+              style={{ display: 'none' }}
+              onChange={onChange}
+              accept={accept}
+            />
+          </div>
+        </ConditionalAnimation>
+      ) : null}
+    </>
   )
 }

--- a/packages/botonic-react/src/webchat/components/common.jsx
+++ b/packages/botonic-react/src/webchat/components/common.jsx
@@ -7,9 +7,3 @@ const PointerImage = styled.img`
   cursor: pointer;
 `
 export const Icon = props => <PointerImage src={resolveImage(props.src)} />
-
-export const IconContainer = styled.div`
-  display: flex;
-  align-items: center;
-  padding-right: 15px;
-`

--- a/packages/botonic-react/src/webchat/components/conditional-animation.jsx
+++ b/packages/botonic-react/src/webchat/components/conditional-animation.jsx
@@ -1,0 +1,25 @@
+import { motion } from 'framer-motion'
+import React, { useContext } from 'react'
+
+import { WEBCHAT } from '../../constants'
+import { WebchatContext } from '../../contexts'
+import { ConditionalWrapper } from '../../util/react'
+
+export const ConditionalAnimation = props => {
+  const { getThemeProperty } = useContext(WebchatContext)
+
+  const animationsEnabled = getThemeProperty(
+    WEBCHAT.CUSTOM_PROPERTIES.enableAnimations,
+    props.enableAnimations !== undefined ? props.enableAnimations : true
+  )
+  return (
+    <ConditionalWrapper
+      condition={animationsEnabled}
+      wrapper={children => (
+        <motion.div whileHover={{ scale: 1.2 }}>{children}</motion.div>
+      )}
+    >
+      {props.children}
+    </ConditionalWrapper>
+  )
+}

--- a/packages/botonic-react/src/webchat/components/emoji-picker.jsx
+++ b/packages/botonic-react/src/webchat/components/emoji-picker.jsx
@@ -5,10 +5,11 @@ import styled from 'styled-components'
 import LogoEmoji from '../../assets/emojiButton.svg'
 import { ROLES, WEBCHAT } from '../../constants'
 import { WebchatContext } from '../../contexts'
+import { ConditionalAnimation } from '../components/conditional-animation'
 import { useComponentVisible } from '../hooks'
-import { Icon, IconContainer } from './common'
+import { Icon } from './common'
 
-export const EmojiPicker = props => {
+export const EmojiPicker = ({ enableEmojiPicker, onClick }) => {
   const { getThemeProperty } = useContext(WebchatContext)
 
   const CustomEmojiPicker = getThemeProperty(
@@ -16,17 +17,36 @@ export const EmojiPicker = props => {
     undefined
   )
 
-  const onClick = event => {
-    props.onClick()
+  const isEmojiPickerEnabled = () => {
+    const hasCustomEmojiPicker = !!CustomEmojiPicker
+    return (
+      getThemeProperty(
+        WEBCHAT.CUSTOM_PROPERTIES.enableEmojiPicker,
+        enableEmojiPicker
+      ) ?? hasCustomEmojiPicker
+    )
+  }
+  const emojiPickerEnabled = isEmojiPickerEnabled()
+
+  const handleClick = event => {
+    onClick()
     event.stopPropagation()
   }
 
   return (
-    <IconContainer role={ROLES.EMOJI_PICKER_ICON}>
-      <div onClick={onClick}>
-        {CustomEmojiPicker ? <CustomEmojiPicker /> : <Icon src={LogoEmoji} />}
-      </div>
-    </IconContainer>
+    <>
+      {emojiPickerEnabled ? (
+        <ConditionalAnimation>
+          <div role={ROLES.EMOJI_PICKER_ICON} onClick={handleClick}>
+            {CustomEmojiPicker ? (
+              <CustomEmojiPicker />
+            ) : (
+              <Icon src={LogoEmoji} />
+            )}
+          </div>
+        </ConditionalAnimation>
+      ) : null}
+    </>
   )
 }
 

--- a/packages/botonic-react/src/webchat/components/emoji-picker.jsx
+++ b/packages/botonic-react/src/webchat/components/emoji-picker.jsx
@@ -1,13 +1,21 @@
 import Picker from 'emoji-picker-react'
-import React from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
 
 import LogoEmoji from '../../assets/emojiButton.svg'
-import { ROLES } from '../../constants'
+import { ROLES, WEBCHAT } from '../../constants'
+import { WebchatContext } from '../../contexts'
 import { useComponentVisible } from '../hooks'
 import { Icon, IconContainer } from './common'
 
 export const EmojiPicker = props => {
+  const { getThemeProperty } = useContext(WebchatContext)
+
+  const CustomEmojiPicker = getThemeProperty(
+    WEBCHAT.CUSTOM_PROPERTIES.customEmojiPicker,
+    undefined
+  )
+
   const onClick = event => {
     props.onClick()
     event.stopPropagation()
@@ -16,7 +24,7 @@ export const EmojiPicker = props => {
   return (
     <IconContainer role={ROLES.EMOJI_PICKER_ICON}>
       <div onClick={onClick}>
-        <Icon src={LogoEmoji} />
+        {CustomEmojiPicker ? <CustomEmojiPicker /> : <Icon src={LogoEmoji} />}
       </div>
     </IconContainer>
   )

--- a/packages/botonic-react/src/webchat/components/persistent-menu.jsx
+++ b/packages/botonic-react/src/webchat/components/persistent-menu.jsx
@@ -5,6 +5,7 @@ import LogoMenu from '../../assets/menuButton.svg'
 import { Button } from '../../components/button'
 import { ROLES, WEBCHAT } from '../../constants'
 import { WebchatContext } from '../../contexts'
+import { ConditionalAnimation } from '../components/conditional-animation'
 import { useComponentVisible } from '../hooks'
 import { Icon } from './common'
 
@@ -59,17 +60,30 @@ export const OpenedPersistentMenu = ({ onClick, options, borderRadius }) => {
   )
 }
 
-const IconContainer = styled.div`
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  padding: 18px;
-`
+export const PersistentMenu = ({ onClick, persistentMenu }) => {
+  const { getThemeProperty } = useContext(WebchatContext)
 
-export const PersistentMenu = props => (
-  <IconContainer role={ROLES.PERSISTENT_MENU_ICON} onClick={props.onClick}>
-    <Icon src={LogoMenu} />
-  </IconContainer>
-)
+  const persistentMenuOptions = getThemeProperty(
+    WEBCHAT.CUSTOM_PROPERTIES.persistentMenu,
+    persistentMenu
+  )
+
+  const CustomMenuButton = getThemeProperty(
+    WEBCHAT.CUSTOM_PROPERTIES.customMenuButton,
+    undefined
+  )
+
+  return (
+    <>
+      {persistentMenuOptions ? (
+        <ConditionalAnimation>
+          <div role={ROLES.PERSISTENT_MENU_ICON} onClick={onClick}>
+            {CustomMenuButton ? <CustomMenuButton /> : <Icon src={LogoMenu} />}
+          </div>
+        </ConditionalAnimation>
+      ) : null}
+    </>
+  )
+}
 
 export default OpenedPersistentMenu

--- a/packages/botonic-react/src/webchat/components/send-button.jsx
+++ b/packages/botonic-react/src/webchat/components/send-button.jsx
@@ -1,11 +1,37 @@
-import React from 'react'
+import React, { useContext } from 'react'
 
 import SendButtonIcon from '../../assets/send-button.svg'
-import { ROLES } from '../../constants'
-import { Icon, IconContainer } from './common'
+import { ROLES, WEBCHAT } from '../../constants'
+import { WebchatContext } from '../../contexts'
+import { ConditionalAnimation } from '../components/conditional-animation'
+import { Icon } from './common'
 
-export const SendButton = () => (
-  <IconContainer role={ROLES.SEND_BUTTON_ICON}>
-    <Icon src={SendButtonIcon} />
-  </IconContainer>
-)
+export const SendButton = ({ onClick }) => {
+  const { getThemeProperty } = useContext(WebchatContext)
+
+  const sendButtonEnabled = getThemeProperty(
+    WEBCHAT.CUSTOM_PROPERTIES.enableSendButton,
+    true
+  )
+
+  const CustomSendButton = getThemeProperty(
+    WEBCHAT.CUSTOM_PROPERTIES.customSendButton,
+    undefined
+  )
+
+  return (
+    <>
+      {sendButtonEnabled || CustomSendButton ? (
+        <ConditionalAnimation>
+          <div onClick={onClick} role={ROLES.SEND_BUTTON_ICON}>
+            {CustomSendButton ? (
+              <CustomSendButton />
+            ) : (
+              <Icon src={SendButtonIcon} />
+            )}
+          </div>
+        </ConditionalAnimation>
+      ) : null}
+    </>
+  )
+}

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -789,8 +789,8 @@ export const Webchat = forwardRef((props, ref) => {
   }
   const emojiPickerEnabled = isEmojiPickerEnabled()
 
-  const isAttacmentsEnabled = () => {
-    const hasCustomAttacments = !!getThemeProperty(
+  const isAttachmentsEnabled = () => {
+    const hasCustomAttachments = !!getThemeProperty(
       WEBCHAT.CUSTOM_PROPERTIES.customAttachments,
       props.enableAttachments
     )
@@ -798,10 +798,10 @@ export const Webchat = forwardRef((props, ref) => {
       getThemeProperty(
         WEBCHAT.CUSTOM_PROPERTIES.enableAttachments,
         props.enableAttachments
-      ) ?? hasCustomAttacments
+      ) ?? hasCustomAttachments
     )
   }
-  const attachmentsEnabled = isAttacmentsEnabled()
+  const attachmentsEnabled = isAttachmentsEnabled()
 
   const sendButtonEnabled = getThemeProperty(
     WEBCHAT.CUSTOM_PROPERTIES.enableSendButton,

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -39,7 +39,6 @@ import {
 import { msgToBotonic } from '../msg-to-botonic'
 import { scrollToBottom } from '../util/dom'
 import { isDev, resolveImage } from '../util/environment'
-import { ConditionalWrapper } from '../util/react'
 import { deserializeRegex, stringifyWithRegexs } from '../util/regexs'
 import {
   _getThemeProperty,
@@ -106,8 +105,13 @@ const StyledTriggerButton = styled.div`
 
 const UserInputContainer = styled.div`
   min-height: 52px;
-  display: flex;
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 16px;
+  padding: 0px 16px;
+  z-index: 1;
   border-top: 1px solid ${COLORS.SOLID_BLACK_ALPHA_0_5};
 `
 
@@ -115,13 +119,6 @@ const TextAreaContainer = styled.div`
   display: flex;
   flex: 1 1 auto;
   align-items: center;
-`
-
-const FeaturesWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1;
 `
 
 const TriggerImage = styled.img`
@@ -402,10 +399,6 @@ export const Webchat = forwardRef((props, ref) => {
     toggleEmojiPicker(!webchatState.isEmojiPickerOpen)
   }
 
-  const animationsEnabled = getThemeProperty(
-    WEBCHAT.CUSTOM_PROPERTIES.enableAnimations,
-    props.enableAnimations !== undefined ? props.enableAnimations : true
-  )
   const persistentMenuOptions = getThemeProperty(
     WEBCHAT.CUSTOM_PROPERTIES.persistentMenu,
     props.persistentMenu
@@ -775,59 +768,6 @@ export const Webchat = forwardRef((props, ref) => {
 
   const userInputEnabled = isUserInputEnabled()
 
-  const isEmojiPickerEnabled = () => {
-    const hasCustomEmojiPicker = !!getThemeProperty(
-      WEBCHAT.CUSTOM_PROPERTIES.customEmojiPicker,
-      props.enableEmojiPicker
-    )
-    return (
-      getThemeProperty(
-        WEBCHAT.CUSTOM_PROPERTIES.enableEmojiPicker,
-        props.enableEmojiPicker
-      ) ?? hasCustomEmojiPicker
-    )
-  }
-  const emojiPickerEnabled = isEmojiPickerEnabled()
-
-  const isAttachmentsEnabled = () => {
-    const hasCustomAttachments = !!getThemeProperty(
-      WEBCHAT.CUSTOM_PROPERTIES.customAttachments,
-      props.enableAttachments
-    )
-    return (
-      getThemeProperty(
-        WEBCHAT.CUSTOM_PROPERTIES.enableAttachments,
-        props.enableAttachments
-      ) ?? hasCustomAttachments
-    )
-  }
-  const attachmentsEnabled = isAttachmentsEnabled()
-
-  const sendButtonEnabled = getThemeProperty(
-    WEBCHAT.CUSTOM_PROPERTIES.enableSendButton,
-    true
-  )
-
-  const CustomSendButton = getThemeProperty(
-    WEBCHAT.CUSTOM_PROPERTIES.customSendButton,
-    undefined
-  )
-  const CustomMenuButton = getThemeProperty(
-    WEBCHAT.CUSTOM_PROPERTIES.customMenuButton,
-    undefined
-  )
-
-  const ConditionalAnimation = props => (
-    <ConditionalWrapper
-      condition={animationsEnabled}
-      wrapper={children => (
-        <motion.div whileHover={{ scale: 1.2 }}>{children}</motion.div>
-      )}
-    >
-      {props.children}
-    </ConditionalWrapper>
-  )
-
   const userInputArea = () => {
     return (
       userInputEnabled && (
@@ -844,15 +784,12 @@ export const Webchat = forwardRef((props, ref) => {
               onClick={handleEmojiClick}
             />
           )}
-          {persistentMenuOptions && (
-            <FeaturesWrapper>
-              <ConditionalAnimation>
-                <div onClick={handleMenu}>
-                  {CustomMenuButton ? <CustomMenuButton /> : <PersistentMenu />}
-                </div>
-              </ConditionalAnimation>
-            </FeaturesWrapper>
-          )}
+
+          <PersistentMenu
+            onClick={handleMenu}
+            persistentMenu={props.persistentMenu}
+          />
+
           <TextAreaContainer>
             <Textarea
               name='text'
@@ -887,28 +824,19 @@ export const Webchat = forwardRef((props, ref) => {
               }}
             />
           </TextAreaContainer>
-          <FeaturesWrapper>
-            {emojiPickerEnabled && (
-              <ConditionalAnimation>
-                <EmojiPicker onClick={handleEmojiClick} />
-              </ConditionalAnimation>
-            )}
-            {attachmentsEnabled && (
-              <ConditionalAnimation>
-                <Attachment
-                  onChange={handleAttachment}
-                  accept={getFullMimeWhitelist().join(',')}
-                />
-              </ConditionalAnimation>
-            )}
-            {(sendButtonEnabled || CustomSendButton) && (
-              <ConditionalAnimation>
-                <div onClick={sendTextAreaText}>
-                  {CustomSendButton ? <CustomSendButton /> : <SendButton />}
-                </div>
-              </ConditionalAnimation>
-            )}
-          </FeaturesWrapper>
+
+          <EmojiPicker
+            enableEmojiPicker={props.enableEmojiPicker}
+            onClick={handleEmojiClick}
+          />
+
+          <Attachment
+            enableAttachments={props.enableAttachments}
+            onChange={handleAttachment}
+            accept={getFullMimeWhitelist().join(',')}
+          />
+
+          <SendButton onClick={sendTextAreaText} />
         </UserInputContainer>
       )
     )

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -774,18 +774,40 @@ export const Webchat = forwardRef((props, ref) => {
   }
 
   const userInputEnabled = isUserInputEnabled()
-  const emojiPickerEnabled = getThemeProperty(
-    WEBCHAT.CUSTOM_PROPERTIES.enableEmojiPicker,
-    props.enableEmojiPicker
-  )
-  const attachmentsEnabled = getThemeProperty(
-    WEBCHAT.CUSTOM_PROPERTIES.enableAttachments,
-    props.enableAttachments
-  )
+
+  const isEmojiPickerEnabled = () => {
+    const hasCustomEmojiPicker = !!getThemeProperty(
+      WEBCHAT.CUSTOM_PROPERTIES.customEmojiPicker,
+      props.enableEmojiPicker
+    )
+    return (
+      getThemeProperty(
+        WEBCHAT.CUSTOM_PROPERTIES.enableEmojiPicker,
+        props.enableEmojiPicker
+      ) ?? hasCustomEmojiPicker
+    )
+  }
+  const emojiPickerEnabled = isEmojiPickerEnabled()
+
+  const isAttacmentsEnabled = () => {
+    const hasCustomAttacments = !!getThemeProperty(
+      WEBCHAT.CUSTOM_PROPERTIES.customAttachments,
+      props.enableAttachments
+    )
+    return (
+      getThemeProperty(
+        WEBCHAT.CUSTOM_PROPERTIES.enableAttachments,
+        props.enableAttachments
+      ) ?? hasCustomAttacments
+    )
+  }
+  const attachmentsEnabled = isAttacmentsEnabled()
+
   const sendButtonEnabled = getThemeProperty(
     WEBCHAT.CUSTOM_PROPERTIES.enableSendButton,
     true
   )
+
   const CustomSendButton = getThemeProperty(
     WEBCHAT.CUSTOM_PROPERTIES.customSendButton,
     undefined


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
This PR adds the feature to define in the bot the icons to send an emoji and attach a file as you can do with the send text button by declaring a custom component
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
I didn't want to modify more things but I think the css should also be refactored to reduce the number of nested divs with fixed paddings to separate the elements. As you can see in the image the custom buttons are not well aligned.
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example
Before change icons
![Captura de Pantalla 2023-03-15 a las 12 10 45](https://user-images.githubusercontent.com/36898236/225292210-b193e6f7-c5fa-49d5-8cfa-d6ab579cce98.png)
After change icons
![Captura de Pantalla 2023-03-15 a las 12 11 40](https://user-images.githubusercontent.com/36898236/225292477-1e019528-5af4-405d-ad30-cdcb6f61849e.png)

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->
You can define custom components for each button like this
![Captura de Pantalla 2023-03-15 a las 12 32 19](https://user-images.githubusercontent.com/36898236/225296815-b4ad301b-8e70-45c5-8f36-b7610cc3ef97.png)

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
