### PR TITLE
feat(react): WhatsappCTAUrlButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ All notable changes to Botonic will be documented in this file.
 
 </details>
 
+## [0.26.0-beta.1] - 2024-04-24
+
+### Added
+
+- [@botonic/react](https://www.npmjs.com/package/@botonic/react)
+  - [Added new component `WhatsappCTAUrlButton` to support Whatsapp's Call to Action URL Buttons](https://github.com/hubtype/botonic/pull/2811).
+
+### Changed
+
+### Fixed
+
 ## [0.26.0-beta.0] - 2024-04-16
 
 ### Added

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -47,6 +47,7 @@ export enum INPUT {
   RAW = 'raw',
   CHAT_EVENT = 'chatevent',
   WHATSAPP_BUTTON_LIST = 'whatsapp-button-list',
+  WHATSAPP_CTA_URL_BUTTON = 'whatsapp-cta-url-button',
 }
 
 export enum CASE_STATUS {
@@ -100,6 +101,7 @@ export type InputType =
   | typeof INPUT.WHATSAPP_TEMPLATE
   | typeof INPUT.CHAT_EVENT
   | typeof INPUT.WHATSAPP_BUTTON_LIST
+  | typeof INPUT.WHATSAPP_CTA_URL_BUTTON
 
 export interface IntentResult {
   intent: string

--- a/packages/botonic-react/jest.config.js
+++ b/packages/botonic-react/jest.config.js
@@ -24,5 +24,4 @@ module.exports = {
       '<rootDir>/tests/__mocks__/file-mock.js',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },
-  projects: ['../../packages/botonic-core'],
 }

--- a/packages/botonic-react/src/components/button.jsx
+++ b/packages/botonic-react/src/components/button.jsx
@@ -1,10 +1,11 @@
-import { INPUT, params2queryString } from '@botonic/core'
+import { INPUT } from '@botonic/core'
 import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
 
 import { COLORS, WEBCHAT } from '../constants'
 import { WebchatContext } from '../contexts'
 import { renderComponent } from '../util/react'
+import { generateWebviewUrlWithParams } from '../util/webviews'
 import { ButtonsDisabler } from './buttons-disabler'
 
 const StyledButton = styled.button`
@@ -159,11 +160,11 @@ export const Button = props => {
   const renderNode = () => {
     const disabledProps = ButtonsDisabler.constructNodeProps(props)
     if (props.webview) {
-      const Webview = props.webview
-      let params = ''
-      if (props.params) params = params2queryString(props.params)
       return (
-        <button url={`/webviews/${Webview.name}?${params}`} {...disabledProps}>
+        <button
+          url={generateWebviewUrlWithParams(props.webview, props.params)}
+          {...disabledProps}
+        >
           {props.children}
         </button>
       )

--- a/packages/botonic-react/src/components/index.ts
+++ b/packages/botonic-react/src/components/index.ts
@@ -25,4 +25,8 @@ export {
   WhatsappButtonListRowProps,
   WhatsappButtonListSectionProps,
 } from './whatsapp-button-list'
+export {
+  WhatsappCTAUrlButton,
+  WhatsappCTAUrlButtonProps,
+} from './whatsapp-cta-url-button'
 export { WhatsappTemplate } from './whatsapp-template'

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -2,7 +2,7 @@ import { INPUT } from '@botonic/core'
 import React, { useContext } from 'react'
 
 import { RequestContext } from '../../contexts'
-import { WhatsappButtonList } from '..'
+import { WhatsappButtonList, WhatsappCTAUrlButton } from '..'
 import { Text } from '../text'
 import { MultichannelFacebook } from './facebook/facebook'
 import { MultichannelButton } from './multichannel-button'
@@ -237,6 +237,29 @@ export const MultichannelText = props => {
       [...postbackButtonElements],
       [...urlButtonElements]
     )
+
+    if (postbackButtonElements.length === 0) {
+      if (urlButtonElements.length === 1) {
+        return (
+          <WhatsappCTAUrlButton
+            body={textElements[0]}
+            displayText={urlButtonElements[0].props.children}
+            url={urlButtonElements[0].props.url}
+          />
+        )
+      }
+
+      if (webviewButtonElements.length === 1) {
+        return (
+          <WhatsappCTAUrlButton
+            body={textElements[0]}
+            displayText={webviewButtonElements[0].props.children}
+            webview={webviewButtonElements[0].props.webview}
+          />
+        )
+      }
+    }
+
     if (multichannelContext.messageSeparator != null) {
       return elements
     }
@@ -273,7 +296,7 @@ export const MultichannelText = props => {
         <Text {...propsLastText}>{propsLastText.children}</Text>
       </>
     )
-  } else {
-    return <Text {...props}>{props.children}</Text>
   }
+
+  return <Text {...props}>{props.children}</Text>
 }

--- a/packages/botonic-react/src/components/multichannel/multichannel-utils.js
+++ b/packages/botonic-react/src/components/multichannel/multichannel-utils.js
@@ -10,6 +10,9 @@ export const MULTICHANNEL_WHATSAPP_PROPS = { markdown: false }
 export const WHATSAPP_MAX_BUTTONS = 3
 export const WHATSAPP_LIST_MAX_BUTTONS = 10
 export const WHATSAPP_MAX_BUTTON_CHARS = 20
+export const WHATSAPP_MAX_HEADER_CHARS = 60
+export const WHATSAPP_MAX_BODY_CHARS = 1024
+export const WHATSAPP_MAX_FOOTER_CHARS = 60
 export const DEFAULT_WHATSAPP_MAX_BUTTON_SEPARATOR = 'More options:'
 export const MENU_BUTTON_WHATSAPP_BUTTON_LIST = 'Show options'
 

--- a/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
+++ b/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
@@ -1,0 +1,76 @@
+import { INPUT } from '@botonic/core'
+import React from 'react'
+
+import { truncateText } from '../util'
+import { renderComponent } from '../util/react'
+import { Message } from './message'
+import {
+  WHATSAPP_MAX_BODY_CHARS,
+  WHATSAPP_MAX_BUTTON_CHARS,
+  WHATSAPP_MAX_FOOTER_CHARS,
+  WHATSAPP_MAX_HEADER_CHARS,
+} from './multichannel/multichannel-utils'
+import { whatsappMarkdown } from './multichannel/whatsapp/markdown'
+
+// TODO: Add validation in component
+
+export const WHATSAPP_MAX_BUTTON_LIST_CHARS = 24
+export const WHATSAPP_MAX_BUTTON_LIST_DESCRIPTION_CHARS = 72
+export const WHATSAPP_MAX_BUTTON_LIST_ID_CHARS = 200
+
+export interface WhatsappCTAUrlButtonProps {
+  header?: string
+  body: string
+  footer?: string
+  parameters: {
+    display_text: string
+    url: string
+  }
+}
+
+const serialize = _whatsappCTAUrlButtonProps => {
+  // TODO: Implement to have data persistance in localStorage, not needed for this WhatsApp development
+  return {}
+}
+
+export const WhatsappCTAUrlButton = (props: WhatsappCTAUrlButtonProps) => {
+  const renderBrowser = () => {
+    // Return a dummy message for browser
+    const message = `${JSON.stringify(props)}`
+    return (
+      <Message
+        json={serialize(message)}
+        {...props}
+        type={INPUT.WHATSAPP_CTA_URL_BUTTON}
+      >
+        {message}
+      </Message>
+    )
+  }
+
+  const renderNode = () => {
+    const validatedProps = {
+      ...props,
+      header: props.header
+        ? truncateText(props.header, WHATSAPP_MAX_HEADER_CHARS)
+        : undefined,
+      body: truncateText(whatsappMarkdown(props.body), WHATSAPP_MAX_BODY_CHARS),
+      footer: props.footer
+        ? truncateText(props.footer, WHATSAPP_MAX_FOOTER_CHARS)
+        : undefined,
+      parameters: {
+        display_text: truncateText(
+          props.parameters.display_text,
+          WHATSAPP_MAX_BUTTON_CHARS
+        ),
+        url: props.parameters.url,
+      },
+    }
+    return (
+      // @ts-ignore Property 'message' does not exist on type 'JSX.IntrinsicElements'.
+      <message {...validatedProps} type={INPUT.WHATSAPP_CTA_URL_BUTTON} />
+    )
+  }
+
+  return renderComponent({ renderBrowser, renderNode })
+}

--- a/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
+++ b/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
@@ -13,19 +13,27 @@ import {
 } from './multichannel/multichannel-utils'
 import { whatsappMarkdown } from './multichannel/whatsapp/markdown'
 
-export const WHATSAPP_MAX_BUTTON_LIST_CHARS = 24
-export const WHATSAPP_MAX_BUTTON_LIST_DESCRIPTION_CHARS = 72
-export const WHATSAPP_MAX_BUTTON_LIST_ID_CHARS = 200
-
-export interface WhatsappCTAUrlButtonProps {
+export interface WhatsappCTAUrlButtonCommonProps {
   header?: string
   body: string
   footer?: string
   displayText: string
-  url?: string
-  webview?: any
+}
+
+export interface WhatsappCTAUrlButtonUrlProps
+  extends WhatsappCTAUrlButtonCommonProps {
+  url: string
+}
+
+export interface WhatsappCTAUrlButtonWebviewProps
+  extends WhatsappCTAUrlButtonCommonProps {
+  webview: any
   params?: any
 }
+
+export type WhatsappCTAUrlButtonProps =
+  | WhatsappCTAUrlButtonUrlProps
+  | WhatsappCTAUrlButtonWebviewProps
 
 const serialize = _whatsappCTAUrlButtonProps => {
   // TODO: Implement to have data persistance in localStorage, not needed for this WhatsApp development
@@ -33,9 +41,6 @@ const serialize = _whatsappCTAUrlButtonProps => {
 }
 
 export const WhatsappCTAUrlButton = (props: WhatsappCTAUrlButtonProps) => {
-  if (!props.url && !props.webview) {
-    console.error('You must provide at least a url or a webview')
-  }
   const renderBrowser = () => {
     // Return a dummy message for browser
     const message = `${JSON.stringify(props)}`
@@ -61,9 +66,10 @@ export const WhatsappCTAUrlButton = (props: WhatsappCTAUrlButtonProps) => {
         ? truncateText(props.footer, WHATSAPP_MAX_FOOTER_CHARS)
         : undefined,
       displayText: truncateText(props.displayText, WHATSAPP_MAX_BUTTON_CHARS),
-      url: props.webview
-        ? generateWebviewUrlWithParams(props.webview, props.params)
-        : props.url,
+      url:
+        'webview' in props
+          ? generateWebviewUrlWithParams(props.webview, props.params)
+          : props.url,
     }
     return (
       // @ts-ignore Property 'message' does not exist on type 'JSX.IntrinsicElements'.

--- a/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
+++ b/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { truncateText } from '../util'
 import { renderComponent } from '../util/react'
+import { generateWebviewUrlWithParams } from '../util/webviews'
 import { Message } from './message'
 import {
   WHATSAPP_MAX_BODY_CHARS,
@@ -12,8 +13,6 @@ import {
 } from './multichannel/multichannel-utils'
 import { whatsappMarkdown } from './multichannel/whatsapp/markdown'
 
-// TODO: Add validation in component
-
 export const WHATSAPP_MAX_BUTTON_LIST_CHARS = 24
 export const WHATSAPP_MAX_BUTTON_LIST_DESCRIPTION_CHARS = 72
 export const WHATSAPP_MAX_BUTTON_LIST_ID_CHARS = 200
@@ -22,10 +21,10 @@ export interface WhatsappCTAUrlButtonProps {
   header?: string
   body: string
   footer?: string
-  parameters: {
-    display_text: string
-    url: string
-  }
+  displayText: string
+  url?: string
+  webview?: any
+  params?: any
 }
 
 const serialize = _whatsappCTAUrlButtonProps => {
@@ -34,6 +33,9 @@ const serialize = _whatsappCTAUrlButtonProps => {
 }
 
 export const WhatsappCTAUrlButton = (props: WhatsappCTAUrlButtonProps) => {
+  if (!props.url && !props.webview) {
+    console.error('You must provide at least a url or a webview')
+  }
   const renderBrowser = () => {
     // Return a dummy message for browser
     const message = `${JSON.stringify(props)}`
@@ -58,13 +60,10 @@ export const WhatsappCTAUrlButton = (props: WhatsappCTAUrlButtonProps) => {
       footer: props.footer
         ? truncateText(props.footer, WHATSAPP_MAX_FOOTER_CHARS)
         : undefined,
-      parameters: {
-        display_text: truncateText(
-          props.parameters.display_text,
-          WHATSAPP_MAX_BUTTON_CHARS
-        ),
-        url: props.parameters.url,
-      },
+      displayText: truncateText(props.displayText, WHATSAPP_MAX_BUTTON_CHARS),
+      url: props.webview
+        ? generateWebviewUrlWithParams(props.webview, props.params)
+        : props.url,
     }
     return (
       // @ts-ignore Property 'message' does not exist on type 'JSX.IntrinsicElements'.

--- a/packages/botonic-react/src/util/webviews.ts
+++ b/packages/botonic-react/src/util/webviews.ts
@@ -1,0 +1,10 @@
+import { params2queryString } from '@botonic/core'
+
+export function generateWebviewUrlWithParams(
+  webview: any,
+  params: any = ''
+): string {
+  let webviewParams = ''
+  if (params) webviewParams = params2queryString(params)
+  return `/webviews/${webview.name}?${webviewParams}`
+}

--- a/packages/botonic-react/src/util/webviews.ts
+++ b/packages/botonic-react/src/util/webviews.ts
@@ -4,7 +4,6 @@ export function generateWebviewUrlWithParams(
   webview: any,
   params: any = ''
 ): string {
-  let webviewParams = ''
-  if (params) webviewParams = params2queryString(params)
+  const webviewParams = params ? params2queryString(params) : ''
   return `/webviews/${webview.name}?${webviewParams}`
 }

--- a/packages/botonic-react/tests/components/__snapshots__/whatsapp-cta-url-button.test.jsx.snap
+++ b/packages/botonic-react/tests/components/__snapshots__/whatsapp-cta-url-button.test.jsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders WhatsappCTAUrlButton component (passing a URL) 1`] = `
+<message
+  body="This is the body"
+  displayText="Go to Hubtype"
+  footer="This is the footer"
+  header="This is the header"
+  type="whatsapp-cta-url-button"
+  url="https://www.hubtype.com"
+/>
+`;
+
+exports[`renders WhatsappCTAUrlButton component (passing a Webview) 1`] = `
+<message
+  body="This is the body"
+  displayText="Go to webview"
+  footer="This is the footer"
+  header="This is the header"
+  params={
+    {
+      "numbers": "123",
+      "redirectUri": "www.some-site.com",
+    }
+  }
+  type="whatsapp-cta-url-button"
+  url="/webviews/MyWebview?numbers=123&redirectUri=www.some-site.com"
+  webview={[Function]}
+/>
+`;

--- a/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel.test.jsx.snap
+++ b/packages/botonic-react/tests/components/multichannel/__snapshots__/multichannel-carousel.test.jsx.snap
@@ -69,31 +69,17 @@ exports[`Multichannel carousel COMPACT mode dynamic carousel with URL and postba
     </button>
   </message>,
   <message
-    buttonsAsText={0}
-    delay={0}
-    indexMode="number"
-    markdown={0}
-    newkey={2}
-    type="text"
-    typing={0}
-  >
-    *Snatch* _Five minutes, Turkish_
-    
-- Visit website: https://www.imdb.com/title/tt0208092
-  </message>,
+    body="_Snatch_ _Five minutes, Turkish_"
+    displayText="Visit website"
+    type="whatsapp-cta-url-button"
+    url="https://www.imdb.com/title/tt0208092"
+  />,
   <message
-    buttonsAsText={0}
-    delay={0}
-    indexMode="number"
-    markdown={0}
-    newkey={3}
-    type="text"
-    typing={0}
-  >
-    *El laberinto del fauno* _2006_
-    
-- Visit website: https://www.imdb.com/title/tt0457430
-  </message>,
+    body="_El laberinto del fauno_ _2006_"
+    displayText="Visit website"
+    type="whatsapp-cta-url-button"
+    url="https://www.imdb.com/title/tt0457430"
+  />,
 ]
 `;
 
@@ -129,28 +115,16 @@ exports[`Multichannel carousel COMPACT mode dynamic carousel with payload/path b
 exports[`Multichannel carousel COMPACT mode dynamic carousel with url buttons 1`] = `
 [
   <message
-    delay={0}
-    indexMode="number"
-    markdown={0}
-    newkey={0}
-    type="text"
-    typing={0}
-  >
-    *Snatch* _Five minutes, Turkish_
-    
-- Visit website: https://www.imdb.com/title/tt0208092
-  </message>,
+    body="_Snatch_ _Five minutes, Turkish_"
+    displayText="Visit website"
+    type="whatsapp-cta-url-button"
+    url="https://www.imdb.com/title/tt0208092"
+  />,
   <message
-    delay={0}
-    indexMode="number"
-    markdown={0}
-    newkey={1}
-    type="text"
-    typing={0}
-  >
-    *El laberinto del fauno* _2006_
-    
-- Visit website: https://www.imdb.com/title/tt0457430
-  </message>,
+    body="_El laberinto del fauno_ _2006_"
+    displayText="Visit website"
+    type="whatsapp-cta-url-button"
+    url="https://www.imdb.com/title/tt0457430"
+  />,
 ]
 `;

--- a/packages/botonic-react/tests/components/whatsapp-cta-url-button.test.jsx
+++ b/packages/botonic-react/tests/components/whatsapp-cta-url-button.test.jsx
@@ -1,0 +1,38 @@
+import { expect, test } from '@jest/globals'
+import React from 'react'
+import TestRenderer from 'react-test-renderer'
+
+import { WhatsappCTAUrlButton } from '../../src/components/whatsapp-cta-url-button'
+
+const renderToJSON = sut => TestRenderer.create(sut).toJSON()
+
+test('renders WhatsappCTAUrlButton component (passing a URL)', () => {
+  const props = {
+    header: 'This is the header',
+    body: 'This is the body',
+    footer: 'This is the footer',
+    displayText: 'Go to Hubtype',
+    url: 'https://www.hubtype.com',
+  }
+
+  const tree = renderToJSON(<WhatsappCTAUrlButton {...props} />)
+  expect(tree).toMatchSnapshot()
+})
+
+test('renders WhatsappCTAUrlButton component (passing a Webview)', () => {
+  class MyWebview {}
+  const props = {
+    header: 'This is the header',
+    body: 'This is the body',
+    footer: 'This is the footer',
+    displayText: 'Go to webview',
+    webview: MyWebview,
+    params: {
+      numbers: '123',
+      redirectUri: 'www.some-site.com',
+    },
+  }
+
+  const tree = renderToJSON(<WhatsappCTAUrlButton {...props} />)
+  expect(tree).toMatchSnapshot()
+})


### PR DESCRIPTION
## Description
[Whatsapp Docs](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-messages?content_id=EhJZ0uS1mCvxd14#cta-url-buttons)
Added support for WhatsappCTAUrlButton by creating a new component.

## Context
Right now we didn't have a way to send a button with a webview in Whatsapp without showing the entire webview url or urls

## Approach taken / Explain the design
Multichannel implemenation will be replacing only texts coming with 1 button at this moment to this new created component, so this has to be taken in consideration when designing flows.

## To document / Usage example
Usage with URLs:
```
export class TestAction extends React.Component {
  static contextType = RequestContext
  render() {
    return (
      <WhatsappCTAUrlButton
        header='This is a header'
        body='This is **CTA Url Body**'
        footer='This is a footer'
        displayText='Go to Hubtype'
        url='https://www.hubtype.com'
      />
    )
  }
}

```
Usage with webviews:
```
export class TestAction extends React.Component {
  static contextType = RequestContext
  render() {
    return (
      <WhatsappCTAUrlButton
        header='This is a header'
        body='This is **CTA Url Body**'
        footer='This is a footer'
        displayText='Open a Hubtype Webview'
        webview={ExampleWebview}
        params={{
          firstParam: 1234,
          secondParam: 'redirect_uri=https://www.fake_url.com',
        }}
      />
    )
  }
}

```

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
