### PR TITLE
Fix bot action after handoff in test integration preview

### DIFF
--- a/packages/botonic-core/src/handoff.ts
+++ b/packages/botonic-core/src/handoff.ts
@@ -261,6 +261,9 @@ export async function storeCaseRating(
   rating: number,
   context: any = {}
 ): Promise<{ status: string }> {
+  if (session.is_test_integration) {
+    return Promise.resolve({ status: 'ok' })
+  }
   const baseUrl = session._hubtype_api || HUBTYPE_API_URL
   const chatId = session.user.id
   context = contextDefaults(context)


### PR DESCRIPTION
## Description

- Refactor the core-bot, create small functions and reuse the runInput function inside the runFollowUpTestIntegrationInput function.
- Avoid storeRatingCase when is_test_integration is true
