### PR TITLE
Botonic-React: change staticAsset function + add unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25963,7 +25963,7 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.27.1",
+      "version": "0.27.2",
       "license": "MIT",
       "dependencies": {
         "@botonic/core": "0.27.0",

--- a/packages/botonic-react/package-lock.json
+++ b/packages/botonic-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/util/environment.js
+++ b/packages/botonic-react/src/util/environment.js
@@ -5,7 +5,7 @@ export const staticAsset = path => {
   try {
     if (isURL(path)) return path // Webpack 5 >= fully resolves absolute path to assets
     const scriptBaseURL = document
-      .querySelector('script[src$="webchat.botonic.js"]')
+      .querySelector('script[src*="webchat.botonic.js"]')
       .getAttribute('src')
     const scriptName = scriptBaseURL.split('/').pop()
     const basePath = scriptBaseURL.replace('/' + scriptName, '/')

--- a/packages/botonic-react/tests/utils.test.js
+++ b/packages/botonic-react/tests/utils.test.js
@@ -1,5 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isURL, staticAsset } from '../src/util/environment'
 import { deserializeRegex, stringifyWithRegexs } from '../src/util/regexs'
-
 describe('Regex serialization / deserialization', () => {
   const regexsItems = [
     { regex: /regex/i, string: '"/regex/i"', samples: ['Regex', 'regex'] },
@@ -24,5 +27,102 @@ describe('Regex serialization / deserialization', () => {
         expect(match).toBe(true)
       })
     })
+  })
+})
+
+jest.mock('../src/util/environment', () => ({
+  ...jest.requireActual('../src/util/environment'),
+  isURL: jest.fn(),
+  normalize: jest.fn(),
+}))
+
+const createScript = src => {
+  const script = document.createElement('script')
+  script.src = src
+  document.head.appendChild(script)
+  return script
+}
+
+const removeScript = script => {
+  document.head.removeChild(script)
+}
+
+describe('staticAsset function', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should return the path if it is a URL', () => {
+    //arrange
+    isURL.mockReturnValue(true)
+    const url = 'https://example.com/asset.png'
+
+    //act
+    const result = staticAsset(url)
+
+    //assert
+    expect(result).toBe(url)
+  })
+
+  test('should resolve the static asset path if it is not a URL and file name is webchat.botonic.js', () => {
+    //arrange
+    isURL.mockReturnValue(false)
+
+    const assetPath = 'asset.svg'
+    const basePath = 'http://localhost/'
+    const scriptBaseURL = `${basePath}webchat.botonic.js`
+    const script = createScript(scriptBaseURL)
+
+    //act
+    const result = staticAsset(assetPath)
+
+    //assert
+    expect(result).toBe(basePath + assetPath)
+
+    removeScript(script)
+  })
+
+  test('should resolve static asset path if filename is different than webchat.botonic.js', () => {
+    //arrange
+    isURL.mockReturnValue(false)
+
+    const assetPath = 'asset.svg'
+    const basePath = 'http://localhost/'
+    const scriptBaseURL = `${basePath}webchat.botonic.js?version=1.0.1`
+    const script = createScript(scriptBaseURL)
+
+    //act
+    const result = staticAsset(assetPath)
+
+    //assert
+    expect(result).toBe(basePath + assetPath)
+
+    removeScript(script)
+  })
+
+  test('should log an error and return normalized path if script element is not found', () => {
+    //arrange
+    isURL.mockReturnValue(false)
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    const path = 'asset.svg'
+    const basePath = 'http://localhost/'
+    const scriptBaseURL = `${basePath}webchat.js?version=1.0.1`
+    const script = createScript(scriptBaseURL)
+
+    //act
+    const result = staticAsset(path)
+
+    //assert
+    expect(result).toBe(path)
+    expect(console.error).toHaveBeenCalledWith(
+      `Could not resolve path: '${path}'`
+    )
+
+    consoleErrorSpy.mockRestore()
+    removeScript(script)
   })
 })


### PR DESCRIPTION
## Description
Changed how `staticAsset` function is searching for the script to resolve the assets path.
<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Context
The function is only searching for scripts that end with "webchat.botonic.js" so if the webchat file has another name it won't work.
<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design
Change the query done in the function to check that the script contains "webchat.botonic.js"
<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

Added unit tests to test the function.
