### PR TITLE
plugin-flow-builder: be able to use bot actions in whatsapp button list

### DIFF
--- a/packages/botonic-plugin-flow-builder/package-lock.json
+++ b/packages/botonic-plugin-flow-builder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.24.4-alpha.0",
+  "version": "0.24.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-flow-builder/package-lock.json
+++ b/packages/botonic-plugin-flow-builder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.24.3",
+  "version": "0.24.4-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.24.3",
+  "version": "0.24.4-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.24.4-alpha.0",
+  "version": "0.24.4",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/content-fields/whatsapp-button-list/flow-whatsapp-button-list-row.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/whatsapp-button-list/flow-whatsapp-button-list-row.tsx
@@ -1,5 +1,6 @@
 import { WhatsappButtonListRowProps } from '@botonic/react'
 
+import { FlowBuilderApi } from '../../api'
 import { SOURCE_INFO_SEPARATOR } from '../../constants'
 import { ContentFieldsBase } from '../content-fields-base'
 import { HtWhatsappButtonListRow } from '../hubtype-fields'
@@ -11,12 +12,13 @@ export class FlowWhatsappButtonListRow extends ContentFieldsBase {
 
   static fromHubtypeCMS(
     component: HtWhatsappButtonListRow,
-    locale: string
+    locale: string,
+    cmsApi: FlowBuilderApi
   ): FlowWhatsappButtonListRow {
     const newRow = new FlowWhatsappButtonListRow(component.id)
     newRow.title = this.getTextByLocale(locale, component.text)
     newRow.description = this.getTextByLocale(locale, component.description)
-    newRow.targetId = component.target?.id
+    newRow.targetId = cmsApi.getPayload(component.target)
     return newRow
   }
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/whatsapp-button-list/flow-whatsapp-button-list-section.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/whatsapp-button-list/flow-whatsapp-button-list-section.tsx
@@ -3,6 +3,7 @@ import {
   WhatsappButtonListSectionProps,
 } from '@botonic/react'
 
+import { FlowBuilderApi } from '../../api'
 import { HtWhatsappButtonListSection } from '../hubtype-fields'
 import { ContentFieldsBase } from './../content-fields-base'
 import { FlowWhatsappButtonListRow } from './flow-whatsapp-button-list-row'
@@ -13,12 +14,13 @@ export class FlowWhatsappButtonListSection extends ContentFieldsBase {
 
   static fromHubtypeCMS(
     component: HtWhatsappButtonListSection,
-    locale: string
+    locale: string,
+    cmsApi: FlowBuilderApi
   ): FlowWhatsappButtonListSection {
     const newButton = new FlowWhatsappButtonListSection(component.id)
     newButton.title = this.getTextByLocale(locale, component.title)
     newButton.rows = component.rows.map(row =>
-      FlowWhatsappButtonListRow.fromHubtypeCMS(row, locale)
+      FlowWhatsappButtonListRow.fromHubtypeCMS(row, locale, cmsApi)
     )
     return newButton
   }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/whatsapp-button-list/flow-whatsapp-button-list.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/whatsapp-button-list/flow-whatsapp-button-list.tsx
@@ -1,6 +1,7 @@
 import { WhatsappButtonList } from '@botonic/react'
 import React from 'react'
 
+import { FlowBuilderApi } from '../../api'
 import { HtWhatsappButtonListNode } from '../hubtype-fields'
 import { ContentFieldsBase } from './../content-fields-base'
 import { FlowWhatsappButtonListSection } from './flow-whatsapp-button-list-section'
@@ -13,7 +14,8 @@ export class FlowWhatsappButtonList extends ContentFieldsBase {
 
   static fromHubtypeCMS(
     component: HtWhatsappButtonListNode,
-    locale: string
+    locale: string,
+    cmsApi: FlowBuilderApi
   ): FlowWhatsappButtonList {
     const newWhatsappButtonList = new FlowWhatsappButtonList(component.id)
     newWhatsappButtonList.code = component.code
@@ -26,7 +28,7 @@ export class FlowWhatsappButtonList extends ContentFieldsBase {
       component.content.button_text
     )
     newWhatsappButtonList.sections = component.content.sections.map(section =>
-      FlowWhatsappButtonListSection.fromHubtypeCMS(section, locale)
+      FlowWhatsappButtonListSection.fromHubtypeCMS(section, locale, cmsApi)
     )
     return newWhatsappButtonList
   }

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -153,7 +153,11 @@ export default class BotonicPluginFlowBuilder implements Plugin {
       case HtNodeWithContentType.VIDEO:
         return FlowVideo.fromHubtypeCMS(hubtypeContent, locale)
       case HtNodeWithContentType.WHATSAPP_BUTTON_LIST:
-        return FlowWhatsappButtonList.fromHubtypeCMS(hubtypeContent, locale)
+        return FlowWhatsappButtonList.fromHubtypeCMS(
+          hubtypeContent,
+          locale,
+          this.cmsApi
+        )
       case HtNodeWithContentType.HANDOFF:
         return FlowHandoff.fromHubtypeCMS(hubtypeContent, locale, this.cmsApi)
       default:


### PR DESCRIPTION
## Description

Be able to use bot actions in whatsapp button list

## Context

The bot actions connected to a whatsapp button list were not working.

## Approach taken / Explain the design

Apply the logic used in the button also in the row of the whatsapp button list.

