### PR TITLE
plugin-flow-builder: test different types of messages

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/content-fields/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/index.ts
@@ -11,6 +11,7 @@ export { FlowButton } from './flow-button'
 export { FlowElement } from './flow-element'
 export { FlowCarousel, FlowImage, FlowText, FlowVideo, FlowWhatsappButtonList }
 export { FlowHandoff } from './flow-handoff'
+export { FlowWhatsappCtaUrlButtonNode } from './flow-whatsapp-cta-url-button'
 
 export type FlowContent =
   | FlowCarousel

--- a/packages/botonic-plugin-flow-builder/tests/helpers/flows/basic.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/flows/basic.ts
@@ -1750,8 +1750,8 @@ export const basicFlow = {
       code: 'CAROUSEL_65',
       is_code_ai_generated: true,
       meta: {
-        x: 884.4844470280865,
-        y: -512.5679853290751,
+        x: 955.1637874563928,
+        y: -510.8440989771652,
       },
       follow_up: null,
       target: null,
@@ -1871,8 +1871,8 @@ export const basicFlow = {
       code: 'BUTTON_2_MESSAGE',
       is_code_ai_generated: true,
       meta: {
-        x: 1226.0008425685378,
-        y: -366.4877435541607,
+        x: 1308.9522027695225,
+        y: -543.7234810769891,
       },
       follow_up: null,
       target: null,
@@ -1894,8 +1894,8 @@ export const basicFlow = {
       code: 'IMAGE_16',
       is_code_ai_generated: true,
       meta: {
-        x: 729.8216949745022,
-        y: -194.98345079823582,
+        x: 1177.51996320645,
+        y: -302.9225687176279,
       },
       follow_up: null,
       target: null,
@@ -1939,8 +1939,8 @@ export const basicFlow = {
       code: 'VIDEO_74',
       is_code_ai_generated: true,
       meta: {
-        x: 1078.419679697304,
-        y: 18.577197975003344,
+        x: 1189.9960330222464,
+        y: 87.1353488513532,
       },
       follow_up: null,
       target: null,
@@ -1961,8 +1961,8 @@ export const basicFlow = {
       code: 'WHATSAPP_BUTTON_LIST',
       is_code_ai_generated: true,
       meta: {
-        x: 1506.9574649513079,
-        y: 99.33883188137656,
+        x: 1479.9556416942435,
+        y: 213.13222989329068,
       },
       follow_up: null,
       target: null,
@@ -1986,7 +1986,7 @@ export const basicFlow = {
             id: '2638db97-3f21-4370-a32b-ebe46de87a34',
             title: [
               {
-                message: '',
+                message: 'Section 1',
                 locale: 'en',
               },
             ],
@@ -2235,6 +2235,156 @@ export const basicFlow = {
         keywords: [
           {
             values: ['differentMessages'],
+            locale: 'en',
+          },
+        ],
+      },
+    },
+    {
+      id: '8ec6a479-dca5-4623-8bab-41fa49c9d6e8',
+      code: '',
+      is_code_ai_generated: false,
+      meta: {
+        x: 227.66304778904035,
+        y: -918.3254123731216,
+      },
+      follow_up: null,
+      target: {
+        id: '7afe0981-e9d3-4e3e-b9d1-5d362d3873b3',
+        type: 'text',
+      },
+      flow_id: '43a736f8-4837-4fbb-a661-021291749b4f',
+      type: 'keyword',
+      content: {
+        title: [],
+        keywords: [
+          {
+            values: ['flowText'],
+            locale: 'en',
+          },
+        ],
+      },
+    },
+    {
+      id: 'd5f69849-d6c9-4845-9ed0-1ac999098ad3',
+      code: '',
+      is_code_ai_generated: false,
+      meta: {
+        x: 688.39997409608,
+        y: -586.5527995084371,
+      },
+      follow_up: null,
+      target: {
+        id: 'd6f17ff2-a8de-4b57-8062-497616a6d35a',
+        type: 'carousel',
+      },
+      flow_id: '43a736f8-4837-4fbb-a661-021291749b4f',
+      type: 'keyword',
+      content: {
+        title: [],
+        keywords: [
+          {
+            values: ['flowCarousel'],
+            locale: 'en',
+          },
+        ],
+      },
+    },
+    {
+      id: '83ad6b2b-2240-4d2e-8be3-8543b76791c7',
+      code: '',
+      is_code_ai_generated: false,
+      meta: {
+        x: 786.6092862088249,
+        y: -302.2270803512114,
+      },
+      follow_up: null,
+      target: {
+        id: '4140f25f-ab22-4c18-b13a-1fdb265368b6',
+        type: 'image',
+      },
+      flow_id: '43a736f8-4837-4fbb-a661-021291749b4f',
+      type: 'keyword',
+      content: {
+        title: [],
+        keywords: [
+          {
+            values: ['flowImage'],
+            locale: 'en',
+          },
+        ],
+      },
+    },
+    {
+      id: '059064c7-f37c-407a-8e92-ab8dbd073f7e',
+      code: '',
+      is_code_ai_generated: false,
+      meta: {
+        x: 839.7855385035422,
+        y: -1.9261167769942915,
+      },
+      follow_up: null,
+      target: {
+        id: 'a1f94824-b620-4f58-9e7a-67e596efbd9d',
+        type: 'video',
+      },
+      flow_id: '43a736f8-4837-4fbb-a661-021291749b4f',
+      type: 'keyword',
+      content: {
+        title: [],
+        keywords: [
+          {
+            values: ['flowVideo'],
+            locale: 'en',
+          },
+        ],
+      },
+    },
+    {
+      id: '72d02d8e-e88d-4bcb-a11d-8dd0952e665a',
+      code: '',
+      is_code_ai_generated: false,
+      meta: {
+        x: 1121.3759810414992,
+        y: 497.6076134786967,
+      },
+      follow_up: null,
+      target: {
+        id: '07a91a2f-cc4e-480a-9f81-7767588682e2',
+        type: 'whatsapp-button-list',
+      },
+      flow_id: '43a736f8-4837-4fbb-a661-021291749b4f',
+      type: 'keyword',
+      content: {
+        title: [],
+        keywords: [
+          {
+            values: ['flowButtonList'],
+            locale: 'en',
+          },
+        ],
+      },
+    },
+    {
+      id: '2055cd95-b48b-48cb-825b-7787ec4462fd',
+      code: '',
+      is_code_ai_generated: false,
+      meta: {
+        x: 284.31946007250366,
+        y: 420.4595470299414,
+      },
+      follow_up: null,
+      target: {
+        id: 'febabaa2-e6fe-4777-873b-2a874efcf248',
+        type: 'whatsapp-cta-url-button',
+      },
+      flow_id: '43a736f8-4837-4fbb-a661-021291749b4f',
+      type: 'keyword',
+      content: {
+        title: [],
+        keywords: [
+          {
+            values: ['flowURLButton'],
             locale: 'en',
           },
         ],

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-button-list.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-button-list.test.ts
@@ -1,0 +1,48 @@
+import { INPUT } from '@botonic/core'
+import { describe, test } from '@jest/globals'
+
+import { FlowWhatsappButtonList } from '../../src/index'
+import { ProcessEnvNodeEnvs } from '../../src/types'
+import { basicFlow } from '../helpers/flows/basic'
+import {
+  createFlowBuilderPlugin,
+  createRequest,
+  getContentsAfterPreAndBotonicInit,
+} from '../helpers/utils'
+
+describe('Check the contents of a WhatsApp Button List node', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+  const flowBuilderPlugin = createFlowBuilderPlugin(basicFlow)
+
+  test('The contents of the WhatsApp Button List are displayed', async () => {
+    const request = createRequest({
+      input: { data: 'flowButtonList', type: INPUT.TEXT },
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+    })
+
+    const { contents } = await getContentsAfterPreAndBotonicInit(
+      request,
+      flowBuilderPlugin
+    )
+    const buttonListContent = contents[0] as FlowWhatsappButtonList
+    expect(buttonListContent.text).toBe('WhatsApp button list')
+    expect(buttonListContent.listButtonText).toBe('Menu')
+
+    const buttonListSections = buttonListContent.sections
+    expect(buttonListSections.length).toBeGreaterThanOrEqual(1)
+
+    const firstSection = buttonListSections[0]
+    expect(firstSection.title).toBe('Section 1')
+
+    const rows = firstSection.rows
+    expect(rows.length).toBeGreaterThan(3)
+
+    const firstRow = rows[0]
+    expect(firstRow.title).toBe('Row title 1')
+    expect(firstRow.description).toBe('Row description 1')
+    expect(firstRow.targetId).toBe('128970b5-3404-472c-a0e7-b6aaa8d38bc9')
+  })
+})

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-carousel.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-carousel.test.ts
@@ -1,0 +1,59 @@
+import { INPUT } from '@botonic/core'
+import { describe, test } from '@jest/globals'
+
+import { FlowCarousel } from '../../src/index'
+import { ProcessEnvNodeEnvs } from '../../src/types'
+import { basicFlow } from '../helpers/flows/basic'
+import {
+  createFlowBuilderPlugin,
+  createRequest,
+  getContentsAfterPreAndBotonicInit,
+} from '../helpers/utils'
+
+describe('Check the contents of a carousel node', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+  const flowBuilderPlugin = createFlowBuilderPlugin(basicFlow)
+
+  test('The contents of the carousel and elements are displayed', async () => {
+    const request = createRequest({
+      input: { data: 'flowCarousel', type: INPUT.TEXT },
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+    })
+
+    const { contents } = await getContentsAfterPreAndBotonicInit(
+      request,
+      flowBuilderPlugin
+    )
+    const carouselContent = contents[0] as FlowCarousel
+    const carouselElements = carouselContent.elements
+
+    const firstElement = carouselElements[0]
+    expect(firstElement.title).toBe('Title element 1')
+    expect(firstElement.subtitle).toBe('Subtitle element 1')
+    expect(firstElement.image).toBe(
+      'https://medias.ent0.flowbuilder.prod.hubtype.com/assets/media_files/825f22e5-421e-4d8d-bdd9-2fb9c6f6e4cb/9415a943-286f-4b69-a983-f4a4ca59b6dc/bola4estrellas.png'
+    )
+
+    const buttonFirstElement = firstElement.button
+    expect(buttonFirstElement?.text).toBe('Button to url')
+    expect(buttonFirstElement?.url).toBe('https://www.hubtype.com')
+    expect(buttonFirstElement?.payload).toBeUndefined()
+
+    const secondElement = carouselElements[1]
+    expect(secondElement.title).toBe('Title element 2')
+    expect(secondElement.subtitle).toBe('Subtitle element 2')
+    expect(secondElement.image).toBe(
+      'https://medias.ent0.flowbuilder.prod.hubtype.com/assets/media_files/825f22e5-421e-4d8d-bdd9-2fb9c6f6e4cb/9415a943-286f-4b69-a983-f4a4ca59b6dc/Vermut.jpeg'
+    )
+
+    const buttonSecondElement = secondElement.button
+    expect(buttonSecondElement?.text).toBe('Button text 2')
+    expect(buttonSecondElement?.payload).toBe(
+      'bff4c6de-06b2-411a-9d13-0fd3c08ce34f'
+    )
+    expect(buttonSecondElement?.url).toBeUndefined()
+  })
+})

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-image.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-image.test.ts
@@ -1,0 +1,35 @@
+import { INPUT } from '@botonic/core'
+import { describe, test } from '@jest/globals'
+
+import { FlowImage } from '../../src/index'
+import { ProcessEnvNodeEnvs } from '../../src/types'
+import { basicFlow } from '../helpers/flows/basic'
+import {
+  createFlowBuilderPlugin,
+  createRequest,
+  getContentsAfterPreAndBotonicInit,
+} from '../helpers/utils'
+
+describe('Check the contents of a image node', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+  const flowBuilderPlugin = createFlowBuilderPlugin(basicFlow)
+
+  test('The src of the image is in contents', async () => {
+    const request = createRequest({
+      input: { data: 'flowImage', type: INPUT.TEXT },
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+    })
+
+    const { contents } = await getContentsAfterPreAndBotonicInit(
+      request,
+      flowBuilderPlugin
+    )
+    const firstContent = contents[0] as FlowImage
+    expect(firstContent.src).toBe(
+      'https://medias.ent0.flowbuilder.prod.hubtype.com/assets/media_files/825f22e5-421e-4d8d-bdd9-2fb9c6f6e4cb/9415a943-286f-4b69-a983-f4a4ca59b6dc/link-2.png'
+    )
+  })
+})

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-text.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-text.test.ts
@@ -1,0 +1,67 @@
+import { INPUT } from '@botonic/core'
+import { describe, test } from '@jest/globals'
+
+import { FlowText } from '../../src/index'
+import { ProcessEnvNodeEnvs } from '../../src/types'
+import { basicFlow } from '../helpers/flows/basic'
+import {
+  createFlowBuilderPlugin,
+  createRequest,
+  getContentsAfterPreAndBotonicInit,
+} from '../helpers/utils'
+
+describe('Check the contents and logic of a text node', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+  const flowBuilderPlugin = createFlowBuilderPlugin(basicFlow)
+
+  test('The contents of the text message are displayed', async () => {
+    const request = createRequest({
+      input: { data: 'flowText', type: INPUT.TEXT },
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+    })
+
+    const { contents } = await getContentsAfterPreAndBotonicInit(
+      request,
+      flowBuilderPlugin
+    )
+    const firstContent = contents[0] as FlowText
+    expect(firstContent.text).toBe(
+      'This text message contains buttons and replaces the variable {bagsAdded}'
+    )
+
+    const firstButton = firstContent.buttons[0]
+    expect(firstButton.text).toEqual('Button to text')
+    expect(firstButton.payload).toEqual('eb877738-3cf4-4a57-9f46-3122e18f1cc7')
+    expect(firstButton.url).toBeUndefined()
+
+    const secondButton = firstContent.buttons[1]
+    expect(secondButton.text).toEqual('Button to url')
+    expect(secondButton.url).toEqual('https://www.hubtype.com')
+    expect(secondButton.payload).toBeUndefined()
+  })
+
+  test('The rendered message has the replaced bagsAdded variable to 2', async () => {
+    const request = createRequest({
+      input: { data: 'flowText', type: INPUT.TEXT },
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+      extraData: { bagsAdded: 2 },
+    })
+
+    const { contents } = await getContentsAfterPreAndBotonicInit(
+      request,
+      flowBuilderPlugin
+    )
+    const firstContent = contents[0] as FlowText
+    // @ts-ignore
+    const renderedMessage = firstContent.toBotonic(firstContent.id, request)
+    expect(renderedMessage.props.children[0]).toBe(
+      'This text message contains buttons and replaces the variable 2'
+    )
+  })
+})

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-url-button.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-url-button.test.ts
@@ -1,0 +1,39 @@
+import { INPUT, PROVIDER } from '@botonic/core'
+import { describe, test } from '@jest/globals'
+
+import { FlowWhatsappCtaUrlButtonNode } from '../../src/content-fields/index'
+import { ProcessEnvNodeEnvs } from '../../src/types'
+import { basicFlow } from '../helpers/flows/basic'
+import {
+  createFlowBuilderPlugin,
+  createRequest,
+  getContentsAfterPreAndBotonicInit,
+} from '../helpers/utils'
+
+describe('Check the contents of a WhatsApp URL CTA Button node', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+  const flowBuilderPlugin = createFlowBuilderPlugin(basicFlow)
+
+  test('The contents displayed have text in all fields', async () => {
+    const request = createRequest({
+      input: { data: 'flowURLButton', type: INPUT.TEXT },
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+      provider: PROVIDER.WHATSAPP,
+    })
+
+    const { contents } = await getContentsAfterPreAndBotonicInit(
+      request,
+      flowBuilderPlugin
+    )
+    const firstContent = contents[0] as FlowWhatsappCtaUrlButtonNode
+
+    expect(firstContent.header).toBe('Header text')
+    expect(firstContent.text).toBe('WhatsApp URL CTA button')
+    expect(firstContent.footer).toBe('footer text')
+    expect(firstContent.displayText).toBe('Button text')
+    expect(firstContent.url).toBe('https://www.hubtype.com')
+  })
+})

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-video.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-video.test.ts
@@ -1,0 +1,33 @@
+import { INPUT } from '@botonic/core'
+import { describe, test } from '@jest/globals'
+
+import { FlowVideo } from '../../src/index'
+import { ProcessEnvNodeEnvs } from '../../src/types'
+import { basicFlow } from '../helpers/flows/basic'
+import {
+  createFlowBuilderPlugin,
+  createRequest,
+  getContentsAfterPreAndBotonicInit,
+} from '../helpers/utils'
+
+describe('Check the contents of a video node', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+  const flowBuilderPlugin = createFlowBuilderPlugin(basicFlow)
+
+  test('The src of the video is in contents', async () => {
+    const request = createRequest({
+      input: { data: 'flowVideo', type: INPUT.TEXT },
+      plugins: {
+        // @ts-ignore
+        flowBuilderPlugin,
+      },
+    })
+
+    const { contents } = await getContentsAfterPreAndBotonicInit(
+      request,
+      flowBuilderPlugin
+    )
+    const firstContent = contents[0] as FlowVideo
+    expect(firstContent.src).toBe('https://www.youtube.com/watch?v=M11dw4o3Au4')
+  })
+})


### PR DESCRIPTION
## Description

Add tests for each type of message 
- Text
- Carousel
- Image
- Video
- WhatsApp button list
- Whatsapp CTA URL button


## Approach taken / Explain the design

Keywords are used to reach the node to be tested

## Testing

This PR only contains tests of the different types of messages
