### PR TITLE
Feature: deploy bot in prod/qa/dev

### DIFF
--- a/packages/botonic-core/src/hubtype-service.ts
+++ b/packages/botonic-core/src/hubtype-service.ts
@@ -96,10 +96,6 @@ export class HubtypeService {
       // TODO recover user & appId somehow
       return Promise.reject('No User or appId. Clear cache and reload')
     }
-    console.log('Initializing Pusher', {
-      _WEBCHAT_PUSHER_KEY_: WEBCHAT_PUSHER_KEY,
-      _HUBTYPE_API_URL_: HUBTYPE_API_URL,
-    })
     this.pusher = new Pusher(WEBCHAT_PUSHER_KEY, {
       cluster: 'eu',
       authEndpoint: `${HUBTYPE_API_URL}/v1/provider_accounts/webhooks/webchat/${this.appId}/auth/`,

--- a/packages/botonic-core/src/hubtype-service.ts
+++ b/packages/botonic-core/src/hubtype-service.ts
@@ -30,7 +30,7 @@ interface HubtypeServiceArgs {
 }
 
 const WEBCHAT_PUSHER_KEY =
-  process.env.WEBCHAT_PUSHER_KEY || '434ca667c8e6cb3f641c'
+  process.env.WEBCHAT_PUSHER_KEY || '434ca667c8e6cb3f641c' // pragma: allowlist secret
 
 const HUBTYPE_API_URL = process.env.HUBTYPE_API_URL || 'https://api.hubtype.com'
 

--- a/packages/botonic-core/src/hubtype-service.ts
+++ b/packages/botonic-core/src/hubtype-service.ts
@@ -4,7 +4,6 @@ import Channels from 'pusher-js/types/src/core/channels/channels'
 
 import { Input, SessionUser } from './models'
 import { decompressData } from './pusher-utils'
-import { getWebpackEnvVar } from './utils'
 
 interface UnsentInput {
   id: string
@@ -30,18 +29,10 @@ interface HubtypeServiceArgs {
   server: ServerConfig
 }
 
-const _WEBCHAT_PUSHER_KEY_ = getWebpackEnvVar(
-  // @ts-ignore
-  typeof WEBCHAT_PUSHER_KEY !== 'undefined' && WEBCHAT_PUSHER_KEY,
-  'WEBCHAT_PUSHER_KEY',
-  '434ca667c8e6cb3f641c' // pragma: allowlist secret
-)
-const _HUBTYPE_API_URL_ = getWebpackEnvVar(
-  // @ts-ignore
-  typeof HUBTYPE_API_URL !== 'undefined' && HUBTYPE_API_URL,
-  'HUBTYPE_API_URL',
-  'https://api.hubtype.com'
-)
+const WEBCHAT_PUSHER_KEY =
+  process.env.WEBCHAT_PUSHER_KEY || '434ca667c8e6cb3f641c'
+
+const HUBTYPE_API_URL = process.env.HUBTYPE_API_URL || 'https://api.hubtype.com'
 
 const ACTIVITY_TIMEOUT = 20 * 1000 // https://pusher.com/docs/channels/using_channels/connection#activitytimeout-integer-
 const PONG_TIMEOUT = 5 * 1000 // https://pusher.com/docs/channels/using_channels/connection#pongtimeout-integer-
@@ -105,9 +96,13 @@ export class HubtypeService {
       // TODO recover user & appId somehow
       return Promise.reject('No User or appId. Clear cache and reload')
     }
-    this.pusher = new Pusher(_WEBCHAT_PUSHER_KEY_, {
+    console.log('Initializing Pusher', {
+      _WEBCHAT_PUSHER_KEY_: WEBCHAT_PUSHER_KEY,
+      _HUBTYPE_API_URL_: HUBTYPE_API_URL,
+    })
+    this.pusher = new Pusher(WEBCHAT_PUSHER_KEY, {
       cluster: 'eu',
-      authEndpoint: `${_HUBTYPE_API_URL_}/v1/provider_accounts/webhooks/webchat/${this.appId}/auth/`,
+      authEndpoint: `${HUBTYPE_API_URL}/v1/provider_accounts/webhooks/webchat/${this.appId}/auth/`,
       forceTLS: true,
       auth: {
         headers: this.constructHeaders(),
@@ -227,7 +222,7 @@ export class HubtypeService {
       // @ts-ignore
       await this.init(user)
       await axios.post(
-        `${_HUBTYPE_API_URL_}/v1/provider_accounts/webhooks/webchat/${this.appId}/`,
+        `${HUBTYPE_API_URL}/v1/provider_accounts/webhooks/webchat/${this.appId}/`,
         {
           sender: this.user,
           message: message,
@@ -249,7 +244,7 @@ export class HubtypeService {
     appId: string
   }): Promise<AxiosResponse<any>> {
     return axios.get(
-      `${_HUBTYPE_API_URL_}/v1/provider_accounts/${appId}/visibility/`
+      `${HUBTYPE_API_URL}/v1/provider_accounts/${appId}/visibility/`
     )
   }
 

--- a/packages/botonic-core/src/utils.ts
+++ b/packages/botonic-core/src/utils.ts
@@ -13,9 +13,7 @@ export const isBrowser = (): boolean => {
   return typeof IS_BROWSER !== 'undefined'
     ? // @ts-ignore
       IS_BROWSER
-    : typeof window !== 'undefined' &&
-        typeof window.document !== 'undefined' &&
-        !window.process
+    : typeof window !== 'undefined' && typeof window.document !== 'undefined'
 }
 
 export const isMobile = (mobileBreakpoint = 460): boolean => {

--- a/packages/botonic-core/src/utils.ts
+++ b/packages/botonic-core/src/utils.ts
@@ -18,18 +18,6 @@ export const isBrowser = (): boolean => {
         !window.process
 }
 
-export function getWebpackEnvVar(
-  webpackEnvVar: string | false,
-  name: string,
-  defaultValue: string
-): string {
-  return (
-    webpackEnvVar ||
-    (typeof process !== 'undefined' && process.env[name]) ||
-    defaultValue
-  )
-}
-
 export const isMobile = (mobileBreakpoint = 460): boolean => {
   if (isBrowser()) {
     const w = Math.max(

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
@@ -1,15 +1,7 @@
 import { ActionRequest } from '@botonic/react'
 import axios from 'axios'
 
-import { getFlowBuilderPlugin } from '../helpers'
-import { getWebpackEnvVar } from '../utils'
-
-const _HUBTYPE_API_URL_ = getWebpackEnvVar(
-  // @ts-ignore
-  typeof HUBTYPE_API_URL !== 'undefined' && HUBTYPE_API_URL,
-  'HUBTYPE_API_URL',
-  'https://api.hubtype.com'
-)
+const HUBTYPE_API_URL = process.env.HUBTYPE_API_URL || 'https://api.hubtype.com'
 
 type ConditionalQueueStatusArgs = {
   request: ActionRequest
@@ -37,8 +29,11 @@ interface AvailabilityData {
 export async function getQueueAvailability(
   queueId: string
 ): Promise<AvailabilityData> {
+  console.log('plugin-flow-builder getQueueAvailability', {
+    _HUBTYPE_API_URL_: HUBTYPE_API_URL,
+  })
   const response = await axios.get(
-    `${_HUBTYPE_API_URL_}/v1/queues/${queueId}/availability/`,
+    `${HUBTYPE_API_URL}/v1/queues/${queueId}/availability/`,
     // TODO: Make it configurable in the future
     {
       params: {

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
@@ -29,9 +29,6 @@ interface AvailabilityData {
 export async function getQueueAvailability(
   queueId: string
 ): Promise<AvailabilityData> {
-  console.log('plugin-flow-builder getQueueAvailability', {
-    _HUBTYPE_API_URL_: HUBTYPE_API_URL,
-  })
   const response = await axios.get(
     `${HUBTYPE_API_URL}/v1/queues/${queueId}/availability/`,
     // TODO: Make it configurable in the future

--- a/packages/botonic-plugin-flow-builder/src/utils.ts
+++ b/packages/botonic-plugin-flow-builder/src/utils.ts
@@ -2,18 +2,6 @@ import { Session } from '@botonic/core'
 
 import { BotonicPluginFlowBuilderOptions, ProcessEnvNodeEnvs } from './types'
 
-export function getWebpackEnvVar(
-  webpackEnvVar: string | false,
-  name: string,
-  defaultValue: string
-): string {
-  return (
-    webpackEnvVar ||
-    (typeof process !== 'undefined' && process.env[name]) ||
-    defaultValue
-  )
-}
-
 function getAccessTokenFromSession(session: Session): string {
   if (!session._access_token) {
     throw new Error('No access token found in session')


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
- Deploy bot in prod/qa/dev with with environment variables set hubtype/infrastructure repository deploy_bot_etc functions.
- Makes a fix to the isBrowser function to solve a problem detected a few days ago in some websites where process.env existed inside the browser.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
The getWebpackEnvVar function did not work correctly and ended up always putting the production url and the production pusher key
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design
instead of using the getWebpackEnvVar function, I read directly process.env and if this is undefined, the HUBTYPE_API_URL or PUSHER_KEY of the production will be used.
<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
