### PR TITLE
feat(core): pass the initialised plugins in the Request used in the Router class 

### DIFF
--- a/packages/botonic-core/src/core-bot.ts
+++ b/packages/botonic-core/src/core-bot.ts
@@ -147,10 +147,12 @@ export class CoreBot {
             input,
             session,
             lastRoutePath,
+            plugins: this.plugins,
           })),
           ...this.defaultRoutes,
         ],
-        this.inspector.routeInspector
+        this.inspector.routeInspector,
+        this.plugins
       )
     }
 

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -223,6 +223,7 @@ export interface BotRequest {
   lastRoutePath: RoutePath
   session: Session
   dataProvider?: DataProvider
+  plugins?: ResolvedPlugins
 }
 
 /** The response of the bot for the triggered actions, which can be

--- a/packages/botonic-core/src/routing/router.ts
+++ b/packages/botonic-core/src/routing/router.ts
@@ -7,6 +7,7 @@ import {
   MatchingProp,
   Nullable,
   ProcessInputResult,
+  ResolvedPlugins,
   Route,
   RouteParams,
   RoutePath,
@@ -19,19 +20,21 @@ import {
   getNotFoundAction,
   getPathParamsFromPathPayload,
   isPathPayload,
-  pathParamsToParams,
 } from './router-utils'
 
 export class Router {
   routes: Route[]
   routeInspector: RouteInspector
+  plugins?: ResolvedPlugins
 
   constructor(
     routes: Route[],
-    routeInspector: RouteInspector | undefined = undefined
+    routeInspector: RouteInspector | undefined = undefined,
+    plugins?: ResolvedPlugins
   ) {
     this.routes = routes
     this.routeInspector = routeInspector || new RouteInspector()
+    this.plugins = plugins
   }
 
   /**
@@ -258,7 +261,8 @@ export class Router {
     else if (prop === 'text') value = input.data
     else if (prop === 'input') value = input
     else if (prop === 'session') value = session
-    else if (prop === 'request') value = { input, session, lastRoutePath }
+    else if (prop === 'request')
+      value = { input, session, lastRoutePath, plugins: this.plugins }
     const matched = this.matchValue(matcher, value)
     if (matched) {
       this.routeInspector.routeMatched(route, prop, matcher, value)

--- a/packages/botonic-core/tests/routing/router.match-route.test.ts
+++ b/packages/botonic-core/tests/routing/router.match-route.test.ts
@@ -1,4 +1,4 @@
-import { BotRequest, INPUT, Input } from '../../src'
+import { BotRequest, INPUT, Input, ResolvedPlugin } from '../../src'
 import { Router } from '../../src/routing'
 import { testRoute, testSession } from '../helpers/routing'
 
@@ -27,14 +27,22 @@ const videoInput: Input = {
   src: 'data:video/mp4;base64,iVBORw0KG',
 }
 
+const testPlugin: ResolvedPlugin = {
+  id: 'testPlugin',
+  name: 'testPlugin',
+  config: {},
+}
+const testPlugins = { testPlugin }
+
 const requestInput: BotRequest = {
   input: textInput,
   session: { ...testSession(), organization: 'myOrg' },
   lastRoutePath: 'initial',
+  plugins: testPlugins,
 }
 
 describe('TEST: Match route by MATCHER <> INPUT', () => {
-  const router = new Router([])
+  const router = new Router([], undefined, testPlugins)
   const matchTextProp = (matcher, textInput) =>
     router.matchRoute(
       testRoute(),
@@ -149,7 +157,8 @@ describe('TEST: Match route by MATCHER <> INPUT', () => {
         request =>
           request.input.text === 'hi' &&
           request.session.organization === 'myOrg' &&
-          request.lastRoutePath === 'initial',
+          request.lastRoutePath === 'initial' &&
+          request.plugins.testPlugin.id === 'testPlugin',
         requestInput
       )
     ).toBeTruthy()
@@ -158,7 +167,8 @@ describe('TEST: Match route by MATCHER <> INPUT', () => {
         request =>
           request.input.text === 'hello' &&
           request.session.organization === 'myOrg' &&
-          request.lastRoutePath === 'initial',
+          request.lastRoutePath === 'initial' &&
+          request.plugins.testPlugin.id === 'testPlugin',
         requestInput
       )
     ).toBeFalsy()


### PR DESCRIPTION
## Description
Pass all the initialised plugins in the `Router` class to be able to use them when checking the `request` condition in the routes.

## Context
The request used in the routes matching was not completed and did not contain the plugins.

## Approach taken / Explain the design


## To document / Usage example


## Testing

The pull request has unit tests.