### PR TITLE
botonic-react: render images sent to the bot by user

### DIFF
--- a/packages/botonic-react/src/components/image.jsx
+++ b/packages/botonic-react/src/components/image.jsx
@@ -20,7 +20,9 @@ const serialize = imageProps => {
 }
 
 export const Image = props => {
-  props = { ...props, src: staticAsset(props.src) }
+  props = props.input?.data
+    ? { ...props, src: props.input.data }
+    : { ...props, src: staticAsset(props.src) }
   let content = props.children
 
   const [isPreviewerOpened, setIsPreviewerOpened] = useState(false)

--- a/packages/botonic-react/src/util/environment.js
+++ b/packages/botonic-react/src/util/environment.js
@@ -24,7 +24,7 @@ export const resolveImage = src => {
 
 export const isURL = urlPath => {
   // @stephenhay (38 chars) from: https://mathiasbynens.be/demo/url-regex
-  const pattern = new RegExp(/^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/)
+  const pattern = new RegExp(/^(blob:)?(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/)
   return !!pattern.test(urlPath)
 }
 

--- a/packages/botonic-react/src/util/environment.js
+++ b/packages/botonic-react/src/util/environment.js
@@ -24,7 +24,7 @@ export const resolveImage = src => {
 
 export const isURL = urlPath => {
   // @stephenhay (38 chars) from: https://mathiasbynens.be/demo/url-regex
-  const pattern = new RegExp(/^(blob:)?(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/)
+  const pattern = new RegExp(/^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/)
   return !!pattern.test(urlPath)
 }
 

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -496,8 +496,10 @@ export const Webchat = forwardRef((props, ref) => {
         from: SENDERS.user,
         src: temporaryDisplayUrl,
       }
-      if (isImage(input)) messageComponent = <Image {...mediaProps} />
-      else if (isAudio(input)) messageComponent = <Audio {...mediaProps} />
+      if (isImage(input)) {
+        mediaProps.input = input
+        messageComponent = <Image {...mediaProps} />
+      } else if (isAudio(input)) messageComponent = <Audio {...mediaProps} />
       else if (isVideo(input)) messageComponent = <Video {...mediaProps} />
       else if (isDocument(input))
         messageComponent = <Document {...mediaProps} />


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
If the user sends an image through the bot it is not rendered correctly. This fails because staticAsset only renders images from a public URL. 
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
User attaches an image to the webchat
(first commit only works in local) In order to render an image within a message, add the `bolb` format in the isURL function which is used by staticAsset.
(second commit) To make the first render after attaching an image you can use the input.data which contains the base 64 string of the image. If you reload the webchat this string will no longer be used , in the localStorage message the url where the image was uploaded is saved. 
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## To document / Usage example
![Captura de pantalla 2023-08-14 a las 11 19 12](https://github.com/hubtype/botonic/assets/36898236/1c62c63f-b54d-4e62-9975-627486aed5c0)

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

