### PR TITLE
core: use ActionRequest in all core-bots steps 

### DIFF
--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 // TODO: This file contains all the legacy types we had in index.ts. After some refactors, we should be able to get rid of many of them.
 
 export enum CASE_STATUS {
@@ -77,23 +78,6 @@ export enum INPUT {
 export interface Locales {
   [id: string]: string | string[] | Locales
 }
-
-interface PluginConstructor<T> {
-  new (arg: T): Plugin
-}
-
-export interface PluginConfig<T> {
-  id: string
-  options?: T
-  resolve: { default: PluginConstructor<T> }
-}
-
-export interface ResolvedPlugin extends Plugin {
-  id: string
-  name: string
-  config: any
-}
-export type ResolvedPlugins = Record<string, ResolvedPlugin>
 
 export type InputType =
   | INPUT.AUDIO
@@ -258,17 +242,50 @@ export interface BotResponse extends BotRequest {
   response: any
 }
 
-export interface PluginPreRequest extends BotRequest {
+export interface ActionRequest {
+  defaultDelay: number
+  defaultTyping: number
+  input: Input
+  lastRoutePath: string | null
+  params: { [key: string]: string }
   plugins: ResolvedPlugins
-}
-export interface PluginPostRequest extends BotResponse {
-  plugins: ResolvedPlugins
+  session: Session
 }
 
-export interface Plugin {
-  post?(request: PluginPostRequest): void | Promise<void>
-  pre?(request: PluginPreRequest): void | Promise<void>
+// Aquest tipus s'hauria de fer servir en el post dels plugins ja que a de tenir la response i els plugins
+export interface ActionResponse extends ActionRequest {
+  response: any
 }
+
+interface PluginConstructor<T> {
+  new (arg: T): Plugin
+}
+
+export interface PluginConfig<T> {
+  id: string
+  options?: T
+  resolve: { default: PluginConstructor<T> }
+}
+
+export interface ResolvedPlugin extends Plugin {
+  id: string
+  name: string
+  config: any
+}
+export type ResolvedPlugins = Record<string, ResolvedPlugin>
+
+export interface Plugin {
+  pre?(request: ActionRequest): void | Promise<void>
+  post?(request: ActionResponse): void | Promise<void>
+}
+
+// export interface PluginPreRequest extends BotRequest {
+//   plugins: ResolvedPlugins
+// }
+
+// export interface PluginPostRequest extends BotResponse {
+//   plugins: ResolvedPlugins
+// }
 
 export interface Params {
   [key: string]: any

--- a/packages/botonic-core/src/plugins.ts
+++ b/packages/botonic-core/src/plugins.ts
@@ -1,10 +1,4 @@
-import {
-  Input,
-  PluginConfig,
-  ResolvedPlugins,
-  RoutePath,
-  Session,
-} from './models'
+import { ActionRequest, PluginConfig, ResolvedPlugins } from './models'
 
 type PluginMode = 'pre' | 'post'
 
@@ -27,26 +21,21 @@ export function loadPlugins(plugins: PluginConfig<any>[]): ResolvedPlugins {
 }
 
 export async function runPlugins(
-  plugins: ResolvedPlugins,
+  actionRequest: ActionRequest,
   mode: PluginMode,
-  input: Input,
-  session: Session,
-  lastRoutePath: RoutePath,
   response: string | null = null
 ): Promise<void> {
+  const { plugins } = actionRequest
   for (const key in plugins) {
-    const p = await plugins[key]
+    const plugin = plugins[key]
     try {
-      if (mode === 'pre' && p.pre) {
-        await p.pre({ input, session, lastRoutePath, plugins })
+      if (mode === 'pre' && plugin.pre) {
+        await plugin.pre(actionRequest)
       }
-      if (mode === 'post' && p.post) {
-        await p.post({
-          input,
-          session,
-          lastRoutePath,
+      if (mode === 'post' && plugin.post) {
+        await plugin.post({
+          ...actionRequest,
           response,
-          plugins,
         })
       }
     } catch (e) {

--- a/packages/botonic-core/src/routing/router.ts
+++ b/packages/botonic-core/src/routing/router.ts
@@ -1,6 +1,7 @@
 import { NOT_FOUND_PATH } from '../constants'
 import { RouteInspector } from '../debug/inspector'
 import {
+  ActionRequest,
   Input,
   MatchedValue,
   Matcher,
@@ -19,7 +20,6 @@ import {
   getNotFoundAction,
   getPathParamsFromPathPayload,
   isPathPayload,
-  pathParamsToParams,
 } from './router-utils'
 
 export class Router {

--- a/packages/botonic-core/tests/routing/router.test.ts
+++ b/packages/botonic-core/tests/routing/router.test.ts
@@ -87,11 +87,12 @@ const routes = [...defaultRoutes, ...fallbackRoutes, notFoundRoute]
 describe('TEST: Root Level Accesses (lastRoutePath is null)', () => {
   const router = new Router(routes)
 
+  // que es normal input? hi ha diferents inputs amb intent, payload, text
   describe('normal input', () => {
     it('1. should retrieve routes at root level (initial path)', () => {
       expect(
         router.processInput(
-          { type: 'text', text: 'hi', intent: 'greeting' },
+          { type: 'text', text: 'hi', intent: 'greeting' }, // Com funciona el match del intent? si trec el intent falla, si poso ggreting funciona
           testSession(),
           null
         )
@@ -176,7 +177,7 @@ describe('TEST: Root Level Accesses (lastRoutePath is null)', () => {
     it('3. should retrieve routes at root level (404 path payload)', () => {
       expect(
         router.processInput(
-          { type: 'postback', payload: createPathPayload('404') },
+          { type: 'postback', payload: createPathPayload('404') }, // qualsevol payload que no existeixi fa que el test passi en verd
           testSession(),
           null
         )
@@ -1257,7 +1258,7 @@ describe('TEST: Converting Functional Routes to Routes', () => {
     expect(computedRoutes).toEqual(routes)
   })
 })
-// eslint-disable-next-line jest/valid-describe
+
 describe('TEST: Functional Router process input', () => {
   it('Resolves correctly the dynamic routes and incoming input', async () => {
     const routes = async ({ input, session }) => {

--- a/packages/botonic-react/src/index-types.ts
+++ b/packages/botonic-react/src/index-types.ts
@@ -1,4 +1,5 @@
 import {
+  ActionRequest,
   BotRequest as CoreBotRequest,
   Input as CoreInput,
   InputType as CoreInputType,
@@ -36,19 +37,20 @@ export interface Route extends CoreRoute {
 export type Routes = CoreRoutes<Route>
 
 // Parameters of the actions' botonicInit method
-export interface ActionRequest {
-  defaultDelay: number
-  defaultTyping: number
-  input: CoreInput
-  lastRoutePath: string
-  params: { [key: string]: string }
-  plugins: { [id: string]: CorePlugin }
-  session: CoreSession
-}
+// export interface ActionRequest {
+//   defaultDelay: number
+//   defaultTyping: number
+//   input: CoreInput
+//   lastRoutePath: string
+//   params: { [key: string]: string }
+//   plugins: { [id: string]: CorePlugin }
+//   session: CoreSession
+// }
+export { ActionRequest } from '@botonic/core'
 
 export interface RequestContextInterface extends ActionRequest {
   getString: (stringId: string) => string
-  setLocale: (locale: string) => string
+  setLocale: (locale: string) => void
 }
 
 export interface CustomMessageType {


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

Create the actionRequest object with everything that has the request in the action at the start of the core-bot. 
Use this object for the pre functions of the plugin, the routes and the action. After that create actionResponse to use it in the post function of the plugins. 
Finally create and return the botResponse object from the actionResponse used in the plugins post function.

## Context

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
