### PR TITLE
plugin-knowledge-bases: update api endpoint to use source ids #BLT-983

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.29.X] - aaaa-mm-dd
+## [0.30.X] - aaaa-mm-dd
+
+### Added
 
 ### Changed
 
@@ -18,9 +20,21 @@ All notable changes to Botonic will be documented in this file.
 
 </details>
 
+## [0.29.0] - 2024-08-14
+
+### Added
+
+### Changed
+
+- [@botonic/plugin-knowledge-bases](https://www.npmjs.com/package/@botonic/plugin-knowledge-bases)
+
+  - [Update inference endpoint to use source ids instead of source names](https://github.com/hubtype/botonic/pull/2880)
+
+### Fixed
+
 ## [0.28.0] - 2024-07-09
 
-### Added
+### Added
 
 - [Project](https://github.com/hubtype/botonic)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28604,7 +28604,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@botonic/core": "^0.28.1",
+        "@botonic/core": "^0.28.2",
         "axios": "^1.7.2"
       },
       "devDependencies": {

--- a/packages/botonic-plugin-knowledge-bases/package.json
+++ b/packages/botonic-plugin-knowledge-bases/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.9",
-    "@botonic/core": "^0.28.1",
+    "@botonic/core": "^0.28.2",
     "axios": "^1.7.2"
   },
   "devDependencies": {

--- a/packages/botonic-plugin-knowledge-bases/src/hubtype-knowledge-api-service.ts
+++ b/packages/botonic-plugin-knowledge-bases/src/hubtype-knowledge-api-service.ts
@@ -23,16 +23,12 @@ export class HubtypeApiService {
       answer: string
       has_knowledge: boolean
       is_faithful: boolean
-      sources: {
-        knowledge_base_id: string
-        knowledge_source_id: string
-        knowledge_chunk_id: string
-      }[]
+      chunk_ids: string[]
     }>
   > {
     return await axios({
       method: 'POST',
-      url: `${this.host}/external/v1/ai/knowledge_bases/inference/`,
+      url: `${this.host}/external/v1/ai/knowledge_base/inference/`,
       headers: {
         Authorization: `Bearer ${authToken}`,
         'Content-Type': 'application/json',

--- a/packages/botonic-plugin-knowledge-bases/src/index.ts
+++ b/packages/botonic-plugin-knowledge-bases/src/index.ts
@@ -31,21 +31,13 @@ export default class BotonicPluginKnowledgeBases implements Plugin {
       sources
     )
 
-    const responseSources = response.data.sources.map(source => {
-      return {
-        knowledgeBaseId: source.knowledge_base_id,
-        knowledgeSourceId: source.knowledge_source_id,
-        knowledgeChunkId: source.knowledge_chunk_id,
-      }
-    })
-
     return {
       inferenceId: response.data.inference_id,
       question: response.data.question,
       answer: response.data.answer,
       hasKnowledge: response.data.has_knowledge,
       isFaithuful: response.data.is_faithful,
-      sources: responseSources,
+      chunkIds: response.data.chunk_ids,
     }
   }
 }

--- a/packages/botonic-plugin-knowledge-bases/src/types.ts
+++ b/packages/botonic-plugin-knowledge-bases/src/types.ts
@@ -10,9 +10,5 @@ export interface KnowledgeBaseResponse {
   answer: string
   hasKnowledge: boolean
   isFaithuful: boolean
-  sources: {
-    knowledgeBaseId: string
-    knowledgeSourceId: string
-    knowledgeChunkId: string
-  }[]
+  chunkIds: string[]
 }


### PR DESCRIPTION
## Description

Update endpoint to `/knowledge_base/inference/` 
This endpoint use source ids instead of source names

## Context

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
