### PR TITLE
plugin-flow-builder: add custom conditional

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -38,16 +38,18 @@ export class FlowBuilderAction extends React.Component<FlowBuilderActionProps> {
 
   render(): JSX.Element | JSX.Element[] {
     const { contents } = this.props
-    return contents.map(content => content.toBotonic(content.id))
+    const request = this.context
+    return contents.map(content => content.toBotonic(content.id, request))
   }
 }
 
 export class FlowBuilderMultichannelAction extends FlowBuilderAction {
   render(): JSX.Element | JSX.Element[] {
     const { contents } = this.props
+    const request = this.context
     return (
       <Multichannel text={{ buttonsAsText: false }}>
-        {contents.map(content => content.toBotonic(content.id))}
+        {contents.map(content => content.toBotonic(content.id, request))}
       </Multichannel>
     )
   }

--- a/packages/botonic-plugin-flow-builder/src/constants.ts
+++ b/packages/botonic-plugin-flow-builder/src/constants.ts
@@ -1,3 +1,4 @@
 export const SEPARATOR = '|'
 export const SOURCE_INFO_SEPARATOR = `${SEPARATOR}source_`
-export const VARIABLE_REGEX = /{([^}]+)}/g
+export const VARIABLE_PATTERN = /{([^}]+)}/g
+export const ACCESS_TOKEN_VARIABLE_KEY = '_access_token'

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
@@ -39,11 +39,19 @@ export class FlowText extends ContentFieldsBase {
         const botVariable = keyPath.endsWith(ACCESS_TOKEN_VARIABLE_KEY)
           ? getValueFromKeyPath(request, match)
           : getValueFromKeyPath(request, keyPath)
-        replacedText = replacedText.replace(match, botVariable ?? match)
+        replacedText = replacedText.replace(
+          match,
+          this.isValidType(botVariable) ? botVariable : match
+        )
       })
     }
 
     return replacedText
+  }
+
+  private static isValidType(botVariable: any): boolean {
+    const validTypes = ['boolean', 'string', 'number']
+    return validTypes.includes(typeof botVariable)
   }
 
   toBotonic(id: string, request: ActionRequest): JSX.Element {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
@@ -37,7 +37,7 @@ export class FlowText extends ContentFieldsBase {
       matches.forEach(match => {
         const keyPath = match.slice(1, -1)
         const botVariable = keyPath.endsWith(ACCESS_TOKEN_VARIABLE_KEY)
-          ? getValueFromKeyPath(request, match)
+          ? match
           : getValueFromKeyPath(request, keyPath)
         replacedText = replacedText.replace(
           match,

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { FlowBuilderApi } from '../api'
 import { VARIABLE_REGEX } from '../constants'
+import { getValueFromKeyPath } from '../utils'
 import { ContentFieldsBase } from './content-fields-base'
 import { FlowButton } from './flow-button'
 import { HtButtonStyle, HtTextNode } from './hubtype-fields'
@@ -40,9 +41,9 @@ export class FlowText extends ContentFieldsBase {
     let replacedText = text
     if (matches && extraData) {
       matches.forEach(match => {
-        const variable = match.slice(1, -1)
-        const value = extraData[variable] ?? match
-        replacedText = replacedText.replace(match, value)
+        const keyPath = match.slice(1, -1)
+        const botVariable = getValueFromKeyPath(extraData, keyPath)
+        replacedText = replacedText.replace(match, botVariable ?? match)
       })
     }
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
@@ -2,7 +2,7 @@ import { ActionRequest, Text } from '@botonic/react'
 import React from 'react'
 
 import { FlowBuilderApi } from '../api'
-import { VARIABLE_REGEX } from '../constants'
+import { ACCESS_TOKEN_VARIABLE_KEY, VARIABLE_PATTERN } from '../constants'
 import { getValueFromKeyPath } from '../utils'
 import { ContentFieldsBase } from './content-fields-base'
 import { FlowButton } from './flow-button'
@@ -23,10 +23,6 @@ export class FlowText extends ContentFieldsBase {
     newText.code = cmsText.code
     newText.buttonStyle = cmsText.content.buttons_style || HtButtonStyle.BUTTON
     newText.text = this.getTextByLocale(locale, cmsText.content.text)
-    // this.replaceVariables(
-    //   this.getTextByLocale(locale, cmsText.content.text),
-    //   cmsApi.request
-    // )
     newText.buttons = cmsText.content.buttons.map(button =>
       FlowButton.fromHubtypeCMS(button, locale, cmsApi)
     )
@@ -34,13 +30,13 @@ export class FlowText extends ContentFieldsBase {
   }
 
   static replaceVariables(text: string, request: ActionRequest): string {
-    const matches = text.match(VARIABLE_REGEX)
+    const matches = text.match(VARIABLE_PATTERN)
 
     let replacedText = text
     if (matches && request) {
       matches.forEach(match => {
         const keyPath = match.slice(1, -1)
-        const botVariable = keyPath.endsWith('_access_token')
+        const botVariable = keyPath.endsWith(ACCESS_TOKEN_VARIABLE_KEY)
           ? getValueFromKeyPath(request, match)
           : getValueFromKeyPath(request, keyPath)
         replacedText = replacedText.replace(match, botVariable ?? match)

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-bot-variable.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-bot-variable.ts
@@ -13,9 +13,6 @@ export function conditionalBotVariable({
   results,
   keyPath,
 }: ConditionalCountryArgs): string {
-  const botVariable = getValueFromKeyPath(
-    request.session.user.extra_data,
-    keyPath
-  )
+  const botVariable = getValueFromKeyPath(request, keyPath)
   return results.find(result => result === botVariable) ?? 'default'
 }

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-bot-variable.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-bot-variable.ts
@@ -1,0 +1,16 @@
+import { ActionRequest } from '@botonic/react'
+
+interface ConditionalCountryArgs {
+  request: ActionRequest
+  results: string[]
+  variable: string
+}
+
+export function conditionalBotVariable({
+  request,
+  results,
+  variable,
+}: ConditionalCountryArgs): string {
+  const botVariable = request.session.user.extra_data[variable]
+  return results.find(result => result === botVariable) ?? 'default'
+}

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-bot-variable.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-bot-variable.ts
@@ -1,16 +1,21 @@
 import { ActionRequest } from '@botonic/react'
 
+import { getValueFromKeyPath } from '../utils'
+
 interface ConditionalCountryArgs {
   request: ActionRequest
   results: string[]
-  variable: string
+  keyPath: string
 }
 
 export function conditionalBotVariable({
   request,
   results,
-  variable,
+  keyPath,
 }: ConditionalCountryArgs): string {
-  const botVariable = request.session.user.extra_data[variable]
+  const botVariable = getValueFromKeyPath(
+    request.session.user.extra_data,
+    keyPath
+  )
   return results.find(result => result === botVariable) ?? 'default'
 }

--- a/packages/botonic-plugin-flow-builder/src/functions/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/index.ts
@@ -1,3 +1,4 @@
+import { conditionalBotVariable } from './conditional-bot-variable'
 import { conditionalCountry } from './conditional-country'
 import { conditionalProvider } from './conditional-provider'
 import { conditionalQueueStatus } from './conditional-queue-status'
@@ -7,4 +8,5 @@ export const DEFAULT_FUNCTIONS = {
   'check-queue-status': conditionalQueueStatus,
   'get-channel-type': conditionalProvider,
   'check-country': conditionalCountry,
+  'check-bot-variable': conditionalBotVariable,
 }

--- a/packages/botonic-plugin-flow-builder/src/utils.ts
+++ b/packages/botonic-plugin-flow-builder/src/utils.ts
@@ -21,3 +21,9 @@ export function resolveGetAccessToken(
       throw new Error('No method defined for getting access token')
   }
 }
+
+export function getValueFromKeyPath(extraData: any, keyPath: string): any {
+  return keyPath
+    .split('.')
+    .reduce((object, key) => (object && object[key]) || undefined, extraData)
+}

--- a/packages/botonic-plugin-flow-builder/src/utils.ts
+++ b/packages/botonic-plugin-flow-builder/src/utils.ts
@@ -30,13 +30,20 @@ export function getValueFromKeyPath(
   if (keyPath.startsWith('input') || keyPath.startsWith('session')) {
     return keyPath
       .split('.')
-      .reduce((object, key) => (object && object[key]) || undefined, request)
+      .reduce((object, key) => resolveObjectKey(object, key), request)
   }
 
   return keyPath
     .split('.')
     .reduce(
-      (object, key) => (object && object[key]) || undefined,
+      (object, key) => resolveObjectKey(object, key),
       request.session.user.extra_data
     )
+}
+
+function resolveObjectKey(object: any, key: string): any {
+  if (object && object[key] !== undefined) {
+    return object[key]
+  }
+  return undefined
 }

--- a/packages/botonic-plugin-flow-builder/src/utils.ts
+++ b/packages/botonic-plugin-flow-builder/src/utils.ts
@@ -1,4 +1,5 @@
 import { Session } from '@botonic/core'
+import { ActionRequest } from '@botonic/react'
 
 import { BotonicPluginFlowBuilderOptions, ProcessEnvNodeEnvs } from './types'
 
@@ -22,8 +23,20 @@ export function resolveGetAccessToken(
   }
 }
 
-export function getValueFromKeyPath(extraData: any, keyPath: string): any {
+export function getValueFromKeyPath(
+  request: ActionRequest,
+  keyPath: string
+): any {
+  if (keyPath.startsWith('input') || keyPath.startsWith('session')) {
+    return keyPath
+      .split('.')
+      .reduce((object, key) => (object && object[key]) || undefined, request)
+  }
+
   return keyPath
     .split('.')
-    .reduce((object, key) => (object && object[key]) || undefined, extraData)
+    .reduce(
+      (object, key) => (object && object[key]) || undefined,
+      request.session.user.extra_data
+    )
 }


### PR DESCRIPTION
## Description

Add the function to resolve custom conditional node. 
This allows to check any variable(string, boolean, number) inside `request.session.user.extra_data`

## Context

These conditionals have one output for each check plus a `default`. 
When the variable being tested is a boolean the false and default output is the same. This resolves the case where you are testing a boolean that is currently undefined.

You can use variables that are nested in objects within extra_data. 
For example if you have the following extra_data object:
```typescript
const extra_data = {
  isLoggedIn: true,
  numberOfBags: 1,
  vehicle: 'bike',
  booking: {
    payment: {
      isPaid: false,
      type: 'cash',
    },
  },
}
```
You can access any variable by specifying the name with a string. If nested as isPaid or type the string must be dotted as if you were accessing the object in the code editor.

If the string does not start with either session or input, this variable will be looked for within `session.user.extra_data` (most of the variables that will be used are here). For example

- isLoggedIn
- numberOfBags
- vehicle 
- booking.payment.isPaid,
- booking.payment.type

If the string starts with session or input we will look for this variable in `request`. For example 
- session.user.name 
- input.data

If the value to replace in a text message is the `_access_token`, it will not be displayed.

## Approach taken / Explain the design

example of the JSON received from a custom conditional that checks a string variable called vehicle inside extra_data

```typescript
{
      id: 'bb34a3be-9cea-41e7-9616-4604afe00107',
      code: 'CHECK_VEHICLE',
      meta: {
        x: 242.24137237222322,
        y: 316.4777522774672,
      },
      follow_up: null,
      target: null,
      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
      type: 'function',
      content: {
        action: 'check-bot-variable',
        arguments: [
          {
            type: 'string',
            name: 'keyPath',
            value: 'vehicle',
          },
        ],
        result_mapping: [
          {
            result: 'car',
            target: {
              id: '5fb5360e-3d9e-4dea-bdff-51e277b67dcb',
              type: 'text',
            },
          },
          {
            result: 'bike',
            target: {
              id: '63d151eb-993a-4e80-9132-8107e9b928d1',
              type: 'text',
            },
          },
          {
            result: 'default',
            target: {
              id: '8f81e367-6661-4be0-835e-7d598a3c9562',
              type: 'text',
            },
          },
        ],
      },
    },
```
example of JSON recived from a custom conditional that checks a string variable called type inside extra_data.payment.type
```typescript
{
      id: 'bb34a3be-9cea-41e7-9616-4604afe00115',
      code: 'CHECK_PAYMENT_TYPE',
      meta: {
        x: 242.24137237222322,
        y: 316.4777522774672,
      },
      follow_up: null,
      target: null,
      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
      type: 'function',
      content: {
        action: 'check-bot-variable',
        arguments: [
          {
            type: 'string',
            name: 'keyPath',
            value: 'booking.payment.type',
          },
        ],
        result_mapping: [
          {
            result: 'card',
            target: {
              id: '5fb5360e-3d9e-4dea-bdff-51e277b67d00',
              type: 'text',
            },
          },
          {
            result: 'cash',
            target: {
              id: '63d151eb-993a-4e80-9132-8107e9b92800',
              type: 'text',
            },
          },
          {
            result: 'default',
            target: {
              id: '8f81e367-6661-4be0-835e-7d598a3c9500',
              type: 'text',
            },
          },
        ],
      },
    },
```


## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
