### PR TITLE
Plugin Hubtype Analytics: fix get language typo

### DIFF
--- a/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-agent-rating.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-agent-rating.ts
@@ -12,7 +12,7 @@ export class HtEventAgentRating extends HtEvent {
   constructor(event: EventAgentRating, requestData: RequestData) {
     super(event, requestData)
     this.event_data.rating = event.event_data.rating
-    this.event_data.commnent = event.event_data.commnent
+    this.event_data.comment = event.event_data.comment
     this.event_data.case_id = event.event_data.case_id
   }
 }

--- a/packages/botonic-plugin-hubtype-analytics/src/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/index.ts
@@ -5,7 +5,7 @@ import { HtEventProps, RequestData } from './types'
 import { createHtEvent } from './utils'
 
 export interface HubtypeAnalyticsOptions {
-  getLaguange?: (request: BotRequest) => string
+  getLanguage?: (request: BotRequest) => string
   getCountry?: (request: BotRequest) => string
 }
 
@@ -19,11 +19,11 @@ function getDefaultCountry(request: BotRequest): string {
 
 export default class BotonicPluginHubtypeAnalytics implements Plugin {
   baseUrl: string
-  getLaguange: (request: BotRequest) => string
+  getLanguage: (request: BotRequest) => string
   getCountry: (request: BotRequest) => string
   constructor(options?: HubtypeAnalyticsOptions) {
     this.baseUrl = process.env.HUBTYPE_API_URL || 'https://api.hubtype.com'
-    this.getLaguange = options?.getLaguange || getDefaultLanguage
+    this.getLanguage = options?.getLanguage || getDefaultLanguage
     this.getCountry = options?.getCountry || getDefaultCountry
   }
 
@@ -37,7 +37,7 @@ export default class BotonicPluginHubtypeAnalytics implements Plugin {
 
   getRequestData(request: BotRequest): RequestData {
     return {
-      language: this.getLaguange(request),
+      language: this.getLanguage(request),
       country: this.getCountry(request),
       provider: request.session.user.provider,
       userId: request.session.user.id,

--- a/packages/botonic-plugin-hubtype-analytics/src/types.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/types.ts
@@ -44,7 +44,7 @@ export interface EventAgentRating extends HtBaseEventProps {
 export interface EventDataRating {
   case_id: string
   rating?: number
-  commnent?: string
+  comment?: string
 }
 export interface EventChannelRating extends HtBaseEventProps {
   event_type: EventName.botChannelRating


### PR DESCRIPTION
## Description
Fixed typo in getLanguage option.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- doesn't need tests
