### PR TITLE
plugin-flow-builder: check if agents are available in conditional queue 

### DIFF
--- a/packages/botonic-plugin-flow-builder/package-lock.json
+++ b/packages/botonic-plugin-flow-builder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.24.2",
+  "version": "0.24.3-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.24.2",
+  "version": "0.24.3-alpha.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/function.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/function.ts
@@ -2,6 +2,7 @@ import { HtBaseNode, HtNodeLink } from './common'
 import { HtNodeWithContentType } from './node-types'
 
 export enum HtArgumentType {
+  BOOLEAN = 'boolean',
   NUMBER = 'number',
   STRING = 'string',
   JSON = 'json',
@@ -23,11 +24,13 @@ export interface HtFunctionResult {
   target?: HtNodeLink
 }
 
+export type HtFunctionArguments = HtFunctionArgumentLocale | HtFunctionArgument
+
 export interface HtFunctionNode extends HtBaseNode {
   type: HtNodeWithContentType.FUNCTION
   content: {
     action: string
-    arguments: HtFunctionArgumentLocale[]
+    arguments: HtFunctionArguments[]
     result_mapping: HtFunctionResult[]
   }
 }

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
@@ -10,15 +10,21 @@ type ConditionalQueueStatusArgs = {
   check_available_agents: boolean
 }
 
+enum QueueStatusResult {
+  open = 'open',
+  closed = 'closed',
+  openWithoutAgents = 'open-without-agents',
+}
+
 export async function conditionalQueueStatus({
   queue_id,
   check_available_agents,
-}: ConditionalQueueStatusArgs): Promise<string> {
+}: ConditionalQueueStatusArgs): Promise<QueueStatusResult> {
   const data = await getQueueAvailability(queue_id, check_available_agents)
   if (check_available_agents && data.open && data.available_agents === 0) {
-    return 'open_without_agents'
+    return QueueStatusResult.openWithoutAgents
   }
-  return data.open ? 'open' : 'closed'
+  return data.open ? QueueStatusResult.open : QueueStatusResult.closed
 }
 
 interface AvailabilityData {

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
@@ -11,9 +11,9 @@ type ConditionalQueueStatusArgs = {
 }
 
 enum QueueStatusResult {
-  open = 'open',
-  closed = 'closed',
-  openWithoutAgents = 'open-without-agents',
+  OPEN = 'open',
+  CLOSED = 'closed',
+  OPEN_WITHOUT_AGENTS = 'open-without-agents',
 }
 
 export async function conditionalQueueStatus({
@@ -22,9 +22,9 @@ export async function conditionalQueueStatus({
 }: ConditionalQueueStatusArgs): Promise<QueueStatusResult> {
   const data = await getQueueAvailability(queue_id, check_available_agents)
   if (check_available_agents && data.open && data.available_agents === 0) {
-    return QueueStatusResult.openWithoutAgents
+    return QueueStatusResult.OPEN_WITHOUT_AGENTS
   }
-  return data.open ? QueueStatusResult.open : QueueStatusResult.closed
+  return data.open ? QueueStatusResult.OPEN : QueueStatusResult.CLOSED
 }
 
 interface AvailabilityData {

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-queue-status.ts
@@ -38,7 +38,7 @@ interface AvailabilityData {
 
 export async function getQueueAvailability(
   queueId: string,
-  check_available_agents = false
+  checkAvailableAgents = false
 ): Promise<AvailabilityData> {
   const response = await axios.get(
     `${HUBTYPE_API_URL}/public/v1/queues/${queueId}/availability/`,
@@ -47,7 +47,7 @@ export async function getQueueAvailability(
       params: {
         check_queue_schedule: true,
         check_waiting_cases: false,
-        check_available_agents: check_available_agents,
+        check_available_agents: checkAvailableAgents,
       },
     }
   )

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -169,8 +169,6 @@ export default class BotonicPluginFlowBuilder implements Plugin {
       return { [arg.name]: arg.value }
     })
 
-    console.log('callFunction', { functionArguments, nameValues })
-
     const args = Object.assign(
       {
         request: this.currentRequest,
@@ -197,7 +195,6 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     args: HtFunctionArguments[],
     locale: string
   ): HtFunctionArgument[] {
-    console.log('getArgumentsByLocale', args)
     let resultArguments: HtFunctionArgument[] = []
     for (const arg of args) {
       if ('locale' in arg && arg.locale === locale) {

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -15,6 +15,8 @@ import {
 } from './content-fields'
 import {
   HtFlowBuilderData,
+  HtFunctionArgument,
+  HtFunctionArguments,
   HtFunctionNode,
   HtNodeComponent,
   HtNodeWithContent,
@@ -159,10 +161,15 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     locale: string
   ): Promise<string> {
     const functionNodeId = functionNode.id
-    const nameValues =
-      functionNode.content.arguments
-        .find(arg => arg.locale === locale)
-        ?.values.map(value => ({ [value.name]: value.value })) || []
+    const functionArguments = this.getArgumentsByLocale(
+      functionNode.content.arguments,
+      locale
+    )
+    const nameValues = functionArguments.map(arg => {
+      return { [arg.name]: arg.value }
+    })
+
+    console.log('callFunction', { functionArguments, nameValues })
 
     const args = Object.assign(
       {
@@ -184,6 +191,24 @@ export default class BotonicPluginFlowBuilder implements Plugin {
       )
     }
     return result.target.id
+  }
+
+  private getArgumentsByLocale(
+    args: HtFunctionArguments[],
+    locale: string
+  ): HtFunctionArgument[] {
+    console.log('getArgumentsByLocale', args)
+    let resultArguments: HtFunctionArgument[] = []
+    for (const arg of args) {
+      if ('locale' in arg && arg.locale === locale) {
+        resultArguments = [...resultArguments, ...arg.values]
+      }
+      if ('type' in arg) {
+        resultArguments = [...resultArguments, arg]
+      }
+    }
+
+    return resultArguments
   }
 
   getPayloadParams<T extends PayloadParamsBase>(payload: string): T {


### PR DESCRIPTION
## Description

Now in the FlowBuilder frontend we can have queue conditionals, which check if there are available agents with a check box. This generates a conditional queue with 3 outputs.

## Context

The node with 3 outputs will look like this
```typescript
{
      id: 'b0b61028-b683-4ea6-ba7d-b79ca160e438',
      code: 'CONDITIONAL_QUEUE',
      meta: { x: 358.20617669934023, y: 352.83848058278346 },
      follow_up: null,
      target: null,
      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
      type: 'function',
      content: {
        action: 'check-queue-status',
        arguments: [
          {
            type: 'boolean',
            name: 'check_available_agents',
            value: true,
          },
          {
            locale: 'en',
            values: [
              {
                type: 'string',
                name: 'queue_id',
                value: 'e7a2304d-f73c-409d-b272-239a9b8a9e0e',
              },
              { type: 'string', name: 'queue_name', value: 'General' },
            ],
          },
        ],
        result_mapping: [
          {
            result: 'open',
            target: {
              id: 'de7a4af4-0c50-44ee-9f6c-86796c6d4c53',
              type: 'text',
            },
          },
          {
            result: 'open-without-agents',
            target: {
              id: '503cfe1a-8cd4-4c9c-be42-dc00b3d43806',
              type: 'text',
            },
          },
          {
            result: 'closed',
            target: {
              id: 'd2ec4c3a-bdc2-4e22-8b1c-ec0b473feadd',
              type: 'text',
            },
          },
        ],
      },
    },
```

## Approach taken / Explain the design

The arguments of a node of type function can have arguments that depend on the locale and arguments that do not depend on the locale (for example argument with name check_available_agents)

After processing the arguments we get the following arrays:

```typescript 
functionArguments: [
    { type: 'boolean', name: 'check_available_agents', value: true },
    {
      type: 'string',
      name: 'queue_id',
      value: 'e7a2304d-f73c-409d-b272-239a9b8a9e0e'
    },
    { type: 'string', name: 'queue_name', value: 'General' }
  ],
  nameValues: [
    { check_available_agents: true },
    { queue_id: 'e7a2304d-f73c-409d-b272-239a9b8a9e0e' },
    { queue_name: 'General' }
  ]
```