### PR TITLE
plugin-flow-builder: resolve regex in keywords

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -171,12 +171,12 @@ export class FlowBuilderApi {
     const result = node.content.keywords.find(
       keywords =>
         keywords.locale === locale &&
-        this.containsAnyKeywords(input, keywords.values)
+        this.inputMatchesAnyKeyword(input, keywords.values)
     )
     return Boolean(result)
   }
 
-  private containsAnyKeywords(input: string, keywords: string[]): boolean {
+  private inputMatchesAnyKeyword(input: string, keywords: string[]): boolean {
     return keywords.some(keyword => {
       const regExpMatchArray = keyword.match(REG_EXP_PATTERN)
       if (regExpMatchArray) {

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -1,7 +1,7 @@
 import { Input, PluginPreRequest } from '@botonic/core'
 import axios from 'axios'
 
-import { SEPARATOR } from './constants'
+import { REG_EXP_PATTERN, SEPARATOR } from './constants'
 import {
   HtBotActionNode,
   HtFallbackNode,
@@ -169,13 +169,30 @@ export class FlowBuilderApi {
     locale: string
   ): boolean {
     const result = node.content.keywords.find(
-      i => i.locale === locale && this.containsAnyKeywords(input, i.values)
+      keywords =>
+        keywords.locale === locale &&
+        this.containsAnyKeywords(input, keywords.values)
     )
     return Boolean(result)
   }
 
   private containsAnyKeywords(input: string, keywords: string[]): boolean {
-    return keywords.some(keyword => input.includes(keyword))
+    return keywords.some(keyword => {
+      const regExpMatchArray = keyword.match(REG_EXP_PATTERN)
+      if (regExpMatchArray) {
+        return this.resolveKeywordAsRegExp(regExpMatchArray, input)
+      }
+      return input.includes(keyword)
+    })
+  }
+
+  private resolveKeywordAsRegExp(
+    regExpMatchArray: RegExpMatchArray,
+    input: string
+  ) {
+    const [, pattern, flags] = regExpMatchArray
+    const keywordAsRegExp = new RegExp(pattern, flags)
+    return input.match(keywordAsRegExp)
   }
 
   getPayload(target?: HtNodeLink): string | undefined {

--- a/packages/botonic-plugin-flow-builder/src/constants.ts
+++ b/packages/botonic-plugin-flow-builder/src/constants.ts
@@ -2,3 +2,4 @@ export const SEPARATOR = '|'
 export const SOURCE_INFO_SEPARATOR = `${SEPARATOR}source_`
 export const VARIABLE_PATTERN = /{([^}]+)}/g
 export const ACCESS_TOKEN_VARIABLE_KEY = '_access_token'
+export const REG_EXP_PATTERN = /^\/(.*)\/([gimyus]*)$/


### PR DESCRIPTION
## Description

Being able to define keywords as regular expressions in the flow builder frontend, using the RegExp /pattern/flags format.

If the plugin detects that the keyword is a regular expression it will apply this in the user input, otherwise it will do the logic that was done until now to check if the exact word is in the user input.

## Context

The keyword node until now could only pass words and what it checked was if the user input contained that word exactly as it was written, including upper and lower case.
With this new feature we can use regex to do pattern matching.

## Approach taken / Explain the design

First it checks if the keyword is a regex if so it applies the regex on the user input. Otherwise it will do the logic that was done until now looking if the user input contains this word written as in the keyword node.

## To document / Usage example
 By using regex on a keyword you can capture inputs such as: 
- exact word /^word$/ 
- 5 numbers in a row /\d{5}/

In the following image we can see a keyword node where there are two keywords the first one is the text country, if we only have this keyword it would only enter in the next node if the user input contains the word country in lowercase. 
The second keyword is declared as a regex with the flag i which indicates that it will search case-insensitive.

![Captura de pantalla 2024-03-18 a las 17 41 24](https://github.com/hubtype/botonic/assets/36898236/bad2b931-1f4d-4258-8d30-6663537932a7)

