### PR TITLE
plugin-flow-builder: country conditional function

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-country.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-country.ts
@@ -1,0 +1,14 @@
+import { ActionRequest } from '@botonic/react'
+
+interface ConditionalCountryArgs {
+  request: ActionRequest
+  results: string[]
+}
+
+export function conditionalCountry({
+  request,
+  results,
+}: ConditionalCountryArgs): string {
+  const country = request.session.user.extra_data.country
+  return results.find(result => result === country) || 'default'
+}

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-provider.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-provider.ts
@@ -10,6 +10,5 @@ export function conditionalProvider({
   results,
 }: ConditionalProviderArgs): string {
   const provider = request.session.user.provider
-  if (results.includes(provider)) return provider
-  return 'default'
+  return results.find(result => result === provider) || 'default'
 }

--- a/packages/botonic-plugin-flow-builder/src/functions/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/index.ts
@@ -1,3 +1,4 @@
+import { conditionalCountry } from './conditional-country'
 import { conditionalProvider } from './conditional-provider'
 import { conditionalQueueStatus } from './conditional-queue-status'
 
@@ -5,4 +6,5 @@ export const DEFAULT_FUNCTIONS = {
   // TODO: Rename api action name
   'check-queue-status': conditionalQueueStatus,
   'get-channel-type': conditionalProvider,
+  'check-country': conditionalCountry,
 }


### PR DESCRIPTION
## Description
Now in the FlowBuilder frontend we can define a country conditional, which checks which country the bot has defined in session.user.extra_data.country to follow the flow.

## Context
The node with 4 outputs
```
{
    "id": "39eaa899-00b9-4251-aec1-bc70264cb33a",
    "code": "",
    "is_code_ai_generated": false,
    "meta": {
        "x": -203.16711080845553,
        "y": 797.2281904144527
    },
    "follow_up": null,
    "target": null,
    "flow_id": "8d527e7d-ea6d-5422-b810-5b4c8be7657b",
    "type": "function",
    "content": {
        "action": "check-country",
        "arguments": [],
        "result_mapping": [
            {
                "result": "default",
                "target": {
                    "id": "9d171089-82b0-409b-ac2c-93ddc289fb7e",
                    "type": "image"
                }
            },
            {
                "result": "CA",
                "target": {
                    "id": "3e51200b-a385-4758-ab09-9978ca6888b3",
                    "type": "text"
                }
            },
            {
                "result": "FR",
                "target": {
                    "id": "683d91db-38b4-4171-b335-293c7825adad",
                    "type": "text"
                }
            },
            {
                "result": "ES",
                "target": {
                    "id": "5ee3c1b7-8ce0-4564-9e68-d4563ce01a0c",
                    "type": "function"
                }
            }
        ]
    }
}
```

## To document / Usage example

![Captura de pantalla 2024-03-08 a las 13 36 49](https://github.com/hubtype/botonic/assets/36898236/123d6fa2-28a8-4878-a869-a6ff61d5089c)
