### PR TITLE
botonic-react: Fix webviews not closing on fb #PLA-2162

### DIFF
--- a/packages/botonic-react/src/webview-app.tsx
+++ b/packages/botonic-react/src/webview-app.tsx
@@ -63,10 +63,14 @@ class App extends React.Component {
     if (provider === PROVIDER.FACEBOOK) {
       try {
         window.MessengerExtensions.requestCloseBrowser(
-          () => undefined,
-          err => console.log(err)
+          function success() {},
+          function error(err) {
+            window.close()
+          }
         )
-      } catch (e) {}
+      } catch (e) {
+        window.close()
+      }
     }
     if (provider === PROVIDER.WEBCHAT) {
       try {


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
When closing facebook messenger webviews the payload was sent but the webview did not close.

## Approach taken / Explain the design

Add fallback to close the window in case the MessengerExtensions are not available


## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
