### PR TITLE
feat(knowledge-bases): add question attribute in the response

### DIFF
--- a/packages/botonic-plugin-knowledge-bases/package-lock.json
+++ b/packages/botonic-plugin-knowledge-bases/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-knowledge-bases",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-knowledge-bases/package.json
+++ b/packages/botonic-plugin-knowledge-bases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-knowledge-bases",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Use a Hubtype to make the bot respond through a knowledge base.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/botonic-plugin-knowledge-bases/src/hubtype-knowledge-api-service.ts
+++ b/packages/botonic-plugin-knowledge-bases/src/hubtype-knowledge-api-service.ts
@@ -19,6 +19,7 @@ export class HubtypeApiService {
     chatId: string
   ): Promise<
     AxiosResponse<{
+      question: string
       answer: string
       has_knowledge: boolean
       sources: {

--- a/packages/botonic-plugin-knowledge-bases/src/index.ts
+++ b/packages/botonic-plugin-knowledge-bases/src/index.ts
@@ -35,6 +35,7 @@ export default class BotonicPluginKnowledgeBases implements Plugin {
     })
 
     return {
+      question: response.data.question,
       answer: response.data.answer,
       hasKnowledge: response.data.has_knowledge,
       sources,

--- a/packages/botonic-plugin-knowledge-bases/src/types.ts
+++ b/packages/botonic-plugin-knowledge-bases/src/types.ts
@@ -6,6 +6,7 @@ export interface PluginKnowledgeBaseOptions {
 }
 
 export interface KnowledgeBaseResponse {
+  question: string
   answer: string
   hasKnowledge: boolean
   sources: {


### PR DESCRIPTION
## Description
Add a new `question` attribute into the Knowledge Bases responses.

## Context
This new attribute was added in the response to see the standalone question used to get the response from ChatGPT.

## Approach taken / Explain the design


## To document / Usage example


## Testing

The pull request has no tests.
