### PR TITLE
plugin-flow-builder: handle bot action on the flow builder plugin #BLT-483

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to Botonic will be documented in this file.
 
 ### Added
 
+- [@botonic/plugin-flow-builder](https://www.npmjs.com/package/@botonic/plugin-flow-builder)
+
+  - [Add the `bot-action` node](https://github.com/hubtype/botonic/pull/2769) This node is used to define a payload and parameters, to execute an action defined in the bot routes.
+
 ### Changed
 
 ### Fixed

--- a/packages/botonic-plugin-flow-builder/package-lock.json
+++ b/packages/botonic-plugin-flow-builder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.24.1",
+  "version": "0.24.2-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -251,9 +251,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -284,9 +284,9 @@
       }
     },
     "@types/node": {
-      "version": "18.19.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.6.tgz",
-      "integrity": "sha512-X36s5CXMrrJOs2lQCdDF68apW4Rfx9ixYMawlepwmE4Anezv/AV2LSpKD1Ub8DAc+urp5bk0BGZ6NtmBitfnsg==",
+      "version": "18.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
@@ -298,9 +298,9 @@
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "@types/react": {
-      "version": "16.14.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.55.tgz",
-      "integrity": "sha512-HO/QHDg23Dx4ukfufr5YSTWyhrbyThXE2OzXfNkcw7vJcusBY5l1i1TZpJuyAn9EsC6o91/6OsIvXY54xTV+XQ==",
+      "version": "16.14.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.56.tgz",
+      "integrity": "sha512-MxuHB7dvVm5yOxRr7hJoonLG0JY8YvqZtaQ9Quirp3Oe4FLFjAgxkxsKE6IspdHPpRVZKo2ZoDEravWO81EeYA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -338,9 +338,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-sdk": {
-      "version": "2.1532.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1532.0.tgz",
-      "integrity": "sha512-4QVQs01LEAxo7UpSHlq/HaO+SJ1WrYF8W1otO2WhKpVRYXkSxXIgZgfYaK+sQ762XTtB6tSuD2ZS2HGsKNXVLw==",
+      "version": "2.1541.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1541.0.tgz",
+      "integrity": "sha512-+xS/Gq/+j/RKb3A6SHXn6tOCaog1O3troklpVxxNaqVNnq+zlwjFderGNzR6S4ftfNG7sKMUP++Znsqte8GMaw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -473,9 +473,9 @@
       }
     },
     "core-js": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.35.0.tgz",
-      "integrity": "sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg=="
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.35.1.tgz",
+      "integrity": "sha512-IgdsbxNyMskrTFxa9lWHyMwAJU5gXOPP+1yO+K59d50VLVAIDAbs7gIv705KzALModfK3ZrSZTPNpC0PQgIZuw=="
     },
     "css-color-keywords": {
       "version": "1.0.0",
@@ -534,11 +534,11 @@
       "integrity": "sha512-UNuBwTwJwWIZQLz+STdl3xeJyxqk0vMxieUD1AO7VEpbYvGGrLxuvJzzK1ng8Gak0e8xHZlcapuj6a5Zl5pqUw=="
     },
     "emoji-picker-react": {
-      "version": "4.6.7",
-      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.6.7.tgz",
-      "integrity": "sha512-JVv3+TmFqCBhZpCWLehjLCQCcI0f5JEOAvom9bNZPRQPgZ939XmJZPil/cPq+BQEX6zaplUo9dvQWeLPBdN7/A==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.7.0.tgz",
+      "integrity": "sha512-skjmaO4o4SHrQYVJm2D77mWBG2amudJl/RsKItSpwEQyN8va8xkm+Hij1I6aI9Bqt2KUAy4VMIVUB9mGCpYYGQ==",
       "requires": {
-        "flairup": "0.0.24"
+        "flairup": "0.0.32"
       }
     },
     "entities": {
@@ -573,14 +573,14 @@
       }
     },
     "flairup": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/flairup/-/flairup-0.0.24.tgz",
-      "integrity": "sha512-IancRT2IbWl5BxdQOHDFsEAywRharp0wZ/1TJY/rPdFcDMgkbmW3MDg4tgoLqy+pcp0WDxMhNwkkY4ycWr//Dw=="
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-0.0.32.tgz",
+      "integrity": "sha512-kqFDVgPXq714gyUtKp/nEkCg4vWpRni8pSWoPMU54pQNGqVEOfT+bBYgCyWFb5MygSh2q0wCWvcX6kyAus9C7g=="
     },
     "follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -1124,14 +1124,15 @@
       }
     },
     "set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
       "requires": {
         "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.2",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.1"
       }
     },
     "shallowequal": {

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.24.1",
+  "version": "0.24.2-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/action/intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/intent.ts
@@ -1,17 +1,14 @@
 import { ActionRequest } from '@botonic/react'
 
 import { FlowBuilderApi } from '../api'
-import {
-  HtIntentNode,
-  HtNodeWithContent,
-} from '../content-fields/hubtype-fields'
+import { HtIntentNode } from '../content-fields/hubtype-fields'
 import { EventName, trackEvent } from './tracking'
 
-export async function getNodeByIntent(
+export async function getIntentNodeByInput(
   cmsApi: FlowBuilderApi,
   locale: string,
   request: ActionRequest
-): Promise<HtNodeWithContent | undefined> {
+): Promise<HtIntentNode | undefined> {
   const intentNode = cmsApi.getIntentNode(request.input, locale)
   const eventArgs = {
     intent: request.input.intent as string,
@@ -20,7 +17,7 @@ export async function getNodeByIntent(
   }
   if (isIntentValid(intentNode, request, cmsApi) && intentNode?.target?.id) {
     await trackEvent(request, EventName.botAiModel, eventArgs)
-    return cmsApi.getNodeById<HtNodeWithContent>(intentNode.target.id)
+    return intentNode
   } else {
     eventArgs.confidence_successful = false
     await trackEvent(request, EventName.botAiModel, eventArgs)

--- a/packages/botonic-plugin-flow-builder/src/action/keyword.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/keyword.ts
@@ -1,15 +1,15 @@
 import { ActionRequest } from '@botonic/react'
 
 import { FlowBuilderApi } from '../api'
-import { HtNodeWithContent } from '../content-fields/hubtype-fields'
+import { HtKeywordNode } from '../content-fields/hubtype-fields'
 import { EventName, trackEvent } from './tracking'
 
-export async function getNodeByKeyword(
+export async function getKeywordNodeByInput(
   cmsApi: FlowBuilderApi,
   locale: string,
   request: ActionRequest,
   userInput: string
-): Promise<HtNodeWithContent | undefined> {
+): Promise<HtKeywordNode | undefined> {
   const keywordNode = cmsApi.getNodeByKeyword(userInput, locale)
   if (!keywordNode) {
     return undefined

--- a/packages/botonic-plugin-flow-builder/src/action/user-input.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/user-input.ts
@@ -1,32 +1,27 @@
 import { ActionRequest } from '@botonic/react'
 
 import { FlowBuilderApi } from '../api'
-import { HtNodeWithContent } from '../content-fields/hubtype-fields'
-import { getNodeByIntent } from './intent'
-import { getNodeByKeyword } from './keyword'
-import { EventName, trackEvent } from './tracking'
+import { HtIntentNode, HtKeywordNode } from '../content-fields/hubtype-fields'
+import { getIntentNodeByInput } from './intent'
+import { getKeywordNodeByInput } from './keyword'
 
 export async function getNodeByUserInput(
   cmsApi: FlowBuilderApi,
   locale: string,
   request: ActionRequest
-): Promise<HtNodeWithContent | undefined> {
-  if (request.session.is_first_interaction) {
-    const startNode = cmsApi.getStartNode()
-    await trackEvent(request, EventName.botStart)
-    return startNode
-  }
-
+): Promise<HtIntentNode | HtKeywordNode | undefined> {
   if (request.input.data) {
-    const nodeByIntent = await getNodeByIntent(cmsApi, locale, request)
-    if (nodeByIntent) return nodeByIntent
+    const intentNode = await getIntentNodeByInput(cmsApi, locale, request)
+    console.log({ intentNode })
+    if (intentNode) return intentNode
 
-    const keywordNode = await getNodeByKeyword(
+    const keywordNode = await getKeywordNodeByInput(
       cmsApi,
       locale,
       request,
       request.input.data
     )
+    console.log({ keywordNode })
     if (keywordNode) return keywordNode
   }
   return undefined

--- a/packages/botonic-plugin-flow-builder/src/action/user-input.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/user-input.ts
@@ -12,7 +12,6 @@ export async function getNodeByUserInput(
 ): Promise<HtIntentNode | HtKeywordNode | undefined> {
   if (request.input.data) {
     const intentNode = await getIntentNodeByInput(cmsApi, locale, request)
-    console.log({ intentNode })
     if (intentNode) return intentNode
 
     const keywordNode = await getKeywordNodeByInput(
@@ -21,7 +20,6 @@ export async function getNodeByUserInput(
       request,
       request.input.data
     )
-    console.log({ keywordNode })
     if (keywordNode) return keywordNode
   }
   return undefined

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -145,18 +145,16 @@ export class FlowBuilderApi {
   getNodeByKeyword(
     userInput: string,
     locale: string
-  ): HtNodeWithContent | undefined {
+  ): HtKeywordNode | undefined {
     try {
       const keywordNodes = this.flow.nodes.filter(
-        node => node.type == HtNodeWithContentType.KEYWORD
+        node => node.type === HtNodeWithContentType.KEYWORD
       ) as HtKeywordNode[]
       const matchedKeywordNodes = keywordNodes.filter(node =>
         this.matchKeywords(node, userInput, locale)
       )
       if (matchedKeywordNodes.length > 0 && matchedKeywordNodes[0].target) {
-        return this.getNodeById<HtNodeWithContent>(
-          matchedKeywordNodes[0].target.id
-        )
+        return matchedKeywordNodes[0]
       }
     } catch (error) {
       console.error(`Error getting node by keyword '${userInput}': `, error)
@@ -180,12 +178,16 @@ export class FlowBuilderApi {
     return keywords.some(keyword => input.includes(keyword))
   }
 
-  getPayloadFromBotActionNodeId(id?: string): string | undefined {
-    if (id) {
-      const botActionNode = this.getNodeById(id)
-      if (botActionNode.type === HtNodeWithoutContentType.BOT_ACTION) {
+  getPayload(target?: HtNodeLink): string | undefined {
+    if (target) {
+      console.log('getPayload', { target })
+      if (target.type === HtNodeWithoutContentType.BOT_ACTION) {
+        console.log('BOT_ACTION')
+        const botActionNode = this.getNodeById<HtBotActionNode>(target.id)
         return this.createPayloadWithParams(botActionNode)
       }
+      const targetNode = this.getNodeById(target.id)
+      return targetNode.id
     }
     return undefined
   }

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -179,15 +179,16 @@ export class FlowBuilderApi {
   }
 
   getPayload(target?: HtNodeLink): string | undefined {
-    if (target) {
-      if (target.type === HtNodeWithoutContentType.BOT_ACTION) {
-        const botActionNode = this.getNodeById<HtBotActionNode>(target.id)
-        return this.createPayloadWithParams(botActionNode)
-      }
-      const targetNode = this.getNodeById(target.id)
-      return targetNode.id
+    if (!target) {
+      return undefined
     }
-    return undefined
+
+    if (target.type === HtNodeWithoutContentType.BOT_ACTION) {
+      const botActionNode = this.getNodeById<HtBotActionNode>(target.id)
+      return this.createPayloadWithParams(botActionNode)
+    }
+
+    return target.id
   }
 
   private createPayloadWithParams(botActionNode: HtBotActionNode): string {

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -180,9 +180,7 @@ export class FlowBuilderApi {
 
   getPayload(target?: HtNodeLink): string | undefined {
     if (target) {
-      console.log('getPayload', { target })
       if (target.type === HtNodeWithoutContentType.BOT_ACTION) {
-        console.log('BOT_ACTION')
         const botActionNode = this.getNodeById<HtBotActionNode>(target.id)
         return this.createPayloadWithParams(botActionNode)
       }

--- a/packages/botonic-plugin-flow-builder/src/constants.ts
+++ b/packages/botonic-plugin-flow-builder/src/constants.ts
@@ -1,2 +1,3 @@
-export const SOURCE_INFO_SEPARATOR = '|source_'
+export const SEPARATOR = '|'
+export const SOURCE_INFO_SEPARATOR = `${SEPARATOR}source_`
 export const VARIABLE_REGEX = /{([^}]+)}/g

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
@@ -27,12 +27,9 @@ export class FlowButton extends ContentFieldsBase {
     const newButton = new FlowButton(cmsButton.id)
     newButton.text = this.getTextByLocale(locale, cmsButton.text)
     if (cmsButton.target) {
-      const payloadFromBotActionNode = cmsApi.getPayloadFromBotActionNodeId(
-        cmsButton.target.id
-      )
-      const payload = payloadFromBotActionNode || cmsButton.target.id
-      newButton.payload = payload
+      newButton.payload = cmsApi.getPayload(cmsButton.target)
     }
+
     // OLD PAYLOAD
     if (cmsButton.payload && payloadId) {
       const payloadNode = cmsApi.getNodeById<HtPayloadNode>(payloadId)

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
@@ -27,14 +27,19 @@ export class FlowButton extends ContentFieldsBase {
     const newButton = new FlowButton(cmsButton.id)
     newButton.text = this.getTextByLocale(locale, cmsButton.text)
     if (cmsButton.target) {
-      newButton.payload = cmsButton.target.id
+      const payloadFromBotActionNode = cmsApi.getPayloadFromBotActionNodeId(
+        cmsButton.target.id
+      )
+      const payload = payloadFromBotActionNode || cmsButton.target.id
+      newButton.payload = payload
     }
+    // OLD PAYLOAD
     if (cmsButton.payload && payloadId) {
-      const payloadNode = cmsApi.getNodeById(payloadId) as HtPayloadNode
+      const payloadNode = cmsApi.getNodeById<HtPayloadNode>(payloadId)
       newButton.payload = payloadNode.content.payload
     }
     if (cmsButton.url && urlId) {
-      const payloadNode = cmsApi.getNodeById(urlId) as HtUrlNode
+      const payloadNode = cmsApi.getNodeById<HtUrlNode>(urlId)
       newButton.url = payloadNode.content.url
     }
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
@@ -38,10 +38,7 @@ export class FlowHandoff extends ContentFieldsBase {
     cmsApi: FlowBuilderApi
   ): string | undefined {
     if (cmsHandoff.target?.id) {
-      const payloadFromBotActionNode = cmsApi.getPayloadFromBotActionNodeId(
-        cmsHandoff.target.id
-      )
-      return payloadFromBotActionNode || cmsHandoff.target.id
+      return cmsApi.getPayload(cmsHandoff.target)
     }
 
     // OLD PAYLOAD

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
@@ -6,23 +6,7 @@ import { EventName, trackEvent } from '../action/tracking'
 import { FlowBuilderApi } from '../api'
 import { getQueueAvailability } from '../functions/conditional-queue-status'
 import { ContentFieldsBase } from './content-fields-base'
-import {
-  HtCarouselNode,
-  HtHandoffNode,
-  HtImageNode,
-  HtPayloadNode,
-  HtQueueLocale,
-  HtTextNode,
-  HtVideoNode,
-  HtWhatsappButtonListNode,
-} from './hubtype-fields'
-
-type HtAfterHandoff =
-  | HtTextNode
-  | HtImageNode
-  | HtVideoNode
-  | HtCarouselNode
-  | HtWhatsappButtonListNode
+import { HtHandoffNode, HtPayloadNode, HtQueueLocale } from './hubtype-fields'
 
 export class FlowHandoff extends ContentFieldsBase {
   public code: string
@@ -54,21 +38,21 @@ export class FlowHandoff extends ContentFieldsBase {
     cmsApi: FlowBuilderApi
   ): string | undefined {
     if (cmsHandoff.target?.id) {
-      const handoffTargetNode = cmsApi.getNodeById<HtAfterHandoff>(
-        cmsHandoff.target?.id
+      const payloadFromBotActionNode = cmsApi.getPayloadFromBotActionNodeId(
+        cmsHandoff.target.id
       )
-      if (handoffTargetNode?.id) return handoffTargetNode?.id
+      return payloadFromBotActionNode || cmsHandoff.target.id
     }
 
+    // OLD PAYLOAD
     const payloadId = cmsHandoff.content.payload.find(
       payload => payload.locale === locale
     )?.id
+    if (payloadId) {
+      return cmsApi.getNodeById<HtPayloadNode>(payloadId).content.payload
+    }
 
-    if (!payloadId) return undefined
-
-    const actionPayload = cmsApi.getNodeById(payloadId)
-
-    return (actionPayload as HtPayloadNode).content.payload
+    return undefined
   }
 
   async doHandoff(request: ActionRequest): Promise<void> {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/bot-action.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/bot-action.ts
@@ -1,0 +1,11 @@
+import { HtBaseNode } from './common'
+import { HtNodeWithoutContentType } from './node-types'
+
+export interface HtBotActionNode extends HtBaseNode {
+  id: string
+  type: HtNodeWithoutContentType.BOT_ACTION
+  content: {
+    payload_id: string
+    payload_params?: string
+  }
+}

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/index.ts
@@ -1,3 +1,4 @@
+export * from './bot-action'
 export * from './button'
 export * from './carousel'
 export * from './common'

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/node-types.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/node-types.ts
@@ -15,6 +15,7 @@ export enum HtNodeWithoutContentType {
   URL = 'url',
   PAYLOAD = 'payload',
   GO_TO_FLOW = 'go-to-flow',
+  BOT_ACTION = 'bot-action',
 }
 
 export enum HtButtonStyle {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
@@ -1,3 +1,4 @@
+import { HtBotActionNode } from './bot-action'
 import { HtCarouselNode } from './carousel'
 import { HtFallbackNode } from './fallback'
 import { HtFunctionNode } from './function'
@@ -24,6 +25,10 @@ export type HtNodeWithContent =
   | HtFallbackNode
   | HtWhatsappButtonListNode
 
-export type HtNodeWithoutContent = HtUrlNode | HtPayloadNode | HtGoToFlow
+export type HtNodeWithoutContent =
+  | HtUrlNode
+  | HtPayloadNode
+  | HtGoToFlow
+  | HtBotActionNode
 
 export type HtNodeComponent = HtNodeWithContent | HtNodeWithoutContent

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -65,11 +65,12 @@ export default class BotonicPluginFlowBuilder implements Plugin {
       request: this.currentRequest,
     })
 
-    if (
+    const checkUserTextInput =
       request.input.data &&
       !request.input.payload &&
       !request.session.is_first_interaction
-    ) {
+
+    if (checkUserTextInput) {
       const nodeByUserInput = await getNodeByUserInput(
         this.cmsApi,
         this.getLocale(request.session),

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -59,6 +59,22 @@ export default class BotonicPluginFlowBuilder implements Plugin {
       accessToken: this.getAccessToken(request.session),
       request: this.currentRequest,
     })
+
+    if (
+      request.input.data &&
+      !request.input.payload &&
+      !request.session.is_first_interaction
+    ) {
+      const nodeByUserInput = await getNodeByUserInput(
+        this.cmsApi,
+        this.getLocale(request.session),
+        request as unknown as ActionRequest
+      )
+      request.input.payload = this.cmsApi.getPayloadFromBotActionNodeId(
+        nodeByUserInput?.id
+      )
+    }
+
     if (request.input.payload) {
       request.input.payload = request.input.payload?.split(
         SOURCE_INFO_SEPARATOR

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -75,9 +75,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
         this.getLocale(request.session),
         request as unknown as ActionRequest
       )
-      request.input.payload = this.cmsApi.getPayloadFromBotActionNodeId(
-        nodeByUserInput?.id
-      )
+      request.input.payload = this.cmsApi.getPayload(nodeByUserInput?.target)
     }
 
     if (request.input.payload) {

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -1,8 +1,9 @@
 import { Plugin, PluginPreRequest, Session } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
+import { getNodeByUserInput } from './action/user-input'
 import { FlowBuilderApi } from './api'
-import { SOURCE_INFO_SEPARATOR } from './constants'
+import { SEPARATOR, SOURCE_INFO_SEPARATOR } from './constants'
 import {
   FlowCarousel,
   FlowContent,
@@ -20,7 +21,11 @@ import {
   HtNodeWithContentType,
 } from './content-fields/hubtype-fields'
 import { DEFAULT_FUNCTIONS } from './functions'
-import { BotonicPluginFlowBuilderOptions, KnowledgeBaseResponse } from './types'
+import {
+  BotonicPluginFlowBuilderOptions,
+  KnowledgeBaseResponse,
+  PayloadParamsBase,
+} from './types'
 import { resolveGetAccessToken } from './utils'
 
 export default class BotonicPluginFlowBuilder implements Plugin {
@@ -181,8 +186,13 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     }
     return result.target.id
   }
+
+  getPayloadParams<T>(payload: string): T & PayloadParamsBase {
+    const payloadParams = JSON.parse(payload.split(SEPARATOR)[1] || '{}')
+    return payloadParams
+  }
 }
 
 export * from './action'
 export * from './content-fields'
-export { BotonicPluginFlowBuilderOptions } from './types'
+export { BotonicPluginFlowBuilderOptions, PayloadParamsBase } from './types'

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -187,7 +187,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     return result.target.id
   }
 
-  getPayloadParams<T>(payload: string): T & PayloadParamsBase {
+  getPayloadParams<T extends PayloadParamsBase>(payload: string): T {
     const payloadParams = JSON.parse(payload.split(SEPARATOR)[1] || '{}')
     return payloadParams
   }

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -39,3 +39,7 @@ export interface KnowledgeBaseResponse {
     page?: number
   }[]
 }
+
+export interface PayloadParamsBase {
+  followUpId?: string
+}


### PR DESCRIPTION
## Description

- adds the functionality to use BotActionNode created in the FlowBuilder frontend.
- add a function to getPayloadParams in JSON format when receiving a payload.
- add a base type for payloadParams 

## Context

A BotAction node can target 4 types of nodes: Button, Handoff, Keyword and Intent

When the target is a Button (from Text, Carousel or WhatsappButtonList) or a Handoff in the botonicInit function of the plugin-flow-builder we must obtain the payload defined in the BotAction node and replace it. This way when the user clicks on a button or executes a handoff the payload will be the correct one.

With Keywords and Intents it is different, what we want is that when the bot executes the routes, the payload is already in the request so that the route of the action indicated by the payload is executed. To do this we have to make the logic of building the payload in the pre function of the plugin-flow-builder. This function is executed before the routes.
**IMPORTANT -> For the case where an intent points directly to a nod BotAction to work, the plugin-hubtype-babel must be placed before the plugin-flow-builder.**

## To document / Usage example

Example of how a bot action would be executed by receiving a payload defined with a BotActionNode.

Here we use the function getPaylodParams, one of the parameters will be followUpId if the BotAcitonNode has a follow up defined. With this Id we retrieve the contents for rendering.

```typescript
import {
  FlowBuilderActionProps,
  FlowBuilderMultichannelAction,
} from '@botonic/plugin-flow-builder'
import { PayloadParamsBase } from '@botonic/plugin-flow-builder/lib/esm'
import { RequestContext } from '@botonic/react'
import React from 'react'

import { BotRequest } from '../types'
import { getRequestData } from '../utils/actions'

export class TestAction extends FlowBuilderMultichannelAction {
  static contextType = RequestContext
  static async botonicInit(
    request: BotRequest
  ): Promise<FlowBuilderActionProps> {
    const { cmsPlugin, botContext, payload } = getRequestData(request)
    const payloadParams = cmsPlugin.getPayloadParams<PayloadParamsBase>(payload)

    console.log('Do some logic with payloadParams', { payloadParams })

    const contents = await cmsPlugin.getContentsById(
      payloadParams.followUpId,
      botContext.locale
    )
    return { contents }
  }
}
```

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
