### PR TITLE
Botonic cli: use endpoints /v2/bots/ for deploy

### DIFF
--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -367,14 +367,17 @@ Deploying to AWS...
   }
 
   /* istanbul ignore next */
-  async deployBundle(): Promise<{ hasDeployErrors: boolean }> {
+  async deployBundle(
+    botConfigJson: BotConfigJson
+  ): Promise<{ hasDeployErrors: boolean }> {
     const spinner = ora({
       text: 'Deploying...',
       spinner: 'bouncingBar',
     }).start()
     try {
       const deploy = await this.botonicApiService.deployBot(
-        join(process.cwd(), BOTONIC_BUNDLE_FILE)
+        join(process.cwd(), BOTONIC_BUNDLE_FILE),
+        botConfigJson
       )
       if (
         (deploy.response && deploy.response.status == 403) ||
@@ -448,11 +451,11 @@ Deploying to AWS...
         return
       }
 
-      const botConfigJson = new BotConfigJson(process.cwd())
-      await botConfigJson.updateBotConfigJson()
+      const botConfig = new BotConfig(process.cwd())
+      const botConfigJson = await botConfig.createJson()
 
       await this.createBundle()
-      const { hasDeployErrors } = await this.deployBundle()
+      const { hasDeployErrors } = await this.deployBundle(botConfigJson)
       await this.displayDeployResults({ hasDeployErrors })
     } catch (e) {
       console.log(colors.red('Deploy Error'), e)

--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -12,7 +12,7 @@ import { ZipAFolder } from 'zip-a-folder'
 import { Telemetry } from '../analytics/telemetry'
 import { BotonicAPIService } from '../botonic-api-service'
 import { CLOUD_PROVIDERS } from '../constants'
-import { BotConfigJson } from '../util/bot-config-json'
+import { BotConfig, BotConfigJson } from '../util/bot-config-json'
 import {
   copy,
   createDir,
@@ -108,7 +108,7 @@ Deploying to AWS...
       await this.botonicApiService.getMoreBots(bots, nextBots)
     }
     const bot = bots.filter(b => b.name === botName)[0]
-    if (bot == undefined && !botName) {
+    if (bot === undefined && !botName) {
       console.log(colors.red(`Bot ${botName} doesn't exist.`))
       console.log('\nThese are the available options:')
       bots.map(b => console.log(` > ${String(b.name)}`))
@@ -193,10 +193,8 @@ Deploying to AWS...
       const bots = resp.data.results
       if (nextBots) await this.botonicApiService.getMoreBots(bots, nextBots)
       // Show the current bot in credentials at top of the list
-      const first_id = this.botonicApiService.bot.id
-      bots.sort(function (x, y) {
-        return x.id == first_id ? -1 : y.id == first_id ? 1 : 0
-      })
+      const firstId = this.botonicApiService.bot.id
+      bots.sort((x, y) => (x.id === firstId ? -1 : y.id === firstId ? 1 : 0))
       return this.selectExistentBot(bots)
     }
   }

--- a/packages/botonic-cli/src/interfaces.ts
+++ b/packages/botonic-cli/src/interfaces.ts
@@ -18,7 +18,7 @@ export interface OAuth {
   refresh_token: string
 }
 
-interface Me {
+export interface Me {
   id: string
   username: string
   email: string
@@ -43,7 +43,7 @@ interface Me {
   managers_settings_json: any
 }
 
-interface AnalyticsInfo {
+export interface AnalyticsInfo {
   anonymous_id: string
 }
 

--- a/packages/botonic-cli/src/interfaces.ts
+++ b/packages/botonic-cli/src/interfaces.ts
@@ -53,6 +53,13 @@ export interface GlobalCredentials {
   analytics: AnalyticsInfo
 }
 
+export interface BotsList {
+  count: number
+  next: string
+  previous: string
+  results: { id: string; name: string }[]
+}
+
 interface BotLastUpdate {
   version: string
   created_at: string

--- a/packages/botonic-cli/tests/commands/deploy.test.ts
+++ b/packages/botonic-cli/tests/commands/deploy.test.ts
@@ -43,7 +43,19 @@ describe('TEST: Deploy pipeline', () => {
         const onceBundled = readDir('.')
         expect(onceBundled).toContain('botonic_bundle.zip')
         expect(onceBundled).toContain('tmp')
-        const { hasDeployErrors } = await deployCommand.deployBundle()
+        const botConfigJson = {
+          build_info: {
+            node_version: 'v20.0.0',
+            npm_version: '10.0.0',
+            botonic_cli_version: '0.29.0',
+          },
+          packages: {
+            '@botonic/core': '0.29.0',
+            '@botonic/react': '0.29.0',
+          },
+        }
+        const { hasDeployErrors } =
+          await deployCommand.deployBundle(botConfigJson)
         expect(hasDeployErrors).toBe(false)
         removeRecursively(join('.', 'botonic_bundle.zip'))
         removeRecursively(join('.', 'tmp'))


### PR DESCRIPTION
## Description

Use new endpoints /v2/bots/ to deploy.
Send the bot_config as parameters in the POST call /v2/bots/ instead of adding the json in the separate folder next to the bot zip of the bot to be deployed.

## Context

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
