### PR TITLE
fix: update Custom, Fallback and FlowNode (is_meaningful) events with missing fields and use them #BLT-888

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25840,7 +25840,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.27.1",
+      "version": "0.27.2",
       "dependencies": {
         "@botonic/react": "^0.27.0",
         "axios": "^1.6.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25840,7 +25840,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "dependencies": {
         "@botonic/react": "^0.27.0",
         "axios": "^1.6.8",
@@ -25892,7 +25892,7 @@
     },
     "packages/botonic-plugin-hubtype-analytics": {
       "name": "@botonic/plugin-hubtype-analytics",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/action/fallback.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/fallback.ts
@@ -34,6 +34,7 @@ async function getFallbackNode(cmsApi: FlowBuilderApi, request: ActionRequest) {
   request.session.user.extra_data.isFirstFallbackOption = !isFirstFallbackOption
 
   trackEvent(request, EventAction.Fallback, {
+    userInput: request.input.data,
     fallbackOut: isFirstFallbackOption ? 1 : 2,
     fallbackMessageId: request.input.message_id,
   })

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/common.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/common.ts
@@ -33,6 +33,7 @@ export interface HtBaseNode {
   follow_up?: HtNodeLink
   target?: HtNodeLink
   flow_id: string // TODO: Review if this field is necessary in all HtBaseNode
+  is_meaningful?: boolean
 }
 
 export interface HtTextLocale {

--- a/packages/botonic-plugin-flow-builder/src/tracking.ts
+++ b/packages/botonic-plugin-flow-builder/src/tracking.ts
@@ -43,6 +43,7 @@ export async function trackFlowContent(
     flowId: firstNodeContent.flow_id,
     flowName,
     id: firstNodeContent.id,
+    isMeaningful: firstNodeContent.is_meaningful ?? false,
   })
   await trackEvent(request, EventAction.FlowNode, eventArgs)
 }
@@ -54,6 +55,7 @@ export function getContentEventArgs(
     flowId: string
     flowName: string
     id: string
+    isMeaningful: boolean
   }
 ) {
   const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)
@@ -63,6 +65,6 @@ export function getContentEventArgs(
     flowName: flowBuilderPlugin.getFlowName(contentInfo.flowId),
     flowNodeId: contentInfo.id,
     flowNodeContentId: contentInfo.code,
-    flowNodeIsMeaningful: undefined, //node?.isMeaningful,
+    flowNodeIsMeaningful: contentInfo.isMeaningful,
   }
 }

--- a/packages/botonic-plugin-hubtype-analytics/package.json
+++ b/packages/botonic-plugin-hubtype-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-hubtype-analytics",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Plugin for tracking in the Hubtype backend to see the results in the Hubtype Dashbord",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-custom.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-custom.ts
@@ -3,11 +3,13 @@ import { HtEvent } from './ht-event'
 
 export class HtEventCustom extends HtEvent {
   custom_fields: Record<string, any>
+  custom_sensitive_fields: Record<string, any>
 
   constructor(event: EventCustom, requestData: RequestData) {
     super(event, requestData)
     this.type = EventType.WebEvent
     this.action = EventAction.Custom
-    this.custom_fields = event.customFields
+    this.custom_fields = event.customFields || {}
+    this.custom_sensitive_fields = event.customSensitiveFields || {}
   }
 }

--- a/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-fallback.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-fallback.ts
@@ -4,11 +4,13 @@ import { HtEvent } from './ht-event'
 export class HtEventFallback extends HtEvent {
   fallback_out: number
   fallback_message_id: string
+  user_input: string
 
   constructor(event: EventFallback, requestData: RequestData) {
     super(event, requestData)
     this.type = EventType.BotEvent
     this.action = EventAction.Fallback
+    this.user_input = event.userInput
     this.fallback_out = event.fallbackOut
     this.fallback_message_id = event.fallbackMessageId
   }

--- a/packages/botonic-plugin-hubtype-analytics/src/types.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/types.ts
@@ -111,6 +111,7 @@ export enum KnowledgebaseFailReason {
 
 export interface EventFallback extends HtBaseEventProps {
   action: EventAction.Fallback
+  userInput: string
   fallbackOut: number
   fallbackMessageId: string
 }

--- a/packages/botonic-plugin-hubtype-analytics/src/types.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/types.ts
@@ -124,14 +124,6 @@ export interface EventWebview extends HtBaseEventProps {
   webviewEndFailMessage?: string
 }
 
-export interface EventPropsWebview {
-  webviewThreadId: string
-  webviewName: string
-  webviewStepName?: string
-  webviewEndFailType?: string
-  webviewEndFailMessage?: string
-}
-
 export interface EventCustom extends HtBaseEventProps {
   action: EventAction.Custom
   customFields: Record<string, any>

--- a/packages/botonic-plugin-hubtype-analytics/src/types.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/types.ts
@@ -126,7 +126,8 @@ export interface EventWebview extends HtBaseEventProps {
 
 export interface EventCustom extends HtBaseEventProps {
   action: EventAction.Custom
-  customFields: Record<string, any>
+  customFields?: Record<string, any>
+  customSensitiveFields?: Record<string, any>
 }
 
 export type HtEventProps =

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-custom.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-custom.test.ts
@@ -10,6 +10,9 @@ describe('Create custom events', () => {
         name: 'custom bot event',
         value: '12345',
       },
+      customSensitiveFields: {
+        bank_account: '1234567890',
+      },
     })
 
     expect(htEvent).toEqual({
@@ -22,6 +25,7 @@ describe('Create custom events', () => {
         name: 'custom bot event',
         value: '12345',
       },
+      custom_sensitive_fields: { bank_account: '1234567890' },
       type: EventType.WebEvent,
     })
   })

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-fallback.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-fallback.test.ts
@@ -6,6 +6,7 @@ describe('Create fallback events', () => {
   test('The first fallback event is created', () => {
     const htEvent = createHtEvent(requestData, {
       action: EventAction.Fallback,
+      userInput: 'userInputTest',
       fallbackOut: 1,
       fallbackMessageId: 'fallbackMessageIdTest',
     })
@@ -16,6 +17,7 @@ describe('Create fallback events', () => {
       chat_country: 'ES',
       format_version: 2,
       action: EventAction.Fallback,
+      user_input: 'userInputTest',
       fallback_out: 1,
       fallback_message_id: 'fallbackMessageIdTest',
       type: EventType.BotEvent,
@@ -25,6 +27,7 @@ describe('Create fallback events', () => {
   test('The second fallback event is created', () => {
     const htEvent = createHtEvent(requestData, {
       action: EventAction.Fallback,
+      userInput: 'userInputTest',
       fallbackOut: 2,
       fallbackMessageId: 'fallbackMessageIdTest',
     })
@@ -35,6 +38,7 @@ describe('Create fallback events', () => {
       chat_country: 'ES',
       format_version: 2,
       action: EventAction.Fallback,
+      user_input: 'userInputTest',
       fallback_out: 2,
       fallback_message_id: 'fallbackMessageIdTest',
       type: EventType.BotEvent,
@@ -44,6 +48,7 @@ describe('Create fallback events', () => {
   test('The third fallback event is created', () => {
     const htEvent = createHtEvent(requestData, {
       action: EventAction.Fallback,
+      userInput: 'userInputTest',
       fallbackOut: 1,
       fallbackMessageId: 'fallbackMessageIdTest',
     })
@@ -54,6 +59,7 @@ describe('Create fallback events', () => {
       chat_country: 'ES',
       format_version: 2,
       action: EventAction.Fallback,
+      user_input: 'userInputTest',
       fallback_out: 1,
       fallback_message_id: 'fallbackMessageIdTest',
       type: EventType.BotEvent,


### PR DESCRIPTION
## Description
* Removed outdated interface https://github.com/hubtype/botonic/pull/2851/commits/c737dc18eb99c6cf9f1f0124719a319e0379b8bb
* Added customSensitiveFields in EventCustom https://github.com/hubtype/botonic/pull/2851/commits/80927b6c9ddd924f1807463cee8b43855ffb78df
* Added userInput in EventFallback https://github.com/hubtype/botonic/pull/2851/commits/ab1f5ad4a53990343e05ab5760dc431232489802
* Call plugin-flow-builder's trackEvent fallback with user input field https://github.com/hubtype/botonic/pull/2851/commits/3f704fc5d7baf10b3742aae682c557825feb9f9b
* Added is_meaningful tracking https://github.com/hubtype/botonic/pull/2851/commits/5372468a0a79b03765054ddfa905c1f2ffd53e94
