### PR TITLE
Contentful plugin publish 0.23.1

### DIFF
--- a/packages/botonic-plugin-contentful/package-lock.json
+++ b/packages/botonic-plugin-contentful/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-contentful",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-contentful/package.json
+++ b/packages/botonic-plugin-contentful/package.json
@@ -16,7 +16,7 @@
     "postversion": "git push && git push --tags"
   },
   "name": "@botonic/plugin-contentful",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-environment.ts
+++ b/packages/botonic-plugin-contentful/tests/contentful/manage/manage-contentful-environment.ts
@@ -7,11 +7,10 @@ describe('ManageEnvironment', () => {
     const environments = await environmentManager.environments
 
     expect(environments.items[0].name).toEqual('master')
-    expect(environments.items[1].name).toEqual('testx')
-    expect(environments.items[2].name).toEqual('manage-contentful')
+    expect(environments.items[1].name).toEqual('manage-contentful')
   })
 
-  test.each([['master'], ['testx'], ['manage-contentful']])(
+  test.each([['master'], ['manage-contentful']])(
     'TEST: get environment %s',
     async (environmentName: string) => {
       const environmentManager = testManageEnvironment()
@@ -34,18 +33,16 @@ describe('ManageEnvironment', () => {
       )
       const environments = await environmentManager.getEnvironments()
       expect(environment.name).toEqual(newEnvironment)
-      expect(environments.items.length).toBe(4)
+      expect(environments.items.length).toBe(3)
       expect(environments.items[0].name).toEqual('master')
-      expect(environments.items[1].name).toEqual('testx')
-      expect(environments.items[2].name).toEqual('manage-contentful')
-      expect(environments.items[3].name).toEqual(newEnvironment)
+      expect(environments.items[1].name).toEqual('manage-contentful')
+      expect(environments.items[2].name).toEqual(newEnvironment)
     } finally {
       await environmentManager.deleteEnvironment(newEnvironment)
       const environments = await environmentManager.getEnvironments()
-      expect(environments.items.length).toBe(3)
+      expect(environments.items.length).toBe(2)
       expect(environments.items[0].name).toEqual('master')
-      expect(environments.items[1].name).toEqual('testx')
-      expect(environments.items[2].name).toEqual('manage-contentful')
+      expect(environments.items[1].name).toEqual('manage-contentful')
     }
   })
 })

--- a/packages/botonic-plugin-contentful/tests/plugin.test.ts
+++ b/packages/botonic-plugin-contentful/tests/plugin.test.ts
@@ -32,7 +32,7 @@ test('INTEGRATION TEST plugin with contentfulFactory', async () => {
   // Arrange
   const otherEnvironmentCredentials = {
     spaceId: testSpaceId(),
-    environment: 'testx',
+    environment: 'manage-contentful',
     accessToken: testAccessToken(),
   }
   const opts = testContentfulOptions({


### PR DESCRIPTION
## Description
In the free Contentful account where we have everything related to testing, now we can only have master and 2 environments. We had a test that creates and deletes an environment. This test was failing because there was not enough space. I have merged 2 environments into one (deleting the testx environment after copying all the content to manage-contentful.
Released plugin version 0.23.1
