### PR TITLE
fix resetUnreadMessages in local

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/webchat/messages-reducer.ts
+++ b/packages/botonic-react/src/webchat/messages-reducer.ts
@@ -61,7 +61,10 @@ function addMessageComponent(
 function resetUnreadMessages(state: WebchatState) {
   const messagesComponents = state.messagesComponents.map(messageComponent => {
     if (messageComponent.props.isUnread) {
-      messageComponent.props.isUnread = false
+      messageComponent = {
+        ...messageComponent,
+        props: { ...messageComponent.props, isUnread: false },
+      }
     }
     return messageComponent
   })


### PR DESCRIPTION
## Description
Fixes a problem detected in local development. 
In local when reloading the webchat keeping the session and with messages loaded, the following error appeared.
![Captura desde 2023-12-22 10-00-16](https://github.com/hubtype/botonic/assets/36898236/c4564ede-18e6-4b60-9161-d11e0a6ca164)
This is because stric mode does not allow to directly assign a value to isUnread. 

