### PR TITLE
Fix: className in CustomMessage, avoid render undefined in ScrollButton and BannerUnreadMessages

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -38,11 +38,7 @@ export class FlowBuilderAction extends React.Component<FlowBuilderActionProps> {
     ) as FlowHandoff
     if (handoffContent) await handoffContent.doHandoff(request)
 
-    const contentsToRender = contents.filter(content =>
-      content instanceof FlowHandoff ? false : true
-    )
-
-    return { contents: contentsToRender }
+    return { contents }
   }
 
   render(): JSX.Element | JSX.Element[] {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
@@ -1,5 +1,5 @@
 import { HandOffBuilder } from '@botonic/core'
-import { ActionRequest } from '@botonic/react'
+import { ActionRequest, WebchatSettings } from '@botonic/react'
 import React from 'react'
 
 import { EventName, trackEvent } from '../action/tracking'
@@ -95,6 +95,6 @@ export class FlowHandoff extends ContentFieldsBase {
   }
 
   toBotonic(): JSX.Element {
-    return <></>
+    return <WebchatSettings enableUserInput={true} />
   }
 }

--- a/packages/botonic-react/src/components/custom-message.jsx
+++ b/packages/botonic-react/src/components/custom-message.jsx
@@ -64,6 +64,8 @@ export const customMessage = ({
           children: childrenWithoutReplies,
           customTypeName: name,
         }}
+        sentBy={props.sentBy}
+        isUnread={props.isUnread}
       >
         <ErrorBoundary key={'errorBoundary'} {...customMessageProps}>
           <CustomMessageComponent {...customMessageProps}>
@@ -77,7 +79,14 @@ export const customMessage = ({
   WrappedComponent.customTypeName = name
   // eslint-disable-next-line react/display-name
   WrappedComponent.deserialize = msg => (
-    <WrappedComponent id={msg.id} key={msg.key} json={msg.data} {...msg.data} />
+    <WrappedComponent
+      id={msg.id}
+      key={msg.key}
+      json={msg.data}
+      {...msg.data}
+      sentBy={msg.sentBy}
+      isUnread={msg.isUnread}
+    />
   )
   return WrappedComponent
 }

--- a/packages/botonic-react/src/webchat-app.jsx
+++ b/packages/botonic-react/src/webchat-app.jsx
@@ -173,8 +173,7 @@ export class WebchatApp {
     delete message.sent_by
     const response = msgToBotonic(
       message,
-      (this.theme.message && this.theme.message.customTypes) ||
-        this.theme.customMessageTypes
+      this.theme.message?.customTypes || this.theme.customMessageTypes
     )
 
     this.webchatRef.current.addBotResponse({

--- a/packages/botonic-react/src/webchat/hooks/use-typing.ts
+++ b/packages/botonic-react/src/webchat/hooks/use-typing.ts
@@ -19,18 +19,20 @@ export function useTyping({
     let delayTimeout, typingTimeout
     try {
       const nextMsg = webchatState.messagesJSON.filter(m => !m.display)[0]
-      if (nextMsg.delay && nextMsg.typing) {
-        delayTimeout = setTimeout(
-          () => updateTyping(true),
-          nextMsg.delay * 1000
-        )
-      } else if (nextMsg.typing) updateTyping(true)
-      const totalDelay = nextMsg.delay + nextMsg.typing
-      if (totalDelay)
-        typingTimeout = setTimeout(() => {
-          updateMessage({ ...nextMsg, display: true })
-          updateTyping(false)
-        }, totalDelay * 1000)
+      if (nextMsg) {
+        if (nextMsg.delay && nextMsg.typing) {
+          delayTimeout = setTimeout(
+            () => updateTyping(true),
+            nextMsg.delay * 1000
+          )
+        } else if (nextMsg.typing) updateTyping(true)
+        const totalDelay = nextMsg.delay + nextMsg.typing
+        if (totalDelay)
+          typingTimeout = setTimeout(() => {
+            updateMessage({ ...nextMsg, display: true })
+            updateTyping(false)
+          }, totalDelay * 1000)
+      }
     } catch (e) {}
     return () => {
       clearTimeout(delayTimeout)

--- a/packages/botonic-react/src/webchat/message-list/scroll-button.tsx
+++ b/packages/botonic-react/src/webchat/message-list/scroll-button.tsx
@@ -29,17 +29,18 @@ export const ScrollButton = ({
   )
 
   return (
-    scrollButtonEnabled &&
-    show && (
-      <>
-        {CustomScrollButton ? (
-          <CustomScrollButton handleScrollToBottom={handleClick} />
-        ) : (
-          <ContainerScrollButton onClick={handleClick}>
-            <img src={resolveImage(ArrowScrollDown)} />
-          </ContainerScrollButton>
-        )}
-      </>
-    )
+    <>
+      {scrollButtonEnabled && show ? (
+        <>
+          {CustomScrollButton ? (
+            <CustomScrollButton handleScrollToBottom={handleClick} />
+          ) : (
+            <ContainerScrollButton onClick={handleClick}>
+              <img src={resolveImage(ArrowScrollDown)} />
+            </ContainerScrollButton>
+          )}
+        </>
+      ) : null}
+    </>
   )
 }

--- a/packages/botonic-react/src/webchat/message-list/unread-messages-banner.tsx
+++ b/packages/botonic-react/src/webchat/message-list/unread-messages-banner.tsx
@@ -45,17 +45,19 @@ export const UnreadMessagesBanner = ({
   }, [webchatState.isWebchatOpen, unreadMessagesBannerRef])
 
   return (
-    notificationsEnabled && (
-      <div ref={unreadMessagesBannerRef}>
-        {CustomUnreadMessagesBanner ? (
-          <CustomUnreadMessagesBanner />
-        ) : (
-          <ContainerUnreadMessagesBanner>
-            <img src={resolveImage(ArrowDown)} />
-            {webchatState.numUnreadMessages} {text}
-          </ContainerUnreadMessagesBanner>
-        )}
-      </div>
-    )
+    <>
+      {notificationsEnabled ? (
+        <div ref={unreadMessagesBannerRef}>
+          {CustomUnreadMessagesBanner ? (
+            <CustomUnreadMessagesBanner />
+          ) : (
+            <ContainerUnreadMessagesBanner>
+              <img src={resolveImage(ArrowDown)} />
+              {webchatState.numUnreadMessages} {text}
+            </ContainerUnreadMessagesBanner>
+          )}
+        </div>
+      ) : null}
+    </>
   )
 }

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -599,6 +599,7 @@ export const Webchat = forwardRef((props, ref) => {
     updateWebchatSettings: settings => {
       const themeUpdates = normalizeWebchatSettings(settings)
       updateTheme(merge(webchatState.theme, themeUpdates), themeUpdates)
+      updateTyping(false)
     },
   }))
 


### PR DESCRIPTION
## Description
This PR fixes two issues introduced in version 0.24.0 of @botonic/react.

1) Custom components did not have the customMessage name as className.

2) The ScrollButton and BannerUnreadMessages components rendered nothing if this feature was not used. 

## Context
1) Custom components did not have the customMessage name as className. This happened because the deserialize function of the Custom component did not pass the new sentBy and isUnread attributes. 
As these attributes were not serialised in the Message component, a check was made to define the className that verified that the CustomMessage was sent by the bot. Prior to version 0.24.0 if from (sentBy now) was not defined then SENDERS.bot was set by default.

2) The ScrollButton and BannerUnreadMessages components rendered nothing if this feature was not used. 
If the feature is enabled by default or using custom components to display these components the error did not occur but if the feature was not enabled the webchat would break. Now when this feature is not active it returns null. 

