### PR TITLE
Fix: agent message styles use botMessageStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,21 @@ All notable changes to Botonic will be documented in this file.
 
 ### Added
 
-- [@botonic/plugin-flow-builder](https://www.npmjs.com/package/@botonic/plugin-flow-builder)
-
-  - [Add the `bot-action` node](https://github.com/hubtype/botonic/pull/2769) This node is used to define a payload and parameters, to execute an action defined in the bot routes.
-
 ### Changed
 
 ### Fixed
 
 </details>
 
-## [0.24.x] - 2024-01-23
+## [0.24.3] - 2024-01-30
+
+### Fixed
+
+- [@botonic/react](https://www.npmjs.com/package/@botonic/react)
+
+  - [Fix agent message use `botMessageStyle`](https://github.com/hubtype/botonic/pull/2777)
+
+## [0.24.2] - 2024-01-23
 
 ### Added
 

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/components/message/index.jsx
+++ b/packages/botonic-react/src/components/message/index.jsx
@@ -149,9 +149,9 @@ export const Message = props => {
   }
 
   const getMessageStyle = () =>
-    isSentByBot
-      ? getThemeProperty(WEBCHAT.CUSTOM_PROPERTIES.botMessageStyle)
-      : getThemeProperty(WEBCHAT.CUSTOM_PROPERTIES.userMessageStyle)
+    isSentByUser
+      ? getThemeProperty(WEBCHAT.CUSTOM_PROPERTIES.userMessageStyle)
+      : getThemeProperty(WEBCHAT.CUSTOM_PROPERTIES.botMessageStyle)
 
   const userOrBotMessage = isSentByUser ? SENDERS.user : SENDERS.bot
   const hasBlobTick = () =>


### PR DESCRIPTION
## Description
When a message is sent by the agent it must have the same styles as a message sent by the bot

## Context
When the feature of being able to change the image in the agent messages was added, the SENDERS.agent was added.
It was necessary to change the order of the conditional to apply the bot styles to non-user messages.


