### PR TITLE
botonic-react: remove unescape, qrcode.react and he dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25937,7 +25937,6 @@
         "axios": "^1.7.2",
         "emoji-picker-react": "^4.4.9",
         "framer-motion": "^3.1.1",
-        "he": "^1.2.0",
         "lodash.merge": "^4.6.2",
         "markdown-it": "^12.0.6",
         "react": "^16.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20962,22 +20962,6 @@
         "which": "bin/which"
       }
     },
-    "node_modules/qr.js": {
-      "version": "0.0.0",
-      "license": "MIT"
-    },
-    "node_modules/qrcode.react": {
-      "version": "1.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.0",
-        "qr.js": "0.0.0"
-      },
-      "peerDependencies": {
-        "react": "^15.5.3 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/qs": {
       "version": "6.12.0",
       "license": "BSD-3-Clause",
@@ -25956,7 +25940,6 @@
         "he": "^1.2.0",
         "lodash.merge": "^4.6.2",
         "markdown-it": "^12.0.6",
-        "qrcode.react": "^1.0.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-frame-component": "^4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12106,16 +12106,6 @@
       "version": "3.0.2",
       "license": "MIT"
     },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "license": "MIT",
@@ -14564,13 +14554,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -24282,16 +24265,6 @@
       "version": "5.26.5",
       "license": "MIT"
     },
-    "node_modules/unescape": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "license": "MIT",
@@ -25994,7 +25967,6 @@
         "simplebar-react": "^2.4.3",
         "styled-components": "^5.3.0",
         "ua-parser-js": "^0.8.1",
-        "unescape": "^1.0.1",
         "use-async-effect": "^2.2.7",
         "uuid": "^8.3.2"
       },

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -23,7 +23,6 @@
     "@botonic/core": "^0.28.1",
     "axios": "^1.7.2",
     "emoji-picker-react": "^4.4.9",
-    "he": "^1.2.0",
     "lodash.merge": "^4.6.2",
     "markdown-it": "^12.0.6",
     "react": "^16.14.0",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -26,7 +26,6 @@
     "he": "^1.2.0",
     "lodash.merge": "^4.6.2",
     "markdown-it": "^12.0.6",
-    "qrcode.react": "^1.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-frame-component": "^4.1.3",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -37,7 +37,6 @@
     "simplebar-react": "^2.4.3",
     "styled-components": "^5.3.0",
     "ua-parser-js": "^0.8.1",
-    "unescape": "^1.0.1",
     "use-async-effect": "^2.2.7",
     "uuid": "^8.3.2"
   },

--- a/packages/botonic-react/src/botonic-tester.jsx
+++ b/packages/botonic-react/src/botonic-tester.jsx
@@ -1,22 +1,37 @@
 import { INPUT } from '@botonic/core'
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
-import decode from 'unescape'
 
 import { Reply } from './components/reply'
 import { Text } from './components/text'
+
+function decodeHTMLEntities(text) {
+  const entities = {
+    '&quot;': '"',
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&apos;': "'",
+  }
+
+  return text.replace(
+    /&quot;|&amp;|&lt;|&gt;|&apos;/g,
+    match => entities[match]
+  )
+}
 
 export class BotonicInputTester {
   constructor(bot) {
     this.bot = bot
   }
+
   async text(inp, session = { user: { id: '123' } }, lastRoutePath = '') {
     const res = await this.bot.input({
       input: { type: INPUT.TEXT, data: inp },
       session: session,
       lastRoutePath: lastRoutePath,
     })
-    return decode(res.response)
+    return decodeHTMLEntities(res.response)
   }
 
   async payload(inp, session = { user: { id: '123' } }, lastRoutePath = '') {
@@ -25,7 +40,7 @@ export class BotonicInputTester {
       session: session,
       lastRoutePath: lastRoutePath,
     })
-    return decode(res.response)
+    return decodeHTMLEntities(res.response)
   }
 
   async path(inp, session = { user: { id: '123' } }, lastRoutePath = '') {
@@ -34,7 +49,7 @@ export class BotonicInputTester {
       session: session,
       lastRoutePath: lastRoutePath,
     })
-    return decode(res.response)
+    return decodeHTMLEntities(res.response)
   }
 }
 
@@ -44,7 +59,7 @@ export class BotonicOutputTester {
   }
 
   text(out, replies = null) {
-    return decode(
+    return decodeHTMLEntities(
       ReactDOMServer.renderToStaticMarkup(
         !replies ? (
           <Text>{out}</Text>
@@ -60,14 +75,14 @@ export class BotonicOutputTester {
 
   reply({ text, payload = null, path = null }) {
     if (payload) {
-      return decode(
+      return decodeHTMLEntities(
         ReactDOMServer.renderToStaticMarkup(
           <Reply payload={payload}>{text}</Reply>
         )
       )
     }
     if (path) {
-      return decode(
+      return decodeHTMLEntities(
         ReactDOMServer.renderToStaticMarkup(<Reply path={path}>{text}</Reply>)
       )
     }


### PR DESCRIPTION
## Description
* Replace `unescape.decode()` function by a simpler one with a list of well-known HTML Entities. This dependency is only used for using BotonicInput/OutputTesters and can be easily replaced by a function.
* Remove unused dependencies `qrcode.react` and `he` (which come from previous 1.0 test version of botonic)