### PR TITLE
plugin-flow-builder: fix uuid for flowThreadId 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25840,7 +25840,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.27.2",
+      "version": "0.27.3",
       "dependencies": {
         "@botonic/react": "^0.27.0",
         "axios": "^1.6.8",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/tracking.ts
+++ b/packages/botonic-plugin-flow-builder/src/tracking.ts
@@ -1,4 +1,5 @@
 import { ActionRequest } from '@botonic/react'
+import { v4 as uuid } from 'uuid'
 
 import { FlowContent } from './content-fields'
 import { HtNodeWithContent } from './content-fields/hubtype-fields'
@@ -59,8 +60,9 @@ export function getContentEventArgs(
   }
 ) {
   const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)
+  const flowThreadId = request.session.flow_thread_id ?? uuid()
   return {
-    flowThreadId: request.session.flow_thread_id,
+    flowThreadId,
     flowId: contentInfo.flowId,
     flowName: flowBuilderPlugin.getFlowName(contentInfo.flowId),
     flowNodeId: contentInfo.id,


### PR DESCRIPTION
## Description

Create the flowThreadId in the tracking function if it does not exist.

## Context

When tracking content the flowThreadId is required in the backend.
If this happens in a conversation that already existed before adding the plugin the bot does not go through the function getStartContents, which is where this flowThreadId is generated and at the time of tracking the content fails because this value is not undefined.

