### PR TITLE
Plugin flow builder: open user input in webchat when do handoff

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -38,11 +38,7 @@ export class FlowBuilderAction extends React.Component<FlowBuilderActionProps> {
     ) as FlowHandoff
     if (handoffContent) await handoffContent.doHandoff(request)
 
-    const contentsToRender = contents.filter(content =>
-      content instanceof FlowHandoff ? false : true
-    )
-
-    return { contents: contentsToRender }
+    return { contents }
   }
 
   render(): JSX.Element | JSX.Element[] {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
@@ -1,5 +1,5 @@
 import { HandOffBuilder } from '@botonic/core'
-import { ActionRequest } from '@botonic/react'
+import { ActionRequest, WebchatSettings } from '@botonic/react'
 import React from 'react'
 
 import { EventName, trackEvent } from '../action/tracking'
@@ -95,6 +95,6 @@ export class FlowHandoff extends ContentFieldsBase {
   }
 
   toBotonic(): JSX.Element {
-    return <></>
+    return <WebchatSettings enableUserInput={true} />
   }
 }

--- a/packages/botonic-react/src/webchat/hooks/use-typing.ts
+++ b/packages/botonic-react/src/webchat/hooks/use-typing.ts
@@ -19,18 +19,20 @@ export function useTyping({
     let delayTimeout, typingTimeout
     try {
       const nextMsg = webchatState.messagesJSON.filter(m => !m.display)[0]
-      if (nextMsg.delay && nextMsg.typing) {
-        delayTimeout = setTimeout(
-          () => updateTyping(true),
-          nextMsg.delay * 1000
-        )
-      } else if (nextMsg.typing) updateTyping(true)
-      const totalDelay = nextMsg.delay + nextMsg.typing
-      if (totalDelay)
-        typingTimeout = setTimeout(() => {
-          updateMessage({ ...nextMsg, display: true })
-          updateTyping(false)
-        }, totalDelay * 1000)
+      if (nextMsg) {
+        if (nextMsg.delay && nextMsg.typing) {
+          delayTimeout = setTimeout(
+            () => updateTyping(true),
+            nextMsg.delay * 1000
+          )
+        } else if (nextMsg.typing) updateTyping(true)
+        const totalDelay = nextMsg.delay + nextMsg.typing
+        if (totalDelay)
+          typingTimeout = setTimeout(() => {
+            updateMessage({ ...nextMsg, display: true })
+            updateTyping(false)
+          }, totalDelay * 1000)
+      }
     } catch (e) {}
     return () => {
       clearTimeout(delayTimeout)

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -599,6 +599,7 @@ export const Webchat = forwardRef((props, ref) => {
     updateWebchatSettings: settings => {
       const themeUpdates = normalizeWebchatSettings(settings)
       updateTheme(merge(webchatState.theme, themeUpdates), themeUpdates)
+      updateTyping(false)
     },
   }))
 


### PR DESCRIPTION
## Description
When doing a handoff you need to have the userInput of the webchat enable and this is not always the case for all bots. 
From the flow builder plugin always enable userInput when do a handoff.  
If no other message is sent with the WebchatSettings the typing is set to true. That's why I also modify @botonic/react to set it to false when updating the WebchatSettings.
