### PR TITLE
botonic-react: add imagePreviewer in ThemeProps

### DIFF
--- a/packages/botonic-react/src/components/index-types.ts
+++ b/packages/botonic-react/src/components/index-types.ts
@@ -169,6 +169,13 @@ export interface ThemeProps extends StyleProp {
     sendButton?: EnableProp & CustomProp
   } & EnableProp &
     StyleProp
+  imagePreviewer?: React.ComponentType<ImagePreviewerProps>
+}
+
+interface ImagePreviewerProps {
+  src: string
+  isPreviewerOpened: boolean
+  closePreviewer: () => void
 }
 
 export interface CoverComponentOptions {

--- a/packages/botonic-react/src/util/environment.js
+++ b/packages/botonic-react/src/util/environment.js
@@ -24,7 +24,7 @@ export const resolveImage = src => {
 
 export const isURL = urlPath => {
   // @stephenhay (38 chars) from: https://mathiasbynens.be/demo/url-regex
-  const pattern = new RegExp(/^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/)
+  const pattern = new RegExp(/^(blob:)?(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/)
   return !!pattern.test(urlPath)
 }
 


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
add the type of imagePreviewer in the ThemeProps.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
So when using the image preview plugin we don't get the type error in webchat/index.ts
![Captura de pantalla 2023-08-14 a las 13 00 14](https://github.com/hubtype/botonic/assets/36898236/78c5977b-94b2-44c0-b43e-11ce1a5a33d4)
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->
