### PR TITLE
fix: when the same attachment is uploaded twice, the second one will not trigger the onChange event

### DIFF
--- a/packages/botonic-react/src/webchat/components/attachment.jsx
+++ b/packages/botonic-react/src/webchat/components/attachment.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useRef } from 'react'
 
 import AttachmentIcon from '../../assets/attachment-icon.svg'
 import { ROLES, WEBCHAT } from '../../constants'
@@ -8,6 +8,8 @@ import { Icon } from './common'
 
 export const Attachment = ({ onChange, accept, enableAttachments }) => {
   const { getThemeProperty } = useContext(WebchatContext)
+
+  const fileInputRef = useRef(null)
 
   const CustomAttachments = getThemeProperty(
     WEBCHAT.CUSTOM_PROPERTIES.customAttachments,
@@ -25,6 +27,11 @@ export const Attachment = ({ onChange, accept, enableAttachments }) => {
   }
   const attachmentsEnabled = isAttachmentsEnabled()
 
+  const handleOnChange = event => {
+    onChange(event)
+    fileInputRef.current.value = null
+  }
+
   return (
     <>
       {attachmentsEnabled ? (
@@ -38,11 +45,12 @@ export const Attachment = ({ onChange, accept, enableAttachments }) => {
               )}
             </label>
             <input
+              ref={fileInputRef}
               type='file'
               name='file'
               id='attachment'
               style={{ display: 'none' }}
-              onChange={onChange}
+              onChange={handleOnChange}
               accept={accept}
             />
           </div>


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
When the same attachment is uploaded twice, the second one will not trigger the `onChange` event
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

### Before
https://user-images.githubusercontent.com/86048542/236981295-c82db95e-7c65-49ad-9dae-03997ee107a4.mov

### After
https://user-images.githubusercontent.com/86048542/236982343-a2a43d1d-b56a-43e9-82f9-8bb3f03dd0f8.mov


## Approach taken / Explain the design
Solved it by emptying the input.value value
<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[very very minor changes]**
