### PR TITLE
botonic-react: in custom messages set for default sentBy to bot

### DIFF
--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.24.3",
+  "version": "0.24.4-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.24.3",
+  "version": "0.24.4-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/components/custom-message.jsx
+++ b/packages/botonic-react/src/components/custom-message.jsx
@@ -24,7 +24,9 @@ export const customMessage = ({
 }) => {
   const CustomMessage = props => {
     warnDeprecatedProps(defaultProps, 'customMessage:')
-    if (defaultProps.sentBy === SENDERS.user) defaultProps.ack = 1
+    if (defaultProps.sentBy === SENDERS.user) {
+      defaultProps.ack = 1
+    }
     return (
       <Message
         {...merge(mapObjectNonBooleanValues(defaultProps), props)}
@@ -64,7 +66,7 @@ export const customMessage = ({
           children: childrenWithoutReplies,
           customTypeName: name,
         }}
-        sentBy={props.sentBy}
+        sentBy={props.sentBy || SENDERS.bot}
         isUnread={props.isUnread}
       >
         <ErrorBoundary key={'errorBoundary'} {...customMessageProps}>
@@ -84,7 +86,7 @@ export const customMessage = ({
       key={msg.key}
       json={msg.data}
       {...msg.data}
-      sentBy={msg.sentBy}
+      sentBy={msg.sentBy || SENDERS.bot}
       isUnread={msg.isUnread}
     />
   )

--- a/packages/botonic-react/src/webchat/messages-reducer.ts
+++ b/packages/botonic-react/src/webchat/messages-reducer.ts
@@ -1,3 +1,4 @@
+import { SENDERS } from '../index-types'
 import { WebchatAction } from './actions'
 import { WebchatState } from './index-types'
 
@@ -45,7 +46,7 @@ function addMessageComponent(
   const messageComponent = action.payload
   const isUnreadMessage =
     messageComponent.props?.isUnread &&
-    messageComponent.props?.sent_by !== 'user'
+    messageComponent.props?.sentBy !== SENDERS.user
 
   const numUnreadMessages = isUnreadMessage
     ? state.numUnreadMessages + 1

--- a/packages/botonic-react/tests/components/__snapshots__/custom-message.test.jsx.snap
+++ b/packages/botonic-react/tests/components/__snapshots__/custom-message.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`CustomMessage replies TEST: replies are moved outside the custom compon
 <message
   delay={0}
   json="{"children":{"key":null,"ref":null,"props":{"payload":"payloadundefined","children":["button",null]},"_owner":null,"_store":{}},"customTypeName":"test1"}"
+  sentBy="bot"
   type="custom"
   typing={0}
 >
@@ -26,6 +27,7 @@ exports[`CustomMessage replies TEST: replies are moved outside the custom compon
 <message
   delay={0}
   json="{"children":[{"key":".$1","ref":null,"props":{"payload":"payload1","children":["button",1]},"_owner":null,"_store":{}},{"key":".$2","ref":null,"props":{"payload":"payload2","children":["button",2]},"_owner":null,"_store":{}}],"customTypeName":"test1"}"
+  sentBy="bot"
   type="custom"
   typing={0}
 >
@@ -55,6 +57,7 @@ exports[`CustomMessage replies TEST: replies are moved outside the custom compon
 <message
   delay={0}
   json="{"children":[],"customTypeName":"test1"}"
+  sentBy="bot"
   type="custom"
   typing={0}
 >
@@ -76,6 +79,7 @@ exports[`CustomMessage replies TEST: replies are moved outside the custom compon
 <message
   delay={0}
   json="{"children":[{"key":".$2","ref":null,"props":{"payload":"payload2","children":["button",2]},"_owner":null,"_store":{}}],"customTypeName":"test1"}"
+  sentBy="bot"
   type="custom"
   typing={0}
 >
@@ -105,6 +109,7 @@ exports[`CustomMessage replies TEST: replies are moved outside the custom compon
 <message
   delay={0}
   json="{"children":[],"customTypeName":"test1"}"
+  sentBy="bot"
   type="custom"
   typing={0}
 >
@@ -133,6 +138,7 @@ exports[`TEST: CustomMessage defaultProps, props and children are injected into 
 <message
   delay={0}
   json="{"wrappedProp":"wrappedPropV","children":"body","customTypeName":"test1"}"
+  sentBy="bot"
   type="custom"
   typing={0}
   wrapperProp="wrapperPropV"


### PR DESCRIPTION
## Description

Fixes a bug that occurred when developing locally. The bug is that the css class was not added to the custom message. This happened because the sentBy is not set as local is rendered directly in the browser. 