### PR TITLE
plugin-knowledge-bases: add is_faithful param in api response

### DIFF
--- a/packages/botonic-plugin-knowledge-bases/src/hubtype-knowledge-api-service.ts
+++ b/packages/botonic-plugin-knowledge-bases/src/hubtype-knowledge-api-service.ts
@@ -22,6 +22,7 @@ export class HubtypeApiService {
       question: string
       answer: string
       has_knowledge: boolean
+      is_faithful: boolean
       sources: {
         knowledge_source_id: string
         page?: number

--- a/packages/botonic-plugin-knowledge-bases/src/index.ts
+++ b/packages/botonic-plugin-knowledge-bases/src/index.ts
@@ -37,7 +37,7 @@ export default class BotonicPluginKnowledgeBases implements Plugin {
     return {
       question: response.data.question,
       answer: response.data.answer,
-      hasKnowledge: response.data.has_knowledge,
+      hasKnowledge: response.data.has_knowledge && response.data.is_faithful,
       sources,
     }
   }


### PR DESCRIPTION
## Description

Add in the api response the attribute is_faithful which indicates if the IA is trustworthy (has no hallucinations).

If this parameter is false we pass the hasKnowledge to the bot as false so that it does not use the response generated by the AI.
