### PR TITLE
Feat/handle preview for is_test_integration apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,25 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.27.X] - aaaa-mm-dd
+## [0.28.X] - aaaa-mm-dd
 
 ### Changed
 
 ### Fixed
 
 </details>
+
+## [0.28.X] - aaaa-mm-dd
+
+### Added
+
+- [Project](https://github.com/hubtype/botonic)
+
+  - Added specific behavior for bots having `is_test_integration` defined.
+
+### Changed
+
+### Fixed
 
 ## [0.27.0] - 2024-11-06
 

--- a/packages/botonic-core/src/core-bot.ts
+++ b/packages/botonic-core/src/core-bot.ts
@@ -40,7 +40,6 @@ export class CoreBot {
   theme?: any
 
   constructor({
-    // TODO: Receives dataProvider
     renderer,
     routes,
     locales,
@@ -59,10 +58,7 @@ export class CoreBot {
       typeof defaultTyping !== 'undefined' ? defaultTyping : 0.6
     this.defaultDelay = typeof defaultDelay !== 'undefined' ? defaultDelay : 0.4
     this.locales = locales
-    if (appId) {
-      this.appId = appId
-      return
-    }
+    this.appId = appId || undefined
     this.rootElement = null
     this.inspector = inspector || new Inspector()
     this.routes = routes
@@ -133,6 +129,7 @@ export class CoreBot {
         newOutput.emptyAction,
       ],
     })
+
     return {
       input: newInput,
       response: output.response.concat(followUpResponse),

--- a/packages/botonic-core/src/handoff.ts
+++ b/packages/botonic-core/src/handoff.ts
@@ -249,7 +249,11 @@ async function _humanHandOff(
   if (botEvent) {
     params.bot_event = botEvent
   }
-  session._botonic_action = `create_case:${JSON.stringify(params)}`
+  if (!session.is_test_integration) {
+    session._botonic_action = `create_case:${JSON.stringify(params)}`
+  } else {
+    session._botonic_action = `create_test_integration_case:${params.on_finish || ''}`
+  }
 }
 
 export async function storeCaseRating(

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -189,6 +189,7 @@ export interface Session {
   _access_token: string
   _hubtype_api: string
   is_first_interaction: boolean
+  is_test_integration: boolean
   last_session?: any
   organization_id: string
   organization: string

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -248,7 +248,6 @@ export interface BotRequest {
   input: Input
   lastRoutePath: RoutePath
   session: Session
-  followUpAction?: any
 }
 
 /** The response of the bot for the triggered actions, which can be

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -248,6 +248,7 @@ export interface BotRequest {
   input: Input
   lastRoutePath: RoutePath
   session: Session
+  followUpAction?: any
 }
 
 /** The response of the bot for the triggered actions, which can be

--- a/packages/botonic-core/tests/core-bot/core-bot.test.ts
+++ b/packages/botonic-core/tests/core-bot/core-bot.test.ts
@@ -1,0 +1,272 @@
+// @ts-nocheck
+
+import { HandOffBuilder } from '../../src'
+import {
+  developerLocales,
+  developerRoutes,
+  initCoreBotWithDeveloperConfig,
+  LOCALE_EN,
+} from '../helpers/core-bot'
+
+describe('CoreBot', () => {
+  it('inits the class correctly with minimum required values', () => {
+    // Arrange & Act
+    const coreBot = initCoreBotWithDeveloperConfig()
+
+    // Assert
+    expect(coreBot).toBeDefined()
+    expect(coreBot.renderer).toBeDefined()
+    expect(coreBot.routes).toEqual(developerRoutes)
+    expect(coreBot.locales).toEqual(developerLocales)
+    expect(coreBot.defaultRoutes).toEqual([])
+    expect(coreBot.router).toBeDefined()
+    expect(coreBot.inspector).toBeDefined()
+    expect(coreBot.defaultTyping).toEqual(0.6)
+    expect(coreBot.defaultDelay).toEqual(0.4)
+    expect(coreBot.appId).toBeUndefined()
+    expect(coreBot.rootElement).toBeNull()
+    expect(coreBot.plugins).toEqual({})
+    expect(coreBot.theme).toEqual({})
+  })
+
+  it('inits the class correctly with minimum required values + appId', () => {
+    // Arrange & Act
+    const coreBot = initCoreBotWithDeveloperConfig({ appId: '1234' })
+
+    // Assert
+    expect(coreBot).toBeDefined()
+    expect(coreBot.renderer).toBeDefined()
+    expect(coreBot.routes).toEqual(developerRoutes)
+    expect(coreBot.locales).toEqual(developerLocales)
+    expect(coreBot.defaultRoutes).toEqual([])
+    expect(coreBot.router).toBeDefined()
+    expect(coreBot.inspector).toBeDefined()
+    expect(coreBot.defaultTyping).toEqual(0.6)
+    expect(coreBot.defaultDelay).toEqual(0.4)
+    expect(coreBot.appId).toEqual('1234')
+    expect(coreBot.rootElement).toBeNull()
+    expect(coreBot.plugins).toEqual({})
+    expect(coreBot.theme).toEqual({})
+  })
+
+  it('setLocale to define locale in session', () => {
+    // Arrange
+    const coreBot = initCoreBotWithDeveloperConfig()
+    const session = {}
+
+    // Act
+    coreBot.setLocale(LOCALE_EN, session)
+
+    // Assert
+    expect(session).toEqual({ __locale: LOCALE_EN })
+  })
+
+  it('getString to return expected locale', () => {
+    // Arrange
+    const coreBot = initCoreBotWithDeveloperConfig()
+    const session = { __locale: LOCALE_EN }
+
+    // Act
+    const resolvedLocaleText = coreBot.getString('text1', session)
+
+    // Assert
+    expect(coreBot.locales.en.text1).toContain(resolvedLocaleText)
+  })
+
+  it('input processes a chatevent (e.g: sent when enduser is typing', async () => {
+    // Arrange
+    const coreBot = initCoreBotWithDeveloperConfig()
+    const session = {}
+
+    // Act
+    const botResponse = await coreBot.input({
+      input: { type: 'chatevent', data: 'typing_on' },
+      session,
+      lastRoutePath: '',
+    })
+
+    // Assert
+    expect(botResponse).toEqual({
+      input: { data: 'typing_on', type: 'chatevent' },
+      lastRoutePath: '',
+      response: [],
+      session: { __locale: 'en' },
+    })
+  })
+
+  it('processes events if routes are defined as a function', async () => {
+    // Arrange
+    const coreBot = initCoreBotWithDeveloperConfig({
+      routes: async () => developerRoutes,
+    })
+    const session = {}
+
+    // Act
+    const botResponse = await coreBot.input({
+      input: { type: 'text', data: 'hello' },
+      session,
+      lastRoutePath: '',
+    })
+
+    // Assert
+    expect(botResponse).toEqual({
+      input: { data: 'hello', type: 'text' },
+      lastRoutePath: '',
+      response: [
+        {
+          actions: [null, 'Hi user!', null],
+          request: {
+            defaultDelay: 0.4,
+            defaultTyping: 0.6,
+            getString: expect.any(Function),
+            input: { data: 'hello', type: 'text' },
+            lastRoutePath: '',
+            params: {},
+            plugins: {},
+            session: {
+              __locale: 'en',
+              __retries: 0,
+              is_first_interaction: false,
+            },
+            setLocale: expect.any(Function),
+          },
+        },
+      ],
+      session: { __locale: 'en', __retries: 0, is_first_interaction: false },
+    })
+  })
+
+  it('input returns a response', async () => {
+    // Arrange
+    const coreBot = initCoreBotWithDeveloperConfig()
+    const args = {
+      input: { type: 'text', data: 'hello' },
+      session: { is_first_interaction: true },
+      lastRoutePath: '',
+    }
+
+    // Act
+    const botResponse = await coreBot.input(args)
+
+    // Assert
+    expect(botResponse).toBeDefined()
+    expect(botResponse.input).toEqual({ type: 'text', data: 'hello' })
+    expect(botResponse.session).toEqual({
+      __locale: 'en',
+      __retries: 0,
+      is_first_interaction: false,
+    })
+    expect(botResponse.lastRoutePath).toEqual('')
+    expect(botResponse.response[0]).toBeDefined()
+    expect(botResponse.response[0].request).toEqual({
+      defaultDelay: 0.4,
+      defaultTyping: 0.6,
+      getString: expect.any(Function),
+      input: { data: 'hello', type: 'text' },
+      lastRoutePath: '',
+      params: {},
+      plugins: {},
+      session: { __locale: 'en', __retries: 0, is_first_interaction: false },
+      setLocale: expect.any(Function),
+    })
+    expect(botResponse.response[0].actions).toEqual([null, 'Hi user!', null])
+  })
+
+  it('input returns a response if test integration without _botonic_action', async () => {
+    // Arrange
+
+    // Act
+    const coreBot = initCoreBotWithDeveloperConfig()
+    const botResponse = await coreBot.input({
+      input: { type: 'text', data: 'hello' },
+      session: {
+        is_test_integration: true,
+        _botonic_action: undefined,
+      },
+      lastRoutePath: '',
+    })
+
+    // Assert
+    expect(botResponse).toBeDefined()
+    expect(botResponse.input).toEqual({ type: 'text', data: 'hello' })
+    expect(botResponse.session).toEqual({
+      __locale: 'en',
+      __retries: 0,
+      is_first_interaction: false,
+      is_test_integration: true,
+      _botonic_action: undefined,
+    })
+    expect(botResponse.lastRoutePath).toEqual('')
+    expect(botResponse.response[0]).toBeDefined()
+    expect(botResponse.response[0].request).toEqual({
+      defaultDelay: 0.4,
+      defaultTyping: 0.6,
+      getString: expect.any(Function),
+      input: { data: 'hello', type: 'text' },
+      lastRoutePath: '',
+      params: {},
+      plugins: {},
+      session: {
+        __locale: 'en',
+        __retries: 0,
+        is_first_interaction: false,
+        is_test_integration: true,
+        _botonic_action: undefined,
+      },
+      setLocale: expect.any(Function),
+    })
+    expect(botResponse.response[0].actions).toEqual([null, 'Hi user!', null])
+  })
+})
+
+it('input returns the follow up when a handoff is done in a test integration', async () => {
+  // Arrange
+  const session = {
+    is_test_integration: true,
+    _botonic_action: 'create_test_integration_case:payload1',
+  }
+
+  const coreBot = initCoreBotWithDeveloperConfig({
+    routes: [
+      {
+        path: '',
+        text: 'hello',
+        action: 'Hi user!',
+      },
+      {
+        path: 'follow-up',
+        payload: 'payload1',
+        action: 'Follow up action',
+      },
+    ],
+  })
+
+  // Act
+  const botResponse = await coreBot.input({
+    input: { type: 'text', data: 'hello' },
+    session,
+    lastRoutePath: '',
+  })
+
+  // Assert
+  expect(botResponse.input).toEqual({
+    type: 'postback',
+    data: undefined,
+    payload: 'payload1',
+    text: undefined,
+  })
+  expect(botResponse.session).toEqual({
+    is_test_integration: true,
+    _botonic_action: undefined,
+    __locale: 'en',
+    __retries: 0,
+    is_first_interaction: false,
+  })
+  expect(botResponse.lastRoutePath).toEqual('follow-up')
+  expect(botResponse.response[0].actions).toEqual([null, 'Hi user!', null])
+  expect(botResponse.response[1].actions).toEqual([
+    null,
+    'Follow up action',
+    null,
+  ])
+})

--- a/packages/botonic-core/tests/handoff.test.ts
+++ b/packages/botonic-core/tests/handoff.test.ts
@@ -127,4 +127,13 @@ describe('Handoff', () => {
       })
     expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
   })
+
+  test('defines create_test_integration_case_with_payload for test integrations', () => {
+    const builder = new HandOffBuilder({
+      is_test_integration: true,
+    }).withOnFinishPayload('payload1')
+    builder.handOff()
+    const expectedBotonicAction = 'create_test_integration_case:payload1'
+    expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
+  })
 })

--- a/packages/botonic-core/tests/helpers/core-bot.ts
+++ b/packages/botonic-core/tests/helpers/core-bot.ts
@@ -1,0 +1,20 @@
+import { CoreBot } from '../../src/core-bot'
+
+export const LOCALE_EN = 'en'
+export const developerRoutes = [{ path: '', text: 'hello', action: 'Hi user!' }]
+export const developerLocales = {
+  [LOCALE_EN]: {
+    text1: ['Hello!', 'Hey there!', 'Aloha'],
+    text2: ["What's up?", "How're you?"],
+    text3: ['Bye!', 'See you later', 'Ciao'],
+  },
+}
+
+export function initCoreBotWithDeveloperConfig(extraConfig = {}) {
+  return new CoreBot({
+    renderer: async args => [args],
+    routes: developerRoutes,
+    locales: developerLocales,
+    ...extraConfig,
+  })
+}

--- a/packages/botonic-core/tests/helpers/routing.ts
+++ b/packages/botonic-core/tests/helpers/routing.ts
@@ -11,6 +11,7 @@ export function testSession(): Session {
     _access_token: '1234',
     _hubtype_api: 'app.hubtype.com',
     is_first_interaction: true,
+    is_test_integration: false,
     organization: 'test_org',
     organization_id: '1234567890',
     __retries: 0,

--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -31,7 +31,6 @@ export class FlowBuilderAction extends React.Component<FlowBuilderActionProps> {
     if (handoffContent) {
       await handoffContent.doHandoff(request)
     }
-
     return { contents }
   }
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
@@ -1,5 +1,10 @@
 import { HandOffBuilder, isDev, isWebchat } from '@botonic/core'
-import { ActionRequest, WebchatSettings } from '@botonic/react'
+import {
+  ActionRequest,
+  Multichannel,
+  Text,
+  WebchatSettings,
+} from '@botonic/react'
 import React from 'react'
 
 import { FlowBuilderApi } from '../api'
@@ -11,6 +16,7 @@ export class FlowHandoff extends ContentFieldsBase {
   public queue?: HtQueueLocale
   public onFinishPayload?: string
   public handoffAutoAssign: boolean
+  public isTestIntegration: boolean
 
   static fromHubtypeCMS(
     cmsHandoff: HtHandoffNode,
@@ -51,11 +57,24 @@ export class FlowHandoff extends ContentFieldsBase {
         language: request.session.user.extra_data.language,
         country: request.session.user.extra_data.country,
       })
+      this.isTestIntegration = request.session.is_test_integration
       await handOffBuilder.handOff()
     }
   }
 
   toBotonic(id: string, request: ActionRequest): JSX.Element {
+    if (this.isTestIntegration) {
+      return (
+        <Multichannel key={this.id}>
+          <Text>
+            ℹ️ _At this point, a new case would be created in {this.queue?.name}{' '}
+            queue. To continue with the preview, a case resolved scenario will
+            be simulated._
+          </Text>
+        </Multichannel>
+      )
+    }
+
     return isDev(request.session) || isWebchat(request.session) ? (
       <WebchatSettings key={id} enableUserInput={true} />
     ) : (

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
@@ -67,9 +67,9 @@ export class FlowHandoff extends ContentFieldsBase {
       return (
         <Multichannel key={this.id}>
           <Text>
-            ℹ️ _At this point, a new case would be created in {this.queue?.name}{' '}
-            queue. To continue with the preview, a case resolved scenario will
-            be simulated._
+            _**HANDOFF IN PREVIEW**_ {'\n'}ℹ️ _At this point, a new case would
+            be created in {this.queue?.name} queue. To continue with the
+            preview, a case resolved scenario will be simulated._
           </Text>
         </Multichannel>
       )

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -81,7 +81,6 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   }
 
   async pre(request: PluginPreRequest): Promise<void> {
-    request.session.is_test_integration = true
     this.currentRequest = request
     this.cmsApi = await FlowBuilderApi.create({
       url: this.resolveFlowUrl(request),

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -81,6 +81,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   }
 
   async pre(request: PluginPreRequest): Promise<void> {
+    request.session.is_test_integration = true
     this.currentRequest = request
     this.cmsApi = await FlowBuilderApi.create({
       url: this.resolveFlowUrl(request),

--- a/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
@@ -34,7 +34,7 @@ export class SmartIntentsApi {
       bot_id: this.currentRequest.session.bot.id,
       text: this.currentRequest.input.data,
       num_smart_intents_to_use: this.smartIntentsConfig.numSmartIntentsToUse,
-      use_latest: this.smartIntentsConfig.useLatest,
+      use_latest: this.resolveUseLatest(),
     }
 
     try {
@@ -56,6 +56,11 @@ export class SmartIntentsApi {
       console.error(e)
     }
     return undefined
+  }
+
+  private resolveUseLatest(): boolean {
+    if (this.currentRequest.session.is_test_integration) return false
+    return this.smartIntentsConfig.useLatest
   }
 
   private async getInference(

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -67,6 +67,7 @@ export function createRequest({
       __retries: 0,
       _access_token: 'fake_access_token',
       _hubtype_api: 'https://api.hubtype.com',
+      is_test_integration: false,
     },
     input,
     lastRoutePath: '',

--- a/packages/botonic-plugin-hubtype-analytics/src/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/index.ts
@@ -48,9 +48,9 @@ export default class BotonicPluginHubtypeAnalytics implements Plugin {
   }
 
   async trackEvent(request: BotRequest, htEventProps: HtEventProps) {
+    if (request.session.is_test_integration) return Promise.resolve(undefined)
     const requestData = this.getRequestData(request)
     const event = createHtEvent(requestData, htEventProps)
-
     return this.sendEvent(request, event)
   }
 

--- a/packages/botonic-plugin-hubtype-analytics/src/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/index.ts
@@ -1,5 +1,5 @@
 import { BotRequest, Plugin } from '@botonic/core'
-import axios from 'axios'
+import axios, { AxiosResponse } from 'axios'
 
 import { HtEvent } from './event-models'
 import { EventType, HtEventProps, RequestData } from './types'
@@ -48,7 +48,10 @@ export default class BotonicPluginHubtypeAnalytics implements Plugin {
   }
 
   async trackEvent(request: BotRequest, htEventProps: HtEventProps) {
-    if (request.session.is_test_integration) return
+    if (request.session.is_test_integration) {
+      return Promise.resolve()
+    }
+
     const requestData = this.getRequestData(request)
     const event = createHtEvent(requestData, htEventProps)
     return this.sendEvent(request, event)

--- a/packages/botonic-plugin-hubtype-analytics/src/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/index.ts
@@ -48,7 +48,7 @@ export default class BotonicPluginHubtypeAnalytics implements Plugin {
   }
 
   async trackEvent(request: BotRequest, htEventProps: HtEventProps) {
-    if (request.session.is_test_integration) return Promise.resolve(undefined)
+    if (request.session.is_test_integration) return
     const requestData = this.getRequestData(request)
     const event = createHtEvent(requestData, htEventProps)
     return this.sendEvent(request, event)

--- a/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
@@ -34,6 +34,7 @@ export function createRequest(args?: RequestArgs): BotRequest {
       __retries: 0,
       _access_token: 'fake_access_token',
       _hubtype_api: 'https://api.hubtype.com',
+      is_test_integration: false,
     },
     input: { data: 'Hola', type: INPUT.TEXT },
     lastRoutePath: '',


### PR DESCRIPTION
## Description
* Type `is_test_integration` in `Session`.
* Avoid calling botonic-plugin-hubtype-analytics when bot has `session.is_test_integration` set to true.
* Do call smart intents inference with use_latest parameter set to false if bot has `session.is_test_integration` set to true.
* Flow Builder plugin to fetch only draft version of the flow if bot has `session.is_test_integration` set to true.
* FB Plugin and core coordinated to being able to execute a first input with a simulation of the handoff, and a preceding input to emulate the on finish payload after this faked handoff.

## Context
This PR contains the needed implementations in the botonic side to avoid test integration bots to produce not expected data and pollute metrics, this is, not calling analytics, faking handoff, ... if bots are of this type.

## Testing
 
- Add botonic-core: handoff with is_test_integration and core-bot tests
- Fix plugin-flow-builder tests
- Fix plugin-hubtype-analytics tests
