### PR TITLE
Flow builder plugin: Fix url buttons + refactor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,6 +134,12 @@ repos:
         language: system
         files: ^packages/botonic-plugin-intent-classification/
 
+      - id: plugin-flow-builder
+        name: plugin-flow-builder
+        entry: scripts/qa/lint-package.sh packages/botonic-plugin-flow-builder
+        language: system
+        files: ^packages/botonic-plugin-flow-builder/
+
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0
     hooks:

--- a/packages/botonic-plugin-flow-builder/package-lock.json
+++ b/packages/botonic-plugin-flow-builder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-flow-builder/package-lock.json
+++ b/packages/botonic-plugin-flow-builder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.22.0-alpha.2",
+  "version": "0.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-flow-builder/package-lock.json
+++ b/packages/botonic-plugin-flow-builder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -288,9 +288,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
-      "version": "18.2.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.12.tgz",
-      "integrity": "sha512-ndmBMLCgn38v3SntMeoJaIrO6tGHYKMEBohCUmw8HoLLQdRMOIGXfeYaBTLe2lsFaSB3MOK1VXscYFnmLtTSmw==",
+      "version": "16.14.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.43.tgz",
+      "integrity": "sha512-7zdjv7jvoLLQg1tTvpQsm+hyNUMT2mPlNV1+d0I8fbGhkJl82spopMyBlu4wb1dviZAxpGdk5eHu/muacknnfw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -1211,12 +1211,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
-      "dev": true
     },
     "ua-parser-js": {
       "version": "0.8.1",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.22.0-alpha.2",
+  "version": "0.22.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -31,8 +31,7 @@
   "devDependencies": {
     "@types/minipass": "^3.3.5",
     "@types/node": "^18.16.0",
-    "@types/react": "^18.0.38",
-    "typescript": "^5.0.4"
+    "@types/react": "^16.14.43"
   },
   "keywords": [
     "bot-framework",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/action.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action.tsx
@@ -34,11 +34,7 @@ export class FlowBuilderAction extends React.Component<FlowBuilderActionProps> {
         request.input.data,
         locale
       )
-      if (intentNode) {
-        targetNode = intentNode
-      } else if (keywordNode) {
-        targetNode = keywordNode
-      }
+      targetNode = intentNode ?? keywordNode ?? targetNode
     }
 
     if (!targetNode) {
@@ -48,7 +44,7 @@ export class FlowBuilderAction extends React.Component<FlowBuilderActionProps> {
       alternateFallbackMessage = !alternateFallbackMessage
     }
 
-    const { contents, handoffNode } = await flowBuilderPlugin.getContent(
+    const { contents, handoffNode } = await flowBuilderPlugin.getContents(
       targetNode,
       locale
     )

--- a/packages/botonic-plugin-flow-builder/src/action.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action.tsx
@@ -2,6 +2,7 @@ import { ActionRequest, Multichannel, RequestContext } from '@botonic/react'
 import React from 'react'
 
 import { FlowContent } from './content-fields'
+import { HtNodeWithContent } from './content-fields/hubtype-fields'
 import { doHandoff } from './handoff'
 import { getFlowBuilderPlugin } from './helpers'
 
@@ -18,31 +19,37 @@ export class FlowBuilderAction extends React.Component<FlowBuilderActionProps> {
     const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)
     const locale = flowBuilderPlugin.getLocale(request.session)
     const payload = request.input.payload
-    let targetContentId: string | undefined = payload
+    let targetNode: HtNodeWithContent | string | undefined = payload
+
     if (!payload && request.session.is_first_interaction) {
-      targetContentId = await flowBuilderPlugin.getStartId()
+      targetNode = flowBuilderPlugin.cmsApi.getStartNode()
     }
-    if (!payload) {
-      const intentPayload = await flowBuilderPlugin.getPayloadByIntent(
+
+    if (!payload && request.input.data) {
+      const intentNode = flowBuilderPlugin.cmsApi.getNodeByIntent(
         request.input,
         locale
       )
-      if (intentPayload) targetContentId = intentPayload
-      const keywordPayload = await flowBuilderPlugin.getPayloadByKeyword(
-        request.input,
+      const keywordNode = flowBuilderPlugin.cmsApi.getNodeByKeyword(
+        request.input.data,
         locale
       )
-      if (keywordPayload) targetContentId = keywordPayload
+      if (intentNode) {
+        targetNode = intentNode
+      } else if (keywordNode) {
+        targetNode = keywordNode
+      }
     }
-    if (!targetContentId) {
-      targetContentId = await flowBuilderPlugin.getFallbackId(
+
+    if (!targetNode) {
+      targetNode = flowBuilderPlugin.cmsApi.getFallbackNode(
         alternateFallbackMessage
       )
       alternateFallbackMessage = !alternateFallbackMessage
     }
 
-    const { contents, handoffNode } = await flowBuilderPlugin.getContents(
-      targetContentId,
+    const { contents, handoffNode } = await flowBuilderPlugin.getContent(
+      targetNode,
       locale
     )
 

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -18,6 +18,8 @@ export class FlowBuilderApi {
   url: string
   flow: HtFlowBuilderData
 
+  private constructor() {}
+
   static async create(options: FlowBuilderApiOptions): Promise<FlowBuilderApi> {
     const newApi = new FlowBuilderApi()
 

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -1,0 +1,162 @@
+import { Input } from '@botonic/core'
+import axios from 'axios/index'
+
+import {
+  HtFallbackNode,
+  HtFlowBuilderData,
+  HtIntentNode,
+  HtKeywordNode,
+  HtNodeComponent,
+  HtNodeStartType,
+  HtNodeWithContent,
+  HtNodeWithContentType,
+  HtStartNode,
+} from './content-fields/hubtype-fields'
+import { FlowBuilderApiOptions } from './types'
+
+export class FlowBuilderApi {
+  private readonly url: string
+  public flow: HtFlowBuilderData
+
+  constructor(options: FlowBuilderApiOptions) {
+    this.url = options.url
+    if (options.flow) {
+      this.flow = options.flow
+    }
+  }
+
+  async init(token: string) {
+    const { data } = await axios.get(this.url, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    this.flow = data
+  }
+
+  getNode<T extends HtNodeComponent>(id: string): T {
+    const node = this.flow.nodes.find(node => node.id === id)
+    if (!node) throw Error(`Node with id: '${id}' not found`)
+    return node as T
+  }
+
+  getNodeByCode(code: string): HtNodeComponent {
+    const content = this.flow.nodes.find(node =>
+      'code' in node ? node.code === code : false
+    )
+    if (!content) throw Error(`Node with code: '${code}' not found`)
+    return content
+  }
+
+  getStartNode(): HtNodeWithContent {
+    const startUpNode = this.flow.nodes.find(
+      node => node.type === HtNodeStartType.STARTUP
+    ) as HtStartNode | undefined
+    if (!startUpNode) throw new Error('Start-up id must be defined')
+    return this.getNode(startUpNode.target.id)
+  }
+
+  getFallbackNode(alternate: boolean): HtNodeWithContent {
+    const fallbackNode = this.flow.nodes.find(
+      node => node.type === HtNodeWithContentType.FALLBACK
+    ) as HtFallbackNode | undefined
+    if (!fallbackNode) {
+      throw new Error('Fallback node must be defined')
+    }
+    const fallbackFirstMessage = fallbackNode.content.first_message
+    if (!fallbackFirstMessage) {
+      throw new Error('Fallback 1st message must be defined')
+    }
+    const fallbackSecondMessage = fallbackNode.content.second_message
+    if (!fallbackSecondMessage) {
+      return this.getNode(fallbackFirstMessage.id)
+    }
+    return alternate
+      ? this.getNode(fallbackFirstMessage.id)
+      : this.getNode(fallbackSecondMessage.id)
+  }
+
+  getNodeByIntent(input: Input, locale: string): HtNodeWithContent | undefined {
+    try {
+      const intents = this.flow.nodes.filter(
+        node => node.type === HtNodeWithContentType.INTENT
+      ) as HtIntentNode[]
+      const inputIntent = input.intent
+      const inputConfidence = input.confidence
+      if (inputIntent) {
+        const matchedIntentNode = intents.find(
+          node =>
+            inputIntent &&
+            this.hasIntent(node, inputIntent, locale) &&
+            inputConfidence &&
+            this.hasMetConfidenceThreshold(node, inputConfidence)
+        )
+        return (
+          matchedIntentNode?.target &&
+          this.getNode<HtNodeWithContent>(matchedIntentNode?.target.id)
+        )
+      }
+    } catch (error) {
+      console.error(`Error getting node by intent '${input.intent}': `, error)
+    }
+
+    return undefined
+  }
+
+  private hasIntent(
+    node: HtIntentNode,
+    intent: string,
+    locale: string
+  ): boolean {
+    return node.content.intents.some(
+      i => i.locale === locale && i.values.includes(intent)
+    )
+  }
+
+  private hasMetConfidenceThreshold(
+    node: HtIntentNode,
+    predictedConfidence: number
+  ): boolean {
+    const nodeConfidence = node.content.confidence / 100
+    return predictedConfidence >= nodeConfidence
+  }
+
+  getNodeByKeyword(
+    userInput: string,
+    locale: string
+  ): HtNodeWithContent | undefined {
+    try {
+      const keywordNodes = this.flow.nodes.filter(
+        node => node.type == HtNodeWithContentType.KEYWORD
+      ) as HtKeywordNode[]
+      const matchedKeywordNodes = keywordNodes.filter(node =>
+        this.matchKeywords(node, userInput, locale)
+      )
+      if (matchedKeywordNodes.length > 0 && matchedKeywordNodes[0].target) {
+        return this.getNode<HtNodeWithContent>(matchedKeywordNodes[0].target.id)
+      }
+    } catch (error) {
+      console.error(`Error getting node by keyword '${userInput}': `, error)
+    }
+
+    return undefined
+  }
+
+  private matchKeywords(
+    node: HtKeywordNode,
+    input: string,
+    locale: string
+  ): boolean {
+    const result = node.content.keywords.find(
+      i => i.locale === locale && this.containsAnyKeywords(input, i.values)
+    )
+    return Boolean(result)
+  }
+
+  private containsAnyKeywords(input: string, keywords: string[]): boolean {
+    for (let i = 0; i < keywords.length; i++) {
+      if (input.includes(keywords[i])) {
+        return true
+      }
+    }
+    return false
+  }
+}

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -1,5 +1,5 @@
 import { Input } from '@botonic/core'
-import axios from 'axios/index'
+import axios from 'axios'
 
 import {
   HtFallbackNode,

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
@@ -29,11 +29,11 @@ export class FlowButton extends ContentFieldsBase {
       newButton.payload = cmsButton.target.id
     }
     if (cmsButton.payload && payloadId) {
-      const payloadNode = cmsApi.getNode(payloadId) as HtPayloadNode
+      const payloadNode = cmsApi.getNodeById(payloadId) as HtPayloadNode
       newButton.payload = payloadNode.content.payload
     }
     if (cmsButton.url && urlId) {
-      const payloadNode = cmsApi.getNode(urlId) as HtUrlNode
+      const payloadNode = cmsApi.getNodeById(urlId) as HtUrlNode
       newButton.url = payloadNode.content.url
     }
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
@@ -1,22 +1,51 @@
 import { Button, Reply } from '@botonic/react'
 import React from 'react'
 
+import { FlowBuilderApi } from '../api'
 import { ContentFieldsBase } from './content-fields-base'
-import { HtButton, HtButtonStyle } from './hubtype-fields'
+import {
+  HtButton,
+  HtButtonStyle,
+  HtPayloadNode,
+  HtUrlNode,
+} from './hubtype-fields'
 
 export class FlowButton extends ContentFieldsBase {
   public text = ''
   public url?: string
   public payload?: string
 
-  static fromHubtypeCMS(component: HtButton, locale: string): FlowButton {
-    const newButton = new FlowButton(component.id)
-    newButton.text = this.getTextByLocale(locale, component.text)
-    newButton.payload = component.target
-      ? component.target.id
-      : component.payload?.find(payload => payload.locale === locale)?.id
-    newButton.url = component.url?.find(url => url.locale === locale)?.id
+  static fromHubtypeCMS(
+    cmsButton: HtButton,
+    locale: string,
+    cmsApi: FlowBuilderApi
+  ): FlowButton {
+    const payloadId = this.getPayloadId(cmsButton, locale)
+    const urlId = this.getUrlId(cmsButton, locale)
+
+    const newButton = new FlowButton(cmsButton.id)
+    newButton.text = this.getTextByLocale(locale, cmsButton.text)
+    if (cmsButton.target) {
+      newButton.payload = cmsButton.target.id
+    }
+    if (cmsButton.payload && payloadId) {
+      const payloadNode = cmsApi.getNode(payloadId) as HtPayloadNode
+      newButton.payload = payloadNode.content.payload
+    }
+    if (cmsButton.url && urlId) {
+      const payloadNode = cmsApi.getNode(urlId) as HtUrlNode
+      newButton.url = payloadNode.content.url
+    }
+
     return newButton
+  }
+
+  static getPayloadId(cmsButton, locale): string | undefined {
+    return cmsButton.payload.find(payload => payload.locale === locale)?.id
+  }
+
+  static getUrlId(cmsButton, locale): string | undefined {
+    return cmsButton.url.find(url => url.locale === locale)?.id
   }
 
   renderButton(buttonStyle?: HtButtonStyle): JSX.Element {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-carousel.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-carousel.tsx
@@ -1,6 +1,7 @@
 import { Carousel } from '@botonic/react'
 import React from 'react'
 
+import { FlowBuilderApi } from '../api'
 import { ContentFieldsBase } from './content-fields-base'
 import { FlowElement } from './flow-element'
 import { HtCarouselNode } from './hubtype-fields'
@@ -11,12 +12,13 @@ export class FlowCarousel extends ContentFieldsBase {
 
   static fromHubtypeCMS(
     component: HtCarouselNode,
-    locale: string
+    locale: string,
+    cmsApi: FlowBuilderApi
   ): FlowCarousel {
     const newCarousel = new FlowCarousel(component.id)
     newCarousel.code = component.code
     newCarousel.elements = component.content.elements.map(element =>
-      FlowElement.fromHubtypeCMS(element, locale)
+      FlowElement.fromHubtypeCMS(element, locale, cmsApi)
     )
     return newCarousel
   }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-element.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-element.tsx
@@ -1,6 +1,7 @@
 import { Element, Pic, Subtitle, Title } from '@botonic/react'
 import React from 'react'
 
+import { FlowBuilderApi } from '../api'
 import { ContentFieldsBase } from './content-fields-base'
 import { FlowButton } from './flow-button'
 import { HtCarouselElement } from './hubtype-fields'
@@ -14,13 +15,18 @@ export class FlowElement extends ContentFieldsBase {
 
   static fromHubtypeCMS(
     component: HtCarouselElement,
-    locale: string
+    locale: string,
+    cmsApi: FlowBuilderApi
   ): FlowElement {
     const newElement = new FlowElement(component.id)
     newElement.title = this.getTextByLocale(locale, component.title)
     newElement.subtitle = this.getTextByLocale(locale, component.subtitle)
     newElement.image = this.getImageByLocale(locale, component.image)
-    newElement.button = FlowButton.fromHubtypeCMS(component.button, locale)
+    newElement.button = FlowButton.fromHubtypeCMS(
+      component.button,
+      locale,
+      cmsApi
+    )
     return newElement
   }
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
@@ -1,6 +1,7 @@
 import { Text } from '@botonic/react'
 import React from 'react'
 
+import { FlowBuilderApi } from '../api'
 import { ContentFieldsBase } from './content-fields-base'
 import { FlowButton } from './flow-button'
 import { HtButtonStyle, HtTextNode } from './hubtype-fields'
@@ -11,14 +12,17 @@ export class FlowText extends ContentFieldsBase {
   public buttons: FlowButton[] = []
   public buttonStyle = HtButtonStyle.BUTTON
 
-  static fromHubtypeCMS(component: HtTextNode, locale: string): FlowText {
-    const newText = new FlowText(component.id)
-    newText.code = component.code
-    newText.buttonStyle =
-      component.content.buttons_style || HtButtonStyle.BUTTON
-    newText.text = this.getTextByLocale(locale, component.content.text)
-    newText.buttons = component.content.buttons.map(button =>
-      FlowButton.fromHubtypeCMS(button, locale)
+  static fromHubtypeCMS(
+    cmsText: HtTextNode,
+    locale: string,
+    cmsApi: FlowBuilderApi
+  ): FlowText {
+    const newText = new FlowText(cmsText.id)
+    newText.code = cmsText.code
+    newText.buttonStyle = cmsText.content.buttons_style || HtButtonStyle.BUTTON
+    newText.text = this.getTextByLocale(locale, cmsText.content.text)
+    newText.buttons = cmsText.content.buttons.map(button =>
+      FlowButton.fromHubtypeCMS(button, locale, cmsApi)
     )
     return newText
   }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
@@ -10,6 +10,7 @@ import { HtStartNode } from './start'
 import { HtTextNode } from './text'
 import { HtUrlNode } from './url'
 import { HtVideoNode } from './video'
+import { HtWhatsappButtonListNode } from './whatsapp-button-list'
 
 export type HtNodeWithContent =
   | HtTextNode
@@ -21,6 +22,7 @@ export type HtNodeWithContent =
   | HtIntentNode
   | HtFunctionNode
   | HtFallbackNode
+  | HtWhatsappButtonListNode
 
 export type HtNodeWithoutContent = HtUrlNode | HtPayloadNode
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
@@ -10,7 +10,6 @@ import { HtStartNode } from './start'
 import { HtTextNode } from './text'
 import { HtUrlNode } from './url'
 import { HtVideoNode } from './video'
-import { HtWhatsappButtonListNode } from './whatsapp-button-list'
 
 export type HtNodeWithContent =
   | HtTextNode
@@ -22,7 +21,6 @@ export type HtNodeWithContent =
   | HtIntentNode
   | HtFunctionNode
   | HtFallbackNode
-  | HtWhatsappButtonListNode
 
 export type HtNodeWithoutContent = HtUrlNode | HtPayloadNode
 

--- a/packages/botonic-plugin-flow-builder/src/handoff.ts
+++ b/packages/botonic-plugin-flow-builder/src/handoff.ts
@@ -56,10 +56,12 @@ async function getOnFinishPayload(
   handoffNode: HtHandoffNode,
   locale: string
 ): Promise<string | undefined> {
-  const handoffTargetNode = await flowBuilderPlugin.getHandoffContent(
-    handoffNode.target?.id
-  )
-  if (handoffTargetNode?.id) return handoffTargetNode?.id
+  if (handoffNode.target?.id) {
+    const handoffTargetNode = flowBuilderPlugin.cmsApi.getNode<HtHandoffNode>(
+      handoffNode.target?.id
+    )
+    if (handoffTargetNode?.id) return handoffTargetNode?.id
+  }
 
   const payloadId = handoffNode.content.payload.find(
     payload => payload.locale === locale
@@ -67,7 +69,7 @@ async function getOnFinishPayload(
 
   if (!payloadId) return undefined
 
-  const actionPayload = await flowBuilderPlugin.getContent(payloadId)
+  const actionPayload = flowBuilderPlugin.cmsApi.getNode(payloadId)
 
   return (actionPayload as HtPayloadNode).content.payload
 }

--- a/packages/botonic-plugin-flow-builder/src/handoff.ts
+++ b/packages/botonic-plugin-flow-builder/src/handoff.ts
@@ -57,9 +57,10 @@ async function getOnFinishPayload(
   locale: string
 ): Promise<string | undefined> {
   if (handoffNode.target?.id) {
-    const handoffTargetNode = flowBuilderPlugin.cmsApi.getNode<HtHandoffNode>(
-      handoffNode.target?.id
-    )
+    const handoffTargetNode =
+      flowBuilderPlugin.cmsApi.getNodeById<HtHandoffNode>(
+        handoffNode.target?.id
+      )
     if (handoffTargetNode?.id) return handoffTargetNode?.id
   }
 
@@ -69,7 +70,7 @@ async function getOnFinishPayload(
 
   if (!payloadId) return undefined
 
-  const actionPayload = flowBuilderPlugin.cmsApi.getNode(payloadId)
+  const actionPayload = flowBuilderPlugin.cmsApi.getNodeById(payloadId)
 
   return (actionPayload as HtPayloadNode).content.payload
 }

--- a/packages/botonic-plugin-flow-builder/src/helpers.ts
+++ b/packages/botonic-plugin-flow-builder/src/helpers.ts
@@ -1,6 +1,10 @@
 import { Plugin } from '@botonic/core'
 
-import { HtNodeWithContent } from './content-fields/hubtype-fields'
+import {
+  HtHandoffNode,
+  HtNodeWithContent,
+  HtNodeWithContentType,
+} from './content-fields/hubtype-fields'
 import BotonicPluginFlowBuilder from './index'
 
 const FLOW_BUILDER_PLUGIN_NAME = 'BotonicPluginFlowBuilder'
@@ -19,22 +23,6 @@ export function getFlowBuilderPlugin(plugins: {
   return flowBuilderPlugin
 }
 
-export async function updateButtonUrls(
-  hubtypeContent: HtNodeWithContent,
-  contentKey: string,
-  getContentFn: any
-): Promise<void> {
-  if (hubtypeContent.content[contentKey]) {
-    for (const i in hubtypeContent.content[contentKey]) {
-      const button = hubtypeContent.content[contentKey][i].button
-      if (button?.url) {
-        for (const j in button.url) {
-          button.url[j] = {
-            ...button.url[j],
-            ...(await getContentFn(button.url[j].id)),
-          }
-        }
-      }
-    }
-  }
+export function isHandoffNode(node: HtNodeWithContent): node is HtHandoffNode {
+  return node.type === HtNodeWithContentType.HANDOFF
 }

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -20,6 +20,7 @@ export interface BotonicPluginFlowBuilderOptions {
 export interface FlowBuilderApiOptions {
   url: string
   flow?: HtFlowBuilderData
+  accessToken: string
 }
 
 export enum ProcessEnvNodeEnvs {

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -1,6 +1,7 @@
 import { Session } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
+import { FlowBuilderApi } from './api'
 import { HtFlowBuilderData } from './content-fields/hubtype-fields'
 
 export interface BotonicPluginFlowBuilderOptions {
@@ -14,6 +15,11 @@ export interface BotonicPluginFlowBuilderOptions {
     eventName: string,
     args?: Record<string, any>
   ) => Promise<void>
+}
+
+export interface FlowBuilderApiOptions {
+  url: string
+  flow?: HtFlowBuilderData
 }
 
 export enum ProcessEnvNodeEnvs {


### PR DESCRIPTION
## Description
Multiple things have been done in this PR:
- Add pre-commit to the Flow Builder plugin.
- Fix the URL buttons issue to make them point correctly to the URL instead of to the content ID.
- Create a new `FlowBuilderApi` class to handle all the accesses to the flow instead of doing it in the plugin itself.

## Context
The URL buttons were not correctly generated in Botonic and they were pointing to the content ID instead of pointing to the URL.
Trying to solve this issue I came accross with a limitation of how the contents were being retreived from the flow and how the plugin was generating the final content to be sent to Botonic, that's why I ended up doing a refactor of this part.

## Approach taken / Explain the design
The process of generating the flow contents (`FlowButton`, `FlowText`, etc.) was not being done within those clases but also in the `getContents` function of the plugin and this was making the code more complex to mantain and to understand.

Now, each flow class is responsible of fetching correctly all the other contained components (buttons within a text, for example). To be able to do this, we pass the `FlowBuilderApi` instance to any flow class that needs to fetch nodes from the flow.

## Future improvements
- Add cache to the `FlowBuilderApi`'s `init` method to not fetch the whole flow in each bot interaction.
- Try to apply the same logic with the function and follow-up nodes and move all its logic from `getContent` method to independent classes (the same way it's done with `FlowText`, `FlowCarousel`...)
- Add tests!

## Testing

The pull request has no test.