### PR TITLE
Trigger Button with notifications

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.22.2",
+  "version": "0.22.3-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.22.2",
+  "version": "0.22.3-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/components/message.jsx
+++ b/packages/botonic-react/src/components/message.jsx
@@ -122,9 +122,8 @@ export const Message = props => {
 
   const ack = getEnvAck()
 
-  if (isBrowser()) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
+  useEffect(() => {
+    if (isBrowser()) {
       const decomposedChildren = json
       const message = {
         id: state.id,
@@ -156,10 +155,11 @@ export const Message = props => {
         ack: ack,
       }
       addMessage(message)
-    }, [])
+    }
+  }, [])
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useEffect(() => {
+  useEffect(() => {
+    if (isBrowser()) {
       const msg = webchatState.messagesJSON.find(m => m.id === state.id)
       if (
         msg &&
@@ -168,8 +168,8 @@ export const Message = props => {
       ) {
         updateReplies(replies)
       }
-    }, [webchatState.messagesJSON])
-  }
+    }
+  }, [webchatState.messagesJSON])
 
   const brandColor = getThemeProperty(
     WEBCHAT.CUSTOM_PROPERTIES.brandColor,

--- a/packages/botonic-react/src/constants.js
+++ b/packages/botonic-react/src/constants.js
@@ -20,6 +20,7 @@ export const COLORS = {
   LIGHT_GRAY: 'rgba(209, 209, 209, 1)',
   MID_GRAY: 'rgba(105, 105, 115, 1)',
   PIGEON_POST_BLUE_ALPHA_0_5: 'rgba(176, 196, 222, 0.5)',
+  RED_NOTIFICATIONS: 'rgba(255, 66, 111, 1)',
   SCORPION_GRAY: 'rgba(87, 87, 87, 1)',
   SEASHELL_WHITE: 'rgba(241, 240, 240, 1)',
   SILVER: 'rgba(200, 200, 200, 1)',

--- a/packages/botonic-react/src/contexts.jsx
+++ b/packages/botonic-react/src/contexts.jsx
@@ -25,10 +25,11 @@ export const WebchatContext = createContext({
   updateLatestInput: input => {},
   closeWebview: () => {},
   toggleWebchat: toggle => {},
-  getThemeProperty: property => undefined, // used to retrieve a specific property of the theme defined by the developer in his 'webchat/index.js'
+  getThemeProperty: (property, defaultValue) => undefined, // used to retrieve a specific property of the theme defined by the developer in his 'webchat/index.js'
   resolveCase: () => {},
   theme: {},
   webchatState: webchatInitialState,
+  unreadMessages: 0,
   updateWebchatDevSettings: settings => {
     return {}
   },

--- a/packages/botonic-react/src/contexts.jsx
+++ b/packages/botonic-react/src/contexts.jsx
@@ -24,7 +24,7 @@ export const WebchatContext = createContext({
   updateReplies: replies => {},
   updateLatestInput: input => {},
   closeWebview: () => {},
-  toggleWebchat: () => {},
+  toggleWebchat: toggle => {},
   getThemeProperty: property => undefined, // used to retrieve a specific property of the theme defined by the developer in his 'webchat/index.js'
   resolveCase: () => {},
   theme: {},

--- a/packages/botonic-react/src/index-types.ts
+++ b/packages/botonic-react/src/index-types.ts
@@ -175,7 +175,7 @@ export interface WebchatContextProps {
   updateReplies: (replies: boolean) => void
   updateLatestInput: (input: CoreInput) => void
   closeWebview: () => void
-  toggleWebchat: () => void
+  toggleWebchat: (toggle: boolean) => void
   getThemeProperty: (property: string, defaultValue?: string) => any
   resolveCase: () => void
   theme: ThemeProps

--- a/packages/botonic-react/src/webchat/hooks.js
+++ b/packages/botonic-react/src/webchat/hooks.js
@@ -64,6 +64,7 @@ export const webchatInitialState = {
   lastMessageUpdate: undefined,
   currentAttachment: undefined,
   jwt: null,
+  unreadMessages: 0,
 }
 
 export function useWebchat() {
@@ -71,14 +72,10 @@ export function useWebchat() {
     webchatReducer,
     webchatInitialState
   )
-  const [unreadMessages, setUnreadMessages] = useState(0)
-
   const addMessage = message =>
     webchatDispatch({ type: ADD_MESSAGE, payload: message })
-  const addMessageComponent = message => {
-    setUnreadMessages(value => value + 1)
+  const addMessageComponent = message =>
     webchatDispatch({ type: ADD_MESSAGE_COMPONENT, payload: message })
-  }
   const updateMessage = message =>
     webchatDispatch({ type: UPDATE_MESSAGE, payload: message })
   const updateReplies = replies =>
@@ -124,8 +121,6 @@ export function useWebchat() {
     })
 
   const toggleWebchat = toggle => {
-    console.log('toggleWebchat hook function')
-    setUnreadMessages(0)
     webchatDispatch({
       type: TOGGLE_WEBCHAT,
       payload: toggle,
@@ -203,7 +198,6 @@ export function useWebchat() {
     updateHandoff,
     updateTheme,
     updateDevSettings,
-    unreadMessages,
     toggleWebchat,
     toggleEmojiPicker,
     togglePersistentMenu,

--- a/packages/botonic-react/src/webchat/hooks.js
+++ b/packages/botonic-react/src/webchat/hooks.js
@@ -71,11 +71,14 @@ export function useWebchat() {
     webchatReducer,
     webchatInitialState
   )
+  const [unreadMessages, setUnreadMessages] = useState(0)
 
   const addMessage = message =>
     webchatDispatch({ type: ADD_MESSAGE, payload: message })
-  const addMessageComponent = message =>
+  const addMessageComponent = message => {
+    setUnreadMessages(value => value + 1)
     webchatDispatch({ type: ADD_MESSAGE_COMPONENT, payload: message })
+  }
   const updateMessage = message =>
     webchatDispatch({ type: UPDATE_MESSAGE, payload: message })
   const updateReplies = replies =>
@@ -119,11 +122,16 @@ export function useWebchat() {
       type: UPDATE_DEV_SETTINGS,
       payload: settings,
     })
-  const toggleWebchat = toggle =>
+
+  const toggleWebchat = toggle => {
+    console.log('toggleWebchat hook function')
+    setUnreadMessages(0)
     webchatDispatch({
       type: TOGGLE_WEBCHAT,
       payload: toggle,
     })
+  }
+
   const toggleEmojiPicker = toggle =>
     webchatDispatch({
       type: TOGGLE_EMOJI_PICKER,
@@ -195,6 +203,7 @@ export function useWebchat() {
     updateHandoff,
     updateTheme,
     updateDevSettings,
+    unreadMessages,
     toggleWebchat,
     toggleEmojiPicker,
     togglePersistentMenu,

--- a/packages/botonic-react/src/webchat/messages-reducer.js
+++ b/packages/botonic-react/src/webchat/messages-reducer.js
@@ -12,13 +12,7 @@ export const messagesReducer = (state, action) => {
     case ADD_MESSAGE:
       return addMessageReducer(state, action)
     case ADD_MESSAGE_COMPONENT:
-      return {
-        ...state,
-        messagesComponents: [
-          ...(state.messagesComponents || []),
-          action.payload,
-        ],
-      }
+      return addMessageComponent(action, state)
     case UPDATE_MESSAGE:
       return updateMessageReducer(state, action)
     case UPDATE_REPLIES:
@@ -36,6 +30,21 @@ export const messagesReducer = (state, action) => {
       }
     default:
       throw new Error()
+  }
+}
+
+function addMessageComponent(action, state) {
+  const messageComponent = action.payload
+  const isUnreadMessage =
+    !state.isWebchatOpen && messageComponent.props.ack !== 1
+  const unreadMessages = isUnreadMessage
+    ? state.unreadMessages + 1
+    : state.unreadMessages
+
+  return {
+    ...state,
+    messagesComponents: [...(state.messagesComponents || []), messageComponent],
+    unreadMessages,
   }
 }
 

--- a/packages/botonic-react/src/webchat/messages-reducer.js
+++ b/packages/botonic-react/src/webchat/messages-reducer.js
@@ -36,7 +36,7 @@ export const messagesReducer = (state, action) => {
 function addMessageComponent(action, state) {
   const messageComponent = action.payload
   const isUnreadMessage =
-    !state.isWebchatOpen && messageComponent.props.ack !== 1
+    !state.isWebchatOpen && messageComponent.props?.ack !== 1
   const unreadMessages = isUnreadMessage
     ? state.unreadMessages + 1
     : state.unreadMessages

--- a/packages/botonic-react/src/webchat/trigger-button/index.tsx
+++ b/packages/botonic-react/src/webchat/trigger-button/index.tsx
@@ -1,0 +1,78 @@
+import React, { useContext } from 'react'
+
+import { ROLES, WEBCHAT } from '../../constants'
+import { WebchatContext } from '../../contexts'
+import { resolveImage } from '../../util/environment'
+import { _getThemeProperty } from '../../util/webchat'
+import {
+  StyledTriggerButton,
+  TriggerImage,
+  UnreadMessagesCounter,
+} from './styles'
+
+export interface TriggerButtonProps {
+  theme: any
+  unreadMessages: number
+  webchatState: any
+}
+
+export const TriggerButton = ({
+  theme,
+  unreadMessages,
+  webchatState,
+}: TriggerButtonProps): JSX.Element => {
+  const toggleWebchat = useContext(WebchatContext)
+  const getThemeProperty = _getThemeProperty(theme)
+
+  const getTriggerImage = () => {
+    const triggerImage = getThemeProperty(
+      WEBCHAT.CUSTOM_PROPERTIES.triggerButtonImage,
+      undefined
+    )
+    if (triggerImage === null) {
+      webchatState.theme.triggerButtonImage = WEBCHAT.DEFAULTS.LOGO
+      return null
+    }
+    return triggerImage
+  }
+
+  const triggerButtonStyle = getThemeProperty(
+    WEBCHAT.CUSTOM_PROPERTIES.triggerButtonStyle
+  )
+
+  const CustomTriggerButton = getThemeProperty(
+    WEBCHAT.CUSTOM_PROPERTIES.customTrigger,
+    undefined
+  )
+
+  const handleClick = (event: any) => {
+    //@ts-ignore
+    toggleWebchat(true)
+    event.preventDefault()
+  }
+  return (
+    <div
+      onClick={event => {
+        handleClick(event)
+      }}
+    >
+      {unreadMessages !== 0 && (
+        <UnreadMessagesCounter className='trigger-notifications'>
+          {unreadMessages}
+        </UnreadMessagesCounter>
+      )}
+      {CustomTriggerButton ? (
+        <CustomTriggerButton />
+      ) : (
+        <StyledTriggerButton
+          role={ROLES.TRIGGER_BUTTON}
+          style={{ ...triggerButtonStyle }}
+        >
+          {getTriggerImage() && (
+            <TriggerImage src={resolveImage(getTriggerImage())} />
+          )}
+        </StyledTriggerButton>
+      )}
+    </div>
+  )
+}

--- a/packages/botonic-react/src/webchat/trigger-button/index.tsx
+++ b/packages/botonic-react/src/webchat/trigger-button/index.tsx
@@ -3,38 +3,30 @@ import React, { useContext } from 'react'
 import { ROLES, WEBCHAT } from '../../constants'
 import { WebchatContext } from '../../contexts'
 import { resolveImage } from '../../util/environment'
-import { _getThemeProperty } from '../../util/webchat'
 import {
   StyledTriggerButton,
   TriggerImage,
   UnreadMessagesCounter,
 } from './styles'
 
-export interface TriggerButtonProps {
-  theme: any
-  unreadMessages: number
-  webchatState: any
-}
-
-export const TriggerButton = ({
-  theme,
-  unreadMessages,
-  webchatState,
-}: TriggerButtonProps): JSX.Element => {
-  const toggleWebchat = useContext(WebchatContext)
-  const getThemeProperty = _getThemeProperty(theme)
+export const TriggerButton = (): JSX.Element => {
+  const { webchatState, getThemeProperty, toggleWebchat } =
+    useContext(WebchatContext)
 
   const getTriggerImage = () => {
-    const triggerImage = getThemeProperty(
+    const image = getThemeProperty(
       WEBCHAT.CUSTOM_PROPERTIES.triggerButtonImage,
       undefined
     )
-    if (triggerImage === null) {
+
+    if (!image) {
       webchatState.theme.triggerButtonImage = WEBCHAT.DEFAULTS.LOGO
       return null
     }
-    return triggerImage
+    return image
   }
+
+  const triggerButtonImage = getTriggerImage()
 
   const triggerButtonStyle = getThemeProperty(
     WEBCHAT.CUSTOM_PROPERTIES.triggerButtonStyle
@@ -46,30 +38,31 @@ export const TriggerButton = ({
   )
 
   const handleClick = (event: any) => {
-    //@ts-ignore
     toggleWebchat(true)
     event.preventDefault()
   }
+
   return (
     <div
       onClick={event => {
         handleClick(event)
       }}
     >
-      {unreadMessages !== 0 && (
+      {webchatState.unreadMessages !== 0 && (
         <UnreadMessagesCounter className='trigger-notifications'>
-          {unreadMessages}
+          {webchatState.unreadMessages}
         </UnreadMessagesCounter>
       )}
       {CustomTriggerButton ? (
+        //@ts-ignore
         <CustomTriggerButton />
       ) : (
         <StyledTriggerButton
           role={ROLES.TRIGGER_BUTTON}
-          style={{ ...triggerButtonStyle }}
+          style={triggerButtonStyle}
         >
-          {getTriggerImage() && (
-            <TriggerImage src={resolveImage(getTriggerImage())} />
+          {triggerButtonImage && (
+            <TriggerImage src={resolveImage(triggerButtonImage)} />
           )}
         </StyledTriggerButton>
       )}

--- a/packages/botonic-react/src/webchat/trigger-button/index.tsx
+++ b/packages/botonic-react/src/webchat/trigger-button/index.tsx
@@ -43,11 +43,7 @@ export const TriggerButton = (): JSX.Element => {
   }
 
   return (
-    <div
-      onClick={event => {
-        handleClick(event)
-      }}
-    >
+    <div onClick={handleClick}>
       {webchatState.unreadMessages !== 0 && (
         <UnreadMessagesCounter className='trigger-notifications'>
           {webchatState.unreadMessages}

--- a/packages/botonic-react/src/webchat/trigger-button/styles.ts
+++ b/packages/botonic-react/src/webchat/trigger-button/styles.ts
@@ -28,7 +28,7 @@ export const UnreadMessagesCounter = styled.div`
   bottom: 80px;
   width: 24px;
   height: 24px;
-  background-color: #ff426f;
+  background-color: ${COLORS.RED_NOTIFICATIONS};
   color: white;
   z-index: 10;
 `

--- a/packages/botonic-react/src/webchat/trigger-button/styles.ts
+++ b/packages/botonic-react/src/webchat/trigger-button/styles.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components'
+
+import { COLORS } from '../../constants'
+
+export const StyledTriggerButton = styled.div`
+  cursor: pointer;
+  position: fixed;
+  background: ${COLORS.SOLID_WHITE};
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  width: 65px;
+  height: 65px;
+  bottom: 20px;
+  right: 10px;
+  padding: 8px;
+`
+
+export const UnreadMessagesCounter = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  position: absolute;
+  right: 20px;
+  bottom: 80px;
+  width: 24px;
+  height: 24px;
+  background-color: #ff426f;
+  color: white;
+  z-index: 10;
+`
+
+export const TriggerImage = styled.img`
+  max-width: 100%;
+  max-height: 100%;
+`

--- a/packages/botonic-react/src/webchat/webchat-reducer.js
+++ b/packages/botonic-react/src/webchat/webchat-reducer.js
@@ -35,8 +35,14 @@ export function webchatReducer(state, action) {
       }
     case UPDATE_HANDOFF:
       return { ...state, handoff: action.payload }
-    case TOGGLE_WEBCHAT:
-      return { ...state, isWebchatOpen: action.payload }
+    case TOGGLE_WEBCHAT: {
+      const isWebchatOpen = action.payload
+      return {
+        ...state,
+        isWebchatOpen,
+        unreadMessages: isWebchatOpen ? 0 : state.unreadMessages,
+      }
+    }
     case TOGGLE_EMOJI_PICKER:
       return { ...state, isEmojiPickerOpen: action.payload }
     case TOGGLE_PERSISTENT_MENU:

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -37,7 +37,7 @@ import {
 } from '../message-utils'
 import { msgToBotonic } from '../msg-to-botonic'
 import { scrollToBottom } from '../util/dom'
-import { isDev, resolveImage } from '../util/environment'
+import { isDev } from '../util/environment'
 import { deserializeRegex, stringifyWithRegexs } from '../util/regexs'
 import {
   _getThemeProperty,
@@ -63,6 +63,7 @@ import {
 } from './hooks'
 import { WebchatMessageList } from './message-list'
 import { WebchatReplies } from './replies'
+import { TriggerButton } from './trigger-button'
 import { useStorageState } from './use-storage-state-hook'
 import { WebviewContainer } from './webview'
 
@@ -86,22 +87,6 @@ const StyledWebchat = styled.div`
   flex-direction: column;
 `
 
-const StyledTriggerButton = styled.div`
-  cursor: pointer;
-  position: fixed;
-  background: ${COLORS.SOLID_WHITE};
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  width: 65px;
-  height: 65px;
-  bottom: 20px;
-  right: 10px;
-  padding: 8px;
-`
-
 const UserInputContainer = styled.div`
   min-height: 52px;
   position: relative;
@@ -118,11 +103,6 @@ const TextAreaContainer = styled.div`
   display: flex;
   flex: 1 1 auto;
   align-items: center;
-`
-
-const TriggerImage = styled.img`
-  max-width: 100%;
-  max-height: 100%;
 `
 
 const ErrorMessageContainer = styled.div`
@@ -176,6 +156,7 @@ export const Webchat = forwardRef((props, ref) => {
     updateHandoff,
     updateTheme,
     updateDevSettings,
+    unreadMessages,
     toggleWebchat,
     toggleEmojiPicker,
     togglePersistentMenu,
@@ -448,6 +429,7 @@ export const Webchat = forwardRef((props, ref) => {
     }
     return false
   }
+
   const closeMenu = () => {
     togglePersistentMenu(false)
   }
@@ -711,43 +693,6 @@ export const Webchat = forwardRef((props, ref) => {
     }
   }, [webchatState.isWebchatOpen])
 
-  const getTriggerImage = () => {
-    const triggerImage = getThemeProperty(
-      WEBCHAT.CUSTOM_PROPERTIES.triggerButtonImage,
-      null
-    )
-    if (triggerImage === null) {
-      webchatState.theme.triggerButtonImage = WEBCHAT.DEFAULTS.LOGO
-      return null
-    }
-    return triggerImage
-  }
-
-  const triggerButtonStyle = getThemeProperty(
-    WEBCHAT.CUSTOM_PROPERTIES.triggerButtonStyle
-  )
-
-  const CustomTriggerButton = getThemeProperty(
-    WEBCHAT.CUSTOM_PROPERTIES.customTrigger,
-    undefined
-  )
-
-  const triggerButton = () => {
-    if (CustomTriggerButton) {
-      return <CustomTriggerButton />
-    }
-    return (
-      <StyledTriggerButton
-        role={ROLES.TRIGGER_BUTTON}
-        style={{ ...triggerButtonStyle }}
-      >
-        {getTriggerImage() && (
-          <TriggerImage src={resolveImage(getTriggerImage())} />
-        )}
-      </StyledTriggerButton>
-    )
-  }
-
   const webchatMessageList = () => (
     <WebchatMessageList style={{ flex: 1 }}>
       {webchatState.typing && <TypingIndicator />}
@@ -918,14 +863,11 @@ export const Webchat = forwardRef((props, ref) => {
       }}
     >
       {!webchatState.isWebchatOpen && (
-        <div
-          onClick={event => {
-            toggleWebchat(true)
-            event.preventDefault()
-          }}
-        >
-          {triggerButton()}
-        </div>
+        <TriggerButton
+          theme={theme}
+          unreadMessages={unreadMessages}
+          webchatState={webchatState}
+        />
       )}
 
       {webchatState.isWebchatOpen && (

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -156,7 +156,6 @@ export const Webchat = forwardRef((props, ref) => {
     updateHandoff,
     updateTheme,
     updateDevSettings,
-    unreadMessages,
     toggleWebchat,
     toggleEmojiPicker,
     togglePersistentMenu,
@@ -862,13 +861,7 @@ export const Webchat = forwardRef((props, ref) => {
         updateWebchatDevSettings: updateWebchatDevSettings,
       }}
     >
-      {!webchatState.isWebchatOpen && (
-        <TriggerButton
-          theme={theme}
-          unreadMessages={unreadMessages}
-          webchatState={webchatState}
-        />
-      )}
+      {!webchatState.isWebchatOpen && <TriggerButton />}
 
       {webchatState.isWebchatOpen && (
         <StyledWebchat


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
Be able to show in the trigger button the number of received and unread messages. I consider a message unread when I receive it and the webchat is closed.

<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
In local is not working well as the message sets the ack to 1 directly.
Display a notification with the number of unread messages. 
CustomTriggerButton
![Captura de Pantalla 2023-07-04 a las 13 59 39](https://github.com/hubtype/botonic/assets/36898236/3e5adf7c-cfe6-469d-a3fd-77928dba685b)
DefaultTriggerButton
![DefaultTriggerButton](https://github.com/hubtype/botonic/assets/36898236/bc8ae49c-ec42-4b04-ba07-adfb13060b66)

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design
Each time the action of webchatReducer addMessageComponent is called if the webchat is closed and the message ack is 0, I increment the state of unreadMessages by 1. When I reset unreadMessages

The div displaying unread messages has className='trigger-notifications' to be able to adjust the css
<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
