### PR TITLE
plugin-flow-builder: add whatsapp CTA url button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,12 @@ All notable changes to Botonic will be documented in this file.
 ### Added
 
 - [@botonic/react](https://www.npmjs.com/package/@botonic/react)
+
   - [Added new component `WhatsappCTAUrlButton` to support Whatsapp's Call to Action URL Buttons](https://github.com/hubtype/botonic/pull/2811).
+
+- [@botonic/plugin-flow-builder](https://www.npmjs.com/package/@botonic/plugin-flow-builder)
+
+  - [Added support for reading `WhatsappCTAUrlButton` nodes from Flow Builder](https://github.com/hubtype/botonic/pull/2811)
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27965,7 +27965,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.25.0",
+      "version": "0.26.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.23.9",
@@ -28155,6 +28155,28 @@
         "core-js": "^3.35.1"
       }
     },
+    "packages/botonic-plugin-dialogflow/node_modules/@botonic/core": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.25.0.tgz",
+      "integrity": "sha512-yIt1zTb00GN6OdGVgQUoJt7Ba0W/vKYuWuektmcEvv8KIdsN1X0XBGP5L3mX3C8RUd1KDaxIcGV2aSWRQ3EMdg==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "aws-sdk": "^2.1404.0",
+        "axios": "^1.6.8",
+        "decode": "^0.3.0",
+        "dynamodb-toolbox": "^0.3.4",
+        "fast-xml-parser": "3.19.0",
+        "html-entities": "^2.4.0",
+        "node-json-db": "^1.6.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "packages/botonic-plugin-dynamodb": {
       "name": "@botonic/plugin-dynamodb",
       "version": "0.25.0",
@@ -28174,6 +28196,28 @@
         "node": ">=20.0.0"
       }
     },
+    "packages/botonic-plugin-dynamodb/node_modules/@botonic/core": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.25.0.tgz",
+      "integrity": "sha512-yIt1zTb00GN6OdGVgQUoJt7Ba0W/vKYuWuektmcEvv8KIdsN1X0XBGP5L3mX3C8RUd1KDaxIcGV2aSWRQ3EMdg==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "aws-sdk": "^2.1404.0",
+        "axios": "^1.6.8",
+        "decode": "^0.3.0",
+        "dynamodb-toolbox": "^0.3.4",
+        "fast-xml-parser": "3.19.0",
+        "html-entities": "^2.4.0",
+        "node-json-db": "^1.6.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "packages/botonic-plugin-dynamodb/node_modules/@types/node": {
       "version": "20.11.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
@@ -28185,9 +28229,9 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.25.0",
+      "version": "0.26.0-beta.0",
       "dependencies": {
-        "@botonic/react": "^0.25.0",
+        "@botonic/react": "^0.26.0-beta.0",
         "axios": "^1.6.8",
         "uuid": "^9.0.1"
       },
@@ -28225,6 +28269,28 @@
         "axios": "^1.6.8"
       }
     },
+    "packages/botonic-plugin-google-analytics/node_modules/@botonic/core": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.25.0.tgz",
+      "integrity": "sha512-yIt1zTb00GN6OdGVgQUoJt7Ba0W/vKYuWuektmcEvv8KIdsN1X0XBGP5L3mX3C8RUd1KDaxIcGV2aSWRQ3EMdg==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "aws-sdk": "^2.1404.0",
+        "axios": "^1.6.8",
+        "decode": "^0.3.0",
+        "dynamodb-toolbox": "^0.3.4",
+        "fast-xml-parser": "3.19.0",
+        "html-entities": "^2.4.0",
+        "node-json-db": "^1.6.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "packages/botonic-plugin-google-translation": {
       "name": "@botonic/plugin-google-translation",
       "version": "0.25.0",
@@ -28234,6 +28300,28 @@
         "@botonic/core": "^0.25.0",
         "axios": "^1.6.8",
         "jsrsasign": "^10.9.0"
+      }
+    },
+    "packages/botonic-plugin-google-translation/node_modules/@botonic/core": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.25.0.tgz",
+      "integrity": "sha512-yIt1zTb00GN6OdGVgQUoJt7Ba0W/vKYuWuektmcEvv8KIdsN1X0XBGP5L3mX3C8RUd1KDaxIcGV2aSWRQ3EMdg==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "aws-sdk": "^2.1404.0",
+        "axios": "^1.6.8",
+        "decode": "^0.3.0",
+        "dynamodb-toolbox": "^0.3.4",
+        "fast-xml-parser": "3.19.0",
+        "html-entities": "^2.4.0",
+        "node-json-db": "^1.6.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "packages/botonic-plugin-hubtype-analytics": {
@@ -28251,6 +28339,28 @@
         "typescript": "^4.9.5"
       }
     },
+    "packages/botonic-plugin-hubtype-analytics/node_modules/@botonic/core": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.25.0.tgz",
+      "integrity": "sha512-yIt1zTb00GN6OdGVgQUoJt7Ba0W/vKYuWuektmcEvv8KIdsN1X0XBGP5L3mX3C8RUd1KDaxIcGV2aSWRQ3EMdg==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "aws-sdk": "^2.1404.0",
+        "axios": "^1.6.8",
+        "decode": "^0.3.0",
+        "dynamodb-toolbox": "^0.3.4",
+        "fast-xml-parser": "3.19.0",
+        "html-entities": "^2.4.0",
+        "node-json-db": "^1.6.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "packages/botonic-plugin-hubtype-babel": {
       "name": "@botonic/plugin-hubtype-babel",
       "version": "0.25.0",
@@ -28265,6 +28375,28 @@
         "@types/minipass": "^3.3.5",
         "@types/node": "^20.11.19",
         "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/botonic-plugin-hubtype-babel/node_modules/@botonic/core": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.25.0.tgz",
+      "integrity": "sha512-yIt1zTb00GN6OdGVgQUoJt7Ba0W/vKYuWuektmcEvv8KIdsN1X0XBGP5L3mX3C8RUd1KDaxIcGV2aSWRQ3EMdg==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "aws-sdk": "^2.1404.0",
+        "axios": "^1.6.8",
+        "decode": "^0.3.0",
+        "dynamodb-toolbox": "^0.3.4",
+        "fast-xml-parser": "3.19.0",
+        "html-entities": "^2.4.0",
+        "node-json-db": "^1.6.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -28290,6 +28422,28 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.16"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/botonic-plugin-knowledge-bases/node_modules/@botonic/core": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.25.0.tgz",
+      "integrity": "sha512-yIt1zTb00GN6OdGVgQUoJt7Ba0W/vKYuWuektmcEvv8KIdsN1X0XBGP5L3mX3C8RUd1KDaxIcGV2aSWRQ3EMdg==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "aws-sdk": "^2.1404.0",
+        "axios": "^1.6.8",
+        "decode": "^0.3.0",
+        "dynamodb-toolbox": "^0.3.4",
+        "fast-xml-parser": "3.19.0",
+        "html-entities": "^2.4.0",
+        "node-json-db": "^1.6.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -28328,10 +28482,10 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.25.0",
+      "version": "0.26.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@botonic/core": "^0.25.0",
+        "@botonic/core": "^0.26.0-beta.0",
         "axios": "^1.6.8",
         "emoji-picker-react": "^4.4.9",
         "framer-motion": "^3.1.1",

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
@@ -36,8 +36,8 @@ export class FlowButton extends ContentFieldsBase {
       newButton.payload = payloadNode.content.payload
     }
     if (cmsButton.url && urlId) {
-      const payloadNode = cmsApi.getNodeById<HtUrlNode>(urlId)
-      newButton.url = payloadNode.content.url
+      const urlNode = cmsApi.getNodeById<HtUrlNode>(urlId)
+      newButton.url = urlNode.content.url
     }
 
     return newButton

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-whatsapp-cta-url-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-whatsapp-cta-url-button.tsx
@@ -1,0 +1,63 @@
+import { WhatsappCTAUrlButton } from '@botonic/react'
+import React from 'react'
+
+import { FlowBuilderApi } from '../api'
+import { ContentFieldsBase } from './content-fields-base'
+import { FlowButton } from './flow-button'
+import { HtUrlNode } from './hubtype-fields'
+import { HtWhatsappCTAUrlButtonNode } from './hubtype-fields/whatsapp-cta-url-button'
+
+export class FlowWhatsappCtaUrlButtonNode extends ContentFieldsBase {
+  public code = ''
+  public text = ''
+  public header?: string
+  public footer?: string
+  public displayText = ''
+  public url: string = ''
+
+  static fromHubtypeCMS(
+    component: HtWhatsappCTAUrlButtonNode,
+    locale: string,
+    cmsApi: FlowBuilderApi
+  ): FlowWhatsappCtaUrlButtonNode {
+    const whatsappCtaUrlButton = new FlowWhatsappCtaUrlButtonNode(component.id)
+    whatsappCtaUrlButton.code = component.code
+    whatsappCtaUrlButton.text = this.getTextByLocale(
+      locale,
+      component.content.text
+    )
+    whatsappCtaUrlButton.header = this.getTextByLocale(
+      locale,
+      component.content.header
+    )
+    whatsappCtaUrlButton.footer = this.getTextByLocale(
+      locale,
+      component.content.footer
+    )
+    const button = FlowButton.fromHubtypeCMS(
+      component.content.button,
+      locale,
+      cmsApi
+    )
+    whatsappCtaUrlButton.displayText = button.text
+    const urlId = FlowButton.getUrlId(component.content.button, locale)
+    if (urlId) {
+      const urlNode = cmsApi.getNodeById<HtUrlNode>(urlId)
+      whatsappCtaUrlButton.url = urlNode.content.url
+    }
+    return whatsappCtaUrlButton
+  }
+
+  toBotonic(id: string): JSX.Element {
+    return (
+      <WhatsappCTAUrlButton
+        key={id}
+        body={this.text}
+        header={this.header}
+        footer={this.footer}
+        displayText={this.displayText}
+        url={this.url}
+      />
+    )
+  }
+}

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/node-types.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/node-types.ts
@@ -10,6 +10,7 @@ export enum HtNodeWithContentType {
   FALLBACK = 'fallback',
   VIDEO = 'video',
   WHATSAPP_BUTTON_LIST = 'whatsapp-button-list',
+  WHATSAPP_CTA_URL_BUTTON = 'whatsapp-cta-url-button',
 }
 
 export enum HtNodeWithoutContentType {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
@@ -13,6 +13,7 @@ import { HtTextNode } from './text'
 import { HtUrlNode } from './url'
 import { HtVideoNode } from './video'
 import { HtWhatsappButtonListNode } from './whatsapp-button-list'
+import { HtWhatsappCTAUrlButtonNode } from './whatsapp-cta-url-button'
 
 export type HtNodeWithContent =
   | HtTextNode
@@ -25,7 +26,8 @@ export type HtNodeWithContent =
   | HtFunctionNode
   | HtFallbackNode
   | HtWhatsappButtonListNode
-  | HtSmartIntentNode
+  | HtWhatsappCTAUrlButtonNode
+  | HtSmartIntentNode
 
 export type HtNodeWithoutContent =
   | HtUrlNode

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/whatsapp-cta-url-button.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/whatsapp-cta-url-button.ts
@@ -1,0 +1,13 @@
+import { HtButton } from './button'
+import { HtBaseNode, HtTextLocale } from './common'
+import { HtNodeWithContentType } from './node-types'
+
+export interface HtWhatsappCTAUrlButtonNode extends HtBaseNode {
+  type: HtNodeWithContentType.WHATSAPP_CTA_URL_BUTTON
+  content: {
+    text: HtTextLocale[]
+    header: HtTextLocale[]
+    footer: HtTextLocale[]
+    button: HtButton
+  }
+}

--- a/packages/botonic-plugin-flow-builder/src/content-fields/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/index.ts
@@ -3,6 +3,7 @@ import { FlowHandoff } from './flow-handoff'
 import { FlowImage } from './flow-image'
 import { FlowText } from './flow-text'
 import { FlowVideo } from './flow-video'
+import { FlowWhatsappCtaUrlButtonNode } from './flow-whatsapp-cta-url-button'
 import { FlowWhatsappButtonList } from './whatsapp-button-list/flow-whatsapp-button-list'
 
 export { ContentFieldsBase } from './content-fields-base'
@@ -17,4 +18,5 @@ export type FlowContent =
   | FlowText
   | FlowVideo
   | FlowWhatsappButtonList
+  | FlowWhatsappCtaUrlButtonNode
   | FlowHandoff

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -16,6 +16,7 @@ import {
   FlowVideo,
   FlowWhatsappButtonList,
 } from './content-fields'
+import { FlowWhatsappCtaUrlButtonNode } from './content-fields/flow-whatsapp-cta-url-button'
 import {
   HtFlowBuilderData,
   HtFunctionArgument,
@@ -166,6 +167,12 @@ export default class BotonicPluginFlowBuilder implements Plugin {
         return FlowVideo.fromHubtypeCMS(hubtypeContent, locale)
       case HtNodeWithContentType.WHATSAPP_BUTTON_LIST:
         return FlowWhatsappButtonList.fromHubtypeCMS(
+          hubtypeContent,
+          locale,
+          this.cmsApi
+        )
+      case HtNodeWithContentType.WHATSAPP_CTA_URL_BUTTON:
+        return FlowWhatsappCtaUrlButtonNode.fromHubtypeCMS(
           hubtypeContent,
           locale,
           this.cmsApi

--- a/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
+++ b/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
@@ -41,6 +41,9 @@ const serialize = _whatsappCTAUrlButtonProps => {
 }
 
 export const WhatsappCTAUrlButton = (props: WhatsappCTAUrlButtonProps) => {
+  if (!props.url && !props.webview) {
+    console.error('You must provide at least a url or a webview')
+  }
   const renderBrowser = () => {
     // Return a dummy message for browser
     const message = `${JSON.stringify(props)}`

--- a/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
+++ b/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
@@ -41,9 +41,6 @@ const serialize = _whatsappCTAUrlButtonProps => {
 }
 
 export const WhatsappCTAUrlButton = (props: WhatsappCTAUrlButtonProps) => {
-  if (!props.url && !props.webview) {
-    console.error('You must provide at least a url or a webview')
-  }
   const renderBrowser = () => {
     // Return a dummy message for browser
     const message = `${JSON.stringify(props)}`


### PR DESCRIPTION
## Description

Now we can have a whatsapp node containing a single button that redirects to a URL. When the plugin receives the JSON that defines a node of this type it will use a WhatsappCTAUrlButton from @botonic/react to render it.

## Context

Example of JSON defining this node
```
{
  "id": "a0898927-42f6-45a5-8c6a-66bdd92f0e13",
  "code": "test url",
  "is_code_ai_generated": false,
  "meta": {
    "x": -80.59924537568803,
    "y": -221.97477364675905
  },
  "follow_up": null,
  "target": null,
  "flow_id": "8d527e7d-ea6d-5422-b810-5b4c8be7657b",
  "type": "whatsapp-cta-url-button",
  "content": {
    "text": [
      {
        "message": "this is a text",
        "locale": "es"
      },
      {
        "message": "this is a text",
        "locale": "it"
      }
    ],
    "header": [
      {
        "message": "this is a header",
        "locale": "es"
      }
    ],
    "footer": [
      {
        "message": "this is a footer",
        "locale": "es"
      }
    ],
    "button": {
      "id": "85fd9960-1892-4117-96af-e07f5c0c76ca",
      "text": [
        {
          "message": "this is the text of a btn url",
          "locale": "es"
        }
      ],
      "url": [
        {
          "id": "945a346d-ab2f-4dc0-8206-5be281ee9799",
          "locale": "es"
        }
      ],
      "target": null,
      "payloads": [],
      "hidden": [],
    }
  }
}
```

## To document / Usage example
![Captura de pantalla 2024-04-19 a las 10 23 19](https://github.com/hubtype/botonic/assets/36898236/ab1b6408-1d84-4b00-b2dc-7c37c970fec7)
![Captura de pantalla 2024-04-19 a las 10 23 01](https://github.com/hubtype/botonic/assets/36898236/91aa46ca-5864-4290-a447-97dcf762d4f2)

