### PR TITLE
botonic-react: add params in WhatsappCTAURLButton when use it inside Multichannel

### DIFF
--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -253,6 +253,7 @@ export const MultichannelText = props => {
             body={textElements[0]}
             displayText={webviewButtonElements[0].props.children}
             webview={webviewButtonElements[0].props.webview}
+            params={webviewButtonElements[0].props.params}
           />
         )
       }


### PR DESCRIPTION
## Description

Add params in WhatsappCTAURLButton when replacing a Button that leads to a webview with params using the Multichannel component

