### PR TITLE
Plugin flow builder: payloads

### DIFF
--- a/packages/botonic-plugin-flow-builder/package-lock.json
+++ b/packages/botonic-plugin-flow-builder/package-lock.json
@@ -167,11 +167,11 @@
       }
     },
     "@botonic/react": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@botonic/react/-/react-0.21.4.tgz",
-      "integrity": "sha512-cVVFhsZ41XzdjpZTqRp76rIQNbTrSq3/WIQGV5FvZFVh53of0Qq2dYdhQuClannUKq3gesVJlC7jcEYueZydEw==",
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/@botonic/react/-/react-0.21.6.tgz",
+      "integrity": "sha512-Cudv6boU3D0jtjgInWERpcUezMDK2IMRGdg0yGOy007vDW2APr3aoCw9oy9a7aGWa/pZhxkqz2Xt068G2RB5yw==",
       "requires": {
-        "@botonic/core": "~0.21.5",
+        "@botonic/core": "^0.21.6",
         "axios": "^0.24.0",
         "emoji-picker-react": "^3.2.3",
         "framer-motion": "^3.1.1",
@@ -184,14 +184,14 @@
         "react-frame-component": "^4.1.3",
         "react-json-tree": "^0.15.0",
         "react-reveal": "^1.2.2",
-        "react-router-dom": "^5.2.1",
+        "react-router-dom": "^5.3.4",
         "react-textarea-autosize": "^7.1.2",
         "reconnecting-websocket": "^4.4.0",
-        "simplebar-react": "^2.3.3",
+        "simplebar-react": "^2.4.3",
         "styled-components": "^5.3.0",
-        "ua-parser-js": "^0.7.21",
+        "ua-parser-js": "^0.8.1",
         "unescape": "^1.0.1",
-        "use-async-effect": "^2.2.3",
+        "use-async-effect": "^2.2.7",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -1225,9 +1225,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.35",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
-      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.8.1.tgz",
+      "integrity": "sha512-top37bpoaHp+wJBAqjm5KNz7qNfSZ/tmHEisuMMK5uzjdIo/L6uWovDFuYboO+q8EMz1f67exTnd+OPYESuu8Q=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -49,6 +49,6 @@
   "dependencies": {
     "@babel/runtime": "^7.21.0",
     "axios": "^1.3.6",
-    "@botonic/react": "^0.21.4"
+    "@botonic/react": "^0.21.6"
   }
 }

--- a/packages/botonic-plugin-flow-builder/src/functions/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/index.ts
@@ -5,5 +5,5 @@ export const DEFAULT_FUNCTIONS = {
   // TODO: Rename api action name
   // 'conditional-queue-status': conditionalQueueStatus,
   'check-queue-status': conditionalQueueStatus,
-  'conditional-provider': conditionalProvider,
+  'get-channel-type': conditionalProvider,
 }

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -26,9 +26,9 @@ import {
   StartNode,
 } from './flow-builder-models'
 import { DEFAULT_FUNCTIONS } from './functions'
+import { updateButtonUrls } from './helpers'
 import { BotonicPluginFlowBuilderOptions } from './types'
 import { resolveGetAccessToken } from './utils'
-import { updateButtonUrls } from './helpers'
 
 export default class BotonicPluginFlowBuilder implements Plugin {
   private flowUrl: string
@@ -129,6 +129,18 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     await updateButtonUrls(hubtypeContent, 'elements', this.getContent)
     await updateButtonUrls(hubtypeContent, 'buttons', this.getContent)
     const content = await this.getFlowContent(hubtypeContent, locale)
+
+    if (content && 'buttons' in content) {
+      content.buttons.forEach(async button => {
+        if (button.payload) {
+          const contentButton = await this.getContent(button.payload)
+          if (contentButton?.type === NodeType.PAYLOAD) {
+            button.payload = contentButton.content.payload
+          }
+        }
+      })
+    }
+
     if (hubtypeContent.type === NodeType.FUNCTION) {
       const targetId = await this.callFunction(hubtypeContent, locale)
       return this.getContents(targetId, locale, contents)

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -247,9 +247,6 @@ export default class BotonicPluginFlowBuilder implements Plugin {
         .find(arg => arg.locale === locale)
         ?.values.map(value => ({ [value.name]: value.value })) || []
 
-    // if (!nameValues) {
-    //   // throw new Error(`No arguments found for node with id ${functionNodeId}`)
-    // }
     const args = Object.assign(
       {
         session: this.currentRequest.session,

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -230,12 +230,14 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     locale: string
   ): Promise<string> {
     const functionNodeId = functionNode.id
-    const nameValues = functionNode.content.arguments
-      .find(arg => arg.locale === locale)
-      ?.values.map(value => ({ [value.name]: value.value }))
-    if (!nameValues) {
-      throw new Error(`No arguments found for node with id ${functionNodeId}`)
-    }
+    const nameValues =
+      functionNode.content.arguments
+        .find(arg => arg.locale === locale)
+        ?.values.map(value => ({ [value.name]: value.value })) || []
+
+    // if (!nameValues) {
+    //   // throw new Error(`No arguments found for node with id ${functionNodeId}`)
+    // }
     const args = Object.assign(
       {
         session: this.currentRequest.session,


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
This PR adds the logic to detect that a button is of type payload read the payload content and put the text defined as payload in the payload that the bot receives. 
This way for example we can make that after a Handoff a payload rating is sent and this executes an action of the bot that depends on the channel it will send a custom component (webchat) or if it is receiving the rating it will save it. It will also be used to open webviews (in whatsapp we will use tamplates as it is necessary to create a button with the webview attribute)
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
When you create a button in flow builder that has a payload, this is a content with a payload object and what was received in the bot was the id of this content
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
