### PR TITLE
plugin-flow-builder: bot action limit characters

### DIFF
--- a/.github/workflows/botonic-plugin-flow-builder-tests.yml
+++ b/.github/workflows/botonic-plugin-flow-builder-tests.yml
@@ -1,0 +1,18 @@
+name: Botonic plugin flow builder tests
+
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-flow-builder/**'
+      - '.github/workflows/botonic-plugin-flow-builder-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  botonic-react-tests:
+    uses: ./.github/workflows/botonic-common-workflow.yml
+    secrets: inherit #pragma: allowlist secret
+    with:
+      PACKAGE_NAME: Botonic plugin flow builder tests
+      PACKAGE: botonic-plugin-flow-builder
+      BUILD_COMMAND: 'cd ../botonic-core && npm run build && cd ../botonic-react && npm run build && cd ../botonic-plugin-flow-builder && npm run build'
+      NEEDS_CODECOV_UPLOAD: 'yes'

--- a/package-lock.json
+++ b/package-lock.json
@@ -25842,7 +25842,7 @@
       "name": "@botonic/plugin-flow-builder",
       "version": "0.26.1",
       "dependencies": {
-        "@botonic/react": "^0.26.0",
+        "@botonic/react": "^0.26.1",
         "axios": "^1.6.8",
         "uuid": "^9.0.1"
       },

--- a/packages/botonic-plugin-flow-builder/babel.config.js
+++ b/packages/botonic-plugin-flow-builder/babel.config.js
@@ -1,0 +1,21 @@
+/*
+ * This babel configuration is used along with Jest for execute tests,
+ * do not modify to avoid conflicts with webpack.config.js.
+ */
+// require("@babel/register");
+
+/*
+ * This babel configuration is used along with Jest for execute tests,
+ * do not modify to avoid conflicts with webpack.config.js.
+ */
+
+module.exports = {
+  sourceType: 'unambiguous',
+  // .map files are not generated unless babel invoked with --source-maps
+  sourceMaps: true,
+  presets: ['@babel/preset-env', '@babel/preset-react'],
+  plugins: [
+    require('@babel/plugin-transform-modules-commonjs'),
+    require('@babel/plugin-transform-runtime'),
+  ],
+}

--- a/packages/botonic-plugin-flow-builder/jest.config.js
+++ b/packages/botonic-plugin-flow-builder/jest.config.js
@@ -1,0 +1,48 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path')
+
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  roots: ['src/', 'tests/'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.tests.json',
+      },
+    ],
+    '^.+\\.jsx?$': [
+      'babel-jest',
+      { configFile: path.resolve(__dirname, 'babel.config.js') },
+    ],
+  },
+  preset: 'ts-jest',
+  testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.([jt]sx?)$',
+  testPathIgnorePatterns: [
+    'dist',
+    'lib',
+    '.*.d.ts',
+    'tests/helpers',
+    'tests/mocks',
+    '.*json.*',
+    '__mocks__',
+  ],
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
+  transformIgnorePatterns: [
+    'node_modules/(?!@botonic|axios|escape-string-regexp).+\\.(js|jsx)$',
+  ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  snapshotSerializers: [],
+  setupFilesAfterEnv: [
+    // 'jest-expect-message', // to display a message when an assert fails
+    // 'jest-extended', // more assertions
+    '<rootDir>/jest.setup.js',
+  ],
+  modulePaths: ['node_modules', 'src'],
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '@botonic/dx/baseline/tests/__mocks__/file-mock.js',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  testEnvironment: 'node',
+}

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.26.1",
+  "version": "0.26.2-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -14,7 +14,7 @@
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"
   },
   "dependencies": {
-    "@botonic/react": "^0.26.1",
+    "@botonic/react": "^0.26.2-alpha.0",
     "axios": "^1.6.8",
     "uuid": "^9.0.1"
   },

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -14,7 +14,7 @@
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"
   },
   "dependencies": {
-    "@botonic/react": "^0.26.0",
+    "@botonic/react": "^0.26.1",
     "axios": "^1.6.8",
     "uuid": "^9.0.1"
   },

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "rm -rf lib && ../../node_modules/.bin/tsc -p tsconfig.json && ../../node_modules/.bin/tsc -p tsconfig.esm.json",
     "build:watch": "npm run build -- --watch",
-    "test": "echo Skipping tests...",
+    "test": "../../node_modules/.bin/jest --coverage",
     "cloc": "../../scripts/qa/cloc-package.sh .",
     "prepublishOnly": "rm -rf lib && npm i && npm run build",
     "lint": "npm run lint_core -- --fix",

--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -5,8 +5,8 @@ import { FlowBuilderApi } from '../api'
 import { FlowContent, FlowHandoff } from '../content-fields'
 import { HtNodeWithContent } from '../content-fields/hubtype-fields'
 import { getFlowBuilderPlugin } from '../helpers'
-import { createNodeFromKnowledgeBase } from './knowledge-bases'
 import { EventName, trackEvent } from '../tracking'
+import { createNodeFromKnowledgeBase } from './knowledge-bases'
 
 export type FlowBuilderActionProps = {
   contents: FlowContent[]

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -1,7 +1,11 @@
 import { Input, PluginPreRequest } from '@botonic/core'
 import axios from 'axios'
 
-import { REG_EXP_PATTERN, SEPARATOR } from './constants'
+import {
+  BOT_ACTION_PAYLOAD_SEPARATOR,
+  REG_EXP_PATTERN,
+  SEPARATOR,
+} from './constants'
 import {
   HtBotActionNode,
   HtFallbackNode,
@@ -209,14 +213,13 @@ export class FlowBuilderApi {
     }
 
     if (target.type === HtNodeWithoutContentType.BOT_ACTION) {
-      const botActionNode = this.getNodeById<HtBotActionNode>(target.id)
-      return this.createPayloadWithParams(botActionNode)
+      return `${BOT_ACTION_PAYLOAD_SEPARATOR}${target.id}`
     }
 
     return target.id
   }
 
-  private createPayloadWithParams(botActionNode: HtBotActionNode): string {
+  createPayloadWithParams(botActionNode: HtBotActionNode): string {
     const payloadId = botActionNode.content.payload_id
     const payloadNode = this.getNodeById<HtPayloadNode>(payloadId)
     const customParams = JSON.parse(

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -2,7 +2,7 @@ import { Input, PluginPreRequest } from '@botonic/core'
 import axios from 'axios'
 
 import {
-  BOT_ACTION_PAYLOAD_SEPARATOR,
+  BOT_ACTION_PAYLOAD_PREFIX,
   REG_EXP_PATTERN,
   SEPARATOR,
 } from './constants'
@@ -213,7 +213,7 @@ export class FlowBuilderApi {
     }
 
     if (target.type === HtNodeWithoutContentType.BOT_ACTION) {
-      return `${BOT_ACTION_PAYLOAD_SEPARATOR}${target.id}`
+      return `${BOT_ACTION_PAYLOAD_PREFIX}${target.id}`
     }
 
     return target.id

--- a/packages/botonic-plugin-flow-builder/src/constants.ts
+++ b/packages/botonic-plugin-flow-builder/src/constants.ts
@@ -2,7 +2,7 @@ export const FLOW_BUILDER_API_URL_PROD =
   'https://api.ent0.flowbuilder.prod.hubtype.com'
 export const SEPARATOR = '|'
 export const SOURCE_INFO_SEPARATOR = `${SEPARATOR}source_`
-export const BOT_ACTION_PAYLOAD_SEPARATOR = `ba${SEPARATOR}`
+export const BOT_ACTION_PAYLOAD_PREFIX = `ba${SEPARATOR}`
 export const VARIABLE_PATTERN = /{([^}]+)}/g
 export const ACCESS_TOKEN_VARIABLE_KEY = '_access_token'
 export const REG_EXP_PATTERN = /^\/(.*)\/([gimyus]*)$/

--- a/packages/botonic-plugin-flow-builder/src/constants.ts
+++ b/packages/botonic-plugin-flow-builder/src/constants.ts
@@ -2,6 +2,7 @@ export const FLOW_BUILDER_API_URL_PROD =
   'https://api.ent0.flowbuilder.prod.hubtype.com'
 export const SEPARATOR = '|'
 export const SOURCE_INFO_SEPARATOR = `${SEPARATOR}source_`
+export const BOT_ACTION_PAYLOAD_SEPARATOR = `ba${SEPARATOR}`
 export const VARIABLE_PATTERN = /{([^}]+)}/g
 export const ACCESS_TOKEN_VARIABLE_KEY = '_access_token'
 export const REG_EXP_PATTERN = /^\/(.*)\/([gimyus]*)$/

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
@@ -21,7 +21,6 @@ export class FlowButton extends ContentFieldsBase {
     locale: string,
     cmsApi: FlowBuilderApi
   ): FlowButton {
-    const payloadId = this.getPayloadId(cmsButton, locale)
     const urlId = this.getUrlId(cmsButton, locale)
 
     const newButton = new FlowButton(cmsButton.id)
@@ -30,21 +29,12 @@ export class FlowButton extends ContentFieldsBase {
       newButton.payload = cmsApi.getPayload(cmsButton.target)
     }
 
-    // OLD PAYLOAD
-    if (cmsButton.payload && payloadId) {
-      const payloadNode = cmsApi.getNodeById<HtPayloadNode>(payloadId)
-      newButton.payload = payloadNode.content.payload
-    }
     if (cmsButton.url && urlId) {
       const urlNode = cmsApi.getNodeById<HtUrlNode>(urlId)
       newButton.url = urlNode.content.url
     }
 
     return newButton
-  }
-
-  static getPayloadId(cmsButton: HtButton, locale: string): string | undefined {
-    return cmsButton.payload.find(payload => payload.locale === locale)?.id
   }
 
   static getUrlId(cmsButton: HtButton, locale: string): string | undefined {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
@@ -2,9 +2,9 @@ import { HandOffBuilder } from '@botonic/core'
 import { ActionRequest, WebchatSettings } from '@botonic/react'
 import React from 'react'
 
-import { EventName, trackEvent } from '../tracking'
 import { FlowBuilderApi } from '../api'
 import { getQueueAvailability } from '../functions/conditional-queue-status'
+import { EventName, trackEvent } from '../tracking'
 import { ContentFieldsBase } from './content-fields-base'
 import { HtHandoffNode, HtPayloadNode, HtQueueLocale } from './hubtype-fields'
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/button.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/button.ts
@@ -1,15 +1,9 @@
-import {
-  HtNodeLink,
-  HtPayloadLocale,
-  HtTextLocale,
-  HtUrlLocale,
-} from './common'
+import { HtNodeLink, HtTextLocale, HtUrlLocale } from './common'
 
 export interface HtButton {
   id: string
   text: HtTextLocale[]
   url: HtUrlLocale[]
-  payload: HtPayloadLocale[]
   target?: HtNodeLink
   hidden: string[]
 }

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -3,7 +3,7 @@ import { ActionRequest } from '@botonic/react'
 
 import { FlowBuilderApi } from './api'
 import {
-  BOT_ACTION_PAYLOAD_SEPARATOR,
+  BOT_ACTION_PAYLOAD_PREFIX,
   FLOW_BUILDER_API_URL_PROD,
   SEPARATOR,
   SOURCE_INFO_SEPARATOR,
@@ -101,22 +101,23 @@ export default class BotonicPluginFlowBuilder implements Plugin {
       request.input.payload = this.removeSourceSeparatorFromPayload(
         request.input.payload
       )
-      request.input.payload = this.updateBotActionPayload(request.input.payload)
+
+      if (request.input.payload.startsWith(BOT_ACTION_PAYLOAD_PREFIX)) {
+        request.input.payload = this.updateBotActionPayload(
+          request.input.payload
+        )
+      }
     }
   }
 
   private removeSourceSeparatorFromPayload(payload: string): string {
-    return payload?.split(SOURCE_INFO_SEPARATOR)[0]
+    return payload.split(SOURCE_INFO_SEPARATOR)[0]
   }
 
   private updateBotActionPayload(payload: string): string {
-    if (payload.startsWith(BOT_ACTION_PAYLOAD_SEPARATOR)) {
-      const botActionId = payload.split(SEPARATOR)[1]
-      const botActionNode =
-        this.cmsApi.getNodeById<HtBotActionNode>(botActionId)
-      return this.cmsApi.createPayloadWithParams(botActionNode)
-    }
-    return payload
+    const botActionId = payload.split(SEPARATOR)[1]
+    const botActionNode = this.cmsApi.getNodeById<HtBotActionNode>(botActionId)
+    return this.cmsApi.createPayloadWithParams(botActionNode)
   }
 
   async getContentsByContentID(

--- a/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
@@ -35,7 +35,6 @@ export async function getSmartIntentNodeByInput(
       data: { text: request.input.data, intents: intentsInferenceParams },
       timeout: 10000,
     })
-    console.log({ response })
     return smartIntentNodes.find(
       smartIntentNode =>
         smartIntentNode.content.title === response.data.intent_name

--- a/packages/botonic-plugin-flow-builder/tests/bot-action.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/bot-action.test.ts
@@ -1,21 +1,21 @@
 import { INPUT } from '@botonic/core'
 import { describe, test } from '@jest/globals'
 
-import { BOT_ACTION_PAYLOAD_SEPARATOR } from '../src/constants'
-import { FlowBuilderAction, FlowText } from '../src/index'
+import { BOT_ACTION_PAYLOAD_PREFIX } from '../src/constants'
+import { FlowText } from '../src/index'
 import { ProcessEnvNodeEnvs } from '../src/types'
 import { testFlow } from './helpers/flows'
 import {
   createFlowBuilderPlugin,
   createRequest,
-  getActionRequest,
+  getContentsAfterPreAndBotonicInit,
 } from './helpers/utils'
 
 describe('Check the contents returned by the plugin', () => {
   process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
   const flowBuilderPlugin = createFlowBuilderPlugin(testFlow)
 
-  test('The user does the first interaction', async () => {
+  test('The starting content is displayed on the first interaction', async () => {
     const request = createRequest({
       input: { data: 'Hola', type: INPUT.TEXT },
       isFirstInteraction: true,
@@ -24,9 +24,11 @@ describe('Check the contents returned by the plugin', () => {
         flowBuilderPlugin,
       },
     })
-    await flowBuilderPlugin.pre(request)
-    const actionRequest = getActionRequest(request)
-    const { contents } = await FlowBuilderAction.botonicInit(actionRequest)
+
+    const { contents } = await getContentsAfterPreAndBotonicInit(
+      request,
+      flowBuilderPlugin
+    )
 
     expect((contents[0] as FlowText).text).toBe('Welcome message')
   })
@@ -49,18 +51,21 @@ describe('The user clicks on a button that is connected to a BotActionNode', () 
         flowBuilderPlugin,
       },
     })
-    await flowBuilderPlugin.pre(request)
-    const actionRequest = getActionRequest(request)
-    const { contents } = await FlowBuilderAction.botonicInit(actionRequest)
+
+    const { contents } = await getContentsAfterPreAndBotonicInit(
+      request,
+      flowBuilderPlugin
+    )
+
     const nextPaylod = (contents[0] as FlowText).buttons[0].payload
-    expect(nextPaylod).toBe(`${BOT_ACTION_PAYLOAD_SEPARATOR}${botActionUuid}`)
+    expect(nextPaylod).toBe(`${BOT_ACTION_PAYLOAD_PREFIX}${botActionUuid}`)
   })
 
   test('The bot routes receive the correct payload, in the custom action the payloadParmas defined in the BotActionNode are obtained', async () => {
     const request = createRequest({
       input: {
         type: INPUT.POSTBACK,
-        payload: `${BOT_ACTION_PAYLOAD_SEPARATOR}${botActionUuid}`,
+        payload: `${BOT_ACTION_PAYLOAD_PREFIX}${botActionUuid}`,
       },
       plugins: {
         // @ts-ignore

--- a/packages/botonic-plugin-flow-builder/tests/bot-action.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/bot-action.test.ts
@@ -1,0 +1,83 @@
+import { INPUT } from '@botonic/core'
+import { describe, test } from '@jest/globals'
+
+import { BOT_ACTION_PAYLOAD_SEPARATOR } from '../src/constants'
+import { FlowBuilderAction, FlowText } from '../src/index'
+import { ProcessEnvNodeEnvs } from '../src/types'
+import { testFlow } from './helpers/flows'
+import {
+  createFlowBuilderPlugin,
+  createRequest,
+  getActionRequest,
+} from './helpers/utils'
+
+describe('Check the contents returned by the plugin', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+  const flowBuilderPlugin = createFlowBuilderPlugin(testFlow)
+
+  test('The user does the first interaction', async () => {
+    const request = createRequest({
+      input: { data: 'Hola', type: INPUT.TEXT },
+      isFirstInteraction: true,
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+    })
+    await flowBuilderPlugin.pre(request)
+    const actionRequest = getActionRequest(request)
+    const { contents } = await FlowBuilderAction.botonicInit(actionRequest)
+
+    expect((contents[0] as FlowText).text).toBe('Welcome message')
+  })
+})
+
+describe('The user clicks on a button that is connected to a BotActionNode', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+  const flowBuilderPlugin = createFlowBuilderPlugin(testFlow)
+  const messageUUidWithButtonConectedToBotAction =
+    '386ba508-a3b3-49a2-94d0-5e239ba63106'
+  const botActionUuid = '8b0c87c0-77b2-4b05-bae0-3b353240caaa'
+  test('The button has the payload = ba|botActionUuid', async () => {
+    const request = createRequest({
+      input: {
+        type: INPUT.POSTBACK,
+        payload: messageUUidWithButtonConectedToBotAction,
+      },
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+    })
+    await flowBuilderPlugin.pre(request)
+    const actionRequest = getActionRequest(request)
+    const { contents } = await FlowBuilderAction.botonicInit(actionRequest)
+    const nextPaylod = (contents[0] as FlowText).buttons[0].payload
+    expect(nextPaylod).toBe(`${BOT_ACTION_PAYLOAD_SEPARATOR}${botActionUuid}`)
+  })
+
+  test('The bot routes receive the correct payload, in the custom action the payloadParmas defined in the BotActionNode are obtained', async () => {
+    const request = createRequest({
+      input: {
+        type: INPUT.POSTBACK,
+        payload: `${BOT_ACTION_PAYLOAD_SEPARATOR}${botActionUuid}`,
+      },
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+    })
+
+    await flowBuilderPlugin.pre(request)
+    expect(request.input.payload).toBe(
+      'rating|{"value":1,"followUpContentID":"SORRY"}'
+    )
+
+    const payloadParams = flowBuilderPlugin.getPayloadParams(
+      request.input.payload as string
+    )
+    expect(payloadParams).toEqual(
+      JSON.parse('{"value":1,"followUpContentID":"SORRY"}')
+    )
+  })
+})

--- a/packages/botonic-plugin-flow-builder/tests/helpers/flows.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/flows.ts
@@ -1,0 +1,307 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+export const testFlow = {
+  version: 'draft',
+  name: 'Test data',
+  comments: null,
+  published_by: null,
+  published_on: null,
+  locales: ['es'],
+  start_node_id: '607205c9-6814-45ba-9aeb-2dd08d0cb529',
+  ai_model_id: null,
+  nodes: [
+    {
+      id: 'f0ceef47-16a9-49b6-ab30-1ba0f5127ab2',
+      type: 'payload',
+      content: {
+        payload: 'rating',
+      },
+    },
+    {
+      id: 'f3931bce-7de3-5c7a-8287-81f0292ee4f3',
+      code: 'Fallback',
+      is_code_ai_generated: false,
+      meta: {
+        x: 300.0,
+        y: 0.0,
+      },
+      follow_up: null,
+      target: null,
+      flow_id: '03bafba6-c0fa-5449-9d42-bd98b44fe370',
+      type: 'fallback',
+      content: {
+        first_message: {
+          id: '802474a3-cb77-45a9-bff5-ca5eb762eb78',
+          type: 'text',
+        },
+        second_message: null,
+        is_knowledge_base_active: true,
+        knowledge_base_followup: {
+          id: 'c8665d3d-a61c-4f29-a9cc-22217db6def4',
+          type: 'text',
+        },
+      },
+    },
+    {
+      id: '607205c9-6814-45ba-9aeb-2dd08d0cb529',
+      code: 'WELCOME',
+      is_code_ai_generated: false,
+      meta: {
+        x: 382.5,
+        y: 4.750000000000014,
+      },
+      follow_up: null,
+      target: null,
+      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
+      type: 'text',
+      content: {
+        text: [
+          {
+            message: 'Welcome message',
+            locale: 'es',
+          },
+        ],
+        buttons_style: 'button',
+        buttons: [],
+      },
+    },
+    {
+      id: '802474a3-cb77-45a9-bff5-ca5eb762eb78',
+      code: '1ST_FALLBACK',
+      is_code_ai_generated: false,
+      meta: {
+        x: 682.5,
+        y: 67.25000000000001,
+      },
+      follow_up: null,
+      target: null,
+      flow_id: '03bafba6-c0fa-5449-9d42-bd98b44fe370',
+      type: 'text',
+      content: {
+        text: [
+          {
+            message: 'fallback 1st message',
+            locale: 'es',
+          },
+        ],
+        buttons_style: 'button',
+        buttons: [],
+      },
+    },
+    {
+      id: 'c8665d3d-a61c-4f29-a9cc-22217db6def4',
+      code: 'KnowledeBase FU',
+      is_code_ai_generated: false,
+      meta: {
+        x: 710.0,
+        y: -106.5,
+      },
+      follow_up: null,
+      target: null,
+      flow_id: '03bafba6-c0fa-5449-9d42-bd98b44fe370',
+      type: 'text',
+      content: {
+        text: [
+          {
+            message: 'Message after knowledge base',
+            locale: 'es',
+          },
+        ],
+        buttons_style: 'button',
+        buttons: [],
+      },
+    },
+    {
+      id: '8b0c87c0-77b2-4b05-bae0-3b353240caaa',
+      code: 'Rating#1',
+      is_code_ai_generated: false,
+      meta: {
+        x: 562.423575856037,
+        y: 285.29363701139494,
+      },
+      follow_up: {
+        id: 'aa316c3c-db3c-4538-a57a-a63fed919862',
+        type: 'text',
+      },
+      target: null,
+      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
+      type: 'bot-action',
+      content: {
+        payload_id: 'f0ceef47-16a9-49b6-ab30-1ba0f5127ab2',
+        payload_params: '{"value": 1}',
+      },
+    },
+    {
+      id: 'aa316c3c-db3c-4538-a57a-a63fed919862',
+      code: 'SORRY',
+      is_code_ai_generated: false,
+      meta: {
+        x: 935.735851137171,
+        y: 349.1819952529043,
+      },
+      follow_up: null,
+      target: null,
+      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
+      type: 'text',
+      content: {
+        text: [
+          {
+            message: 'Sorry, we will continue to improve',
+            locale: 'es',
+          },
+        ],
+        buttons_style: 'button',
+        buttons: [],
+      },
+    },
+    {
+      id: '386ba508-a3b3-49a2-94d0-5e239ba63106',
+      code: 'RATING_MESSAGE',
+      is_code_ai_generated: false,
+      meta: {
+        x: 232.5,
+        y: 302.25,
+      },
+      follow_up: null,
+      target: null,
+      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
+      type: 'text',
+      content: {
+        text: [
+          {
+            message: 'Can you rate the attention received by the agent?',
+            locale: 'es',
+          },
+        ],
+        buttons_style: 'button',
+        buttons: [
+          {
+            id: '92f9800e-3b89-41f2-92ec-71c3de5a8621',
+            text: [
+              {
+                message: '\u2b50\ufe0f',
+                locale: 'es',
+              },
+            ],
+            url: [],
+            payload: [],
+            target: {
+              id: '8b0c87c0-77b2-4b05-bae0-3b353240caaa',
+              type: 'bot-action',
+            },
+            hidden: [],
+          },
+          {
+            id: '0231e03f-78e4-4798-8f65-677dac44c9d6',
+            text: [
+              {
+                message: '\u2b50\ufe0f\u2b50\ufe0f',
+                locale: 'es',
+              },
+            ],
+            url: [],
+            payload: [],
+            target: {
+              id: 'fb383a44-db8a-4312-9cd5-cce8841d886f',
+              type: 'bot-action',
+            },
+            hidden: [],
+          },
+          {
+            id: 'bd3947cb-6916-4822-b490-94a7f831b895',
+            text: [
+              {
+                message: '\u2b50\ufe0f\u2b50\ufe0f\u2b50\ufe0f',
+                locale: 'es',
+              },
+            ],
+            url: [],
+            payload: [],
+            target: {
+              id: '2acd91ba-8a08-42e2-a723-89820839e972',
+              type: 'bot-action',
+            },
+            hidden: [],
+          },
+        ],
+      },
+    },
+    {
+      id: '51e14949-15cd-491d-9f76-b5370ea0b8ce',
+      code: 'THNAKS',
+      is_code_ai_generated: false,
+      meta: {
+        x: 903.75,
+        y: 574.7499999999999,
+      },
+      follow_up: null,
+      target: null,
+      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
+      type: 'text',
+      content: {
+        text: [
+          {
+            message: 'Thank you',
+            locale: 'es',
+          },
+        ],
+        buttons_style: 'button',
+        buttons: [],
+      },
+    },
+    {
+      id: 'fb383a44-db8a-4312-9cd5-cce8841d886f',
+      code: 'Rating#2',
+      is_code_ai_generated: false,
+      meta: {
+        x: 552.423575856037,
+        y: 462.79363701139494,
+      },
+      follow_up: {
+        id: 'aa316c3c-db3c-4538-a57a-a63fed919862',
+        type: 'text',
+      },
+      target: null,
+      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
+      type: 'bot-action',
+      content: {
+        payload_id: 'f0ceef47-16a9-49b6-ab30-1ba0f5127ab2',
+        payload_params: '{"value": 2}',
+      },
+    },
+    {
+      id: '2acd91ba-8a08-42e2-a723-89820839e972',
+      code: 'Rating#3',
+      is_code_ai_generated: false,
+      meta: {
+        x: 564.923575856037,
+        y: 658.0436370113949,
+      },
+      follow_up: {
+        id: '51e14949-15cd-491d-9f76-b5370ea0b8ce',
+        type: 'text',
+      },
+      target: null,
+      flow_id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
+      type: 'bot-action',
+      content: {
+        payload_id: 'f0ceef47-16a9-49b6-ab30-1ba0f5127ab2',
+        payload_params: '{"value": 3}',
+      },
+    },
+  ],
+  flows: [
+    {
+      id: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
+      name: 'Main',
+      start_node_id: '607205c9-6814-45ba-9aeb-2dd08d0cb529',
+    },
+    {
+      id: '03bafba6-c0fa-5449-9d42-bd98b44fe370',
+      name: 'Fallback',
+      start_node_id: 'f3931bce-7de3-5c7a-8287-81f0292ee4f3',
+    },
+  ],
+  webviews: [],
+  webview_contents: [],
+  bot_variables: [],
+}

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import {
   Input,
   PluginPreRequest,
@@ -47,7 +48,6 @@ export function createRequest({
       bot: { id: 'bid1' },
       user: { provider, id: 'uid1', extra_data: {} },
       __retries: 0,
-      _hubtype_api: 'https://api.hubtype.com',
       _access_token: 'fake_access_token',
     },
     input,

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -1,0 +1,67 @@
+import {
+  Input,
+  PluginPreRequest,
+  PROVIDER,
+  ProviderType,
+  ResolvedPlugins,
+} from '@botonic/core'
+import { ActionRequest } from '@botonic/react'
+
+import BotonicPluginFlowBuilder from '../../src'
+
+export function createFlowBuilderPlugin(flow: any, locale: string = 'es') {
+  const flowBuilderPlugin = new BotonicPluginFlowBuilder({
+    flow,
+    getLocale: () => locale,
+    getAccessToken: () => 'fake_token',
+  })
+
+  // @ts-ignore
+  flowBuilderPlugin.id = 'flowBuilder'
+  // @ts-ignore
+  flowBuilderPlugin.name = 'BotonicPluginFlowBuilder'
+  // @ts-ignore
+  flowBuilderPlugin.config = {}
+
+  return flowBuilderPlugin
+}
+
+interface RequestArgs {
+  input: Input
+  plugins?: ResolvedPlugins
+  provider?: ProviderType
+  isFirstInteraction?: boolean
+}
+
+export function createRequest({
+  input,
+  plugins = {},
+  provider = PROVIDER.WEBCHAT,
+  isFirstInteraction = false,
+}: RequestArgs): PluginPreRequest {
+  return {
+    session: {
+      is_first_interaction: isFirstInteraction,
+      organization: 'orgTest',
+      organization_id: 'orgIdTest',
+      bot: { id: 'bid1' },
+      user: { provider, id: 'uid1', extra_data: {} },
+      __retries: 0,
+      _hubtype_api: 'https://api.hubtype.com',
+      _access_token: 'fake_access_token',
+    },
+    input,
+    lastRoutePath: '',
+    plugins,
+  }
+}
+
+export function getActionRequest(request: PluginPreRequest): ActionRequest {
+  return {
+    ...request,
+    lastRoutePath: 'flow-builder-action',
+    defaultDelay: 0,
+    defaultTyping: 0,
+    params: {},
+  }
+}

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -8,7 +8,7 @@ import {
 } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
-import BotonicPluginFlowBuilder from '../../src'
+import BotonicPluginFlowBuilder, { FlowBuilderAction } from '../../src'
 
 export function createFlowBuilderPlugin(flow: any, locale: string = 'es') {
   const flowBuilderPlugin = new BotonicPluginFlowBuilder({
@@ -65,4 +65,13 @@ export function getActionRequest(request: PluginPreRequest): ActionRequest {
     defaultTyping: 0,
     params: {},
   }
+}
+
+export async function getContentsAfterPreAndBotonicInit(
+  request: PluginPreRequest,
+  flowBuilderPlugin: BotonicPluginFlowBuilder
+): Promise<any> {
+  await flowBuilderPlugin.pre(request)
+  const actionRequest = getActionRequest(request)
+  return await FlowBuilderAction.botonicInit(actionRequest)
 }

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -49,6 +49,7 @@ export function createRequest({
       user: { provider, id: 'uid1', extra_data: {} },
       __retries: 0,
       _access_token: 'fake_access_token',
+      _hubtype_api: 'https://api.hubtype.com',
     },
     input,
     lastRoutePath: '',

--- a/packages/botonic-plugin-flow-builder/tsconfig.tests.json
+++ b/packages/botonic-plugin-flow-builder/tsconfig.tests.json
@@ -1,0 +1,21 @@
+// Only used for verifying the code (& by jest)
+// It uses noEmit to have faster builds (up to 30%)
+{
+  "extends": "./tsconfig.json",
+  // include: [] makes jest faster,
+  // but it needs to be set for tsc to find the files to verify them. See https://www.notion.so/Typescript-performance-7aa77701970d4d49b8399efcee1b0754
+  "include": [
+    "**/*.[jt]s",
+    "**/*.[jt]sx",
+    "../src/**/*.[jt]s",
+    "../src/**/*.[jt]sx"
+  ],
+  "compilerOptions": {
+    "rootDir": "../",
+    // Options below are for compiling @botonic js/jsx files
+    "declaration": false,
+    "declarationDir": null,
+    "noEmit": true,
+    "types": ["@types/jest", "@types/node"]
+  }
+}


### PR DESCRIPTION
## Description

When using a Bot Action node with parameters that is connected to a follow up. It is easy to exceed the character limit allowed by Telegram (64bytes = 64 characters).

## Context

When connecting a BotActionNode to a button the payload will be ba|BotActionNodeUUID|source_x

In the pre function of the plugin: first the |source_x is removed, then if a payload starting with ba| is detected the BotActionNode is obtained using the botActionNodeUUID and the payload is replaced by the payload plus the parameters defined in the BotActionNode.

When we get to the bot routes we have the payload with the parameters.

In the action we can continue using the getPayloadParams function as we did before.

## Testing

Add config for jest and github action
Add test for first interaction 
Add test for bot action node
