### PR TITLE
Plugin hubtype babel: read HUBTYPE_API_URL from process.env

### DIFF
--- a/packages/botonic-plugin-hubtype-babel/src/hubtype-babel-api-service.ts
+++ b/packages/botonic-plugin-hubtype-babel/src/hubtype-babel-api-service.ts
@@ -1,10 +1,10 @@
 import axios, { AxiosResponse } from 'axios'
 
 export class HubtypeBabelApiService {
-  constructor(
-    readonly projectId: string,
-    readonly host: string = 'https://api.hubtype.com'
-  ) {}
+  private readonly host: string
+  constructor(readonly projectId: string) {
+    this.host = process.env.HUBTYPE_API_URL || 'https://api.hubtype.com'
+  }
 
   async inference(
     text: string,

--- a/packages/botonic-plugin-hubtype-babel/src/index.ts
+++ b/packages/botonic-plugin-hubtype-babel/src/index.ts
@@ -1,10 +1,4 @@
-import {
-  HubtypeSession,
-  INPUT,
-  Plugin,
-  PluginPostRequest,
-  PluginPreRequest,
-} from '@botonic/core'
+import { HubtypeSession, INPUT, Plugin, PluginPreRequest } from '@botonic/core'
 
 import { HubtypeBabelApiService } from './hubtype-babel-api-service'
 import { PluginHubtypeBabelOptions } from './options'
@@ -17,10 +11,7 @@ export default class BotonicPluginHubtypeBabel implements Plugin {
   readonly automaticBotMessagePrefix: string
 
   constructor(private readonly options: PluginHubtypeBabelOptions) {
-    this.apiService = new HubtypeBabelApiService(
-      options.projectId,
-      options.host
-    )
+    this.apiService = new HubtypeBabelApiService(options.projectId)
     this.includeHasSense = options.includeHasSense || false
     this.automaticBotMessagePrefix =
       options.automaticBotMessagePrefix || '[Automatic Bot Message]'
@@ -76,8 +67,6 @@ export default class BotonicPluginHubtypeBabel implements Plugin {
       .toLowerCase()
       .startsWith(this.automaticBotMessagePrefix.toLowerCase())
   }
-
-  async post(_request: PluginPostRequest) {}
 }
 
 export { PluginHubtypeBabelOptions } from './options'

--- a/packages/botonic-plugin-hubtype-babel/src/options.ts
+++ b/packages/botonic-plugin-hubtype-babel/src/options.ts
@@ -1,7 +1,6 @@
 export interface PluginHubtypeBabelOptions {
   projectId: string
   authToken?: string
-  host?: string
   automaticBotMessagePrefix?: string
   includeHasSense?: boolean
 }


### PR DESCRIPTION
## Description
Read HUBTYPE_API_URL from process.env.HUBTYPE_API_URL or use production api (https://api.hubtype.com) if it is undefined 

## Context
This is how it is used in the rest of the plugins and core

## Approach taken / Explain the design
Reading this url from the environment variable and if it is not set to use the default production api, it is no longer necessary to pass the host through the plugin constructo

