### PR TITLE
plugin-flow-builder: bot action as follow up, first node in a flow, after conditionals etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,19 @@ All notable changes to Botonic will be documented in this file.
 
 - [@botonic/cli](https://www.npmjs.com/package/@botonic/cli)
 
-  - [use new endpoint v2 to deploy bots](https://github.com/hubtype/botonic/pull/2884)
+  - [use new `endpoint v2 to deploy` bots](https://github.com/hubtype/botonic/pull/2884)
+
+- [@botonic/core](https://www.npmjs.com/package/@botonic/core)
+
+  - [after resolving an input the `core-bot can redirect to another action, with a maximum of 10 times`](https://github.com/hubtype/botonic/pull/2898)
 
 - [@botonic/react](https://www.npmjs.com/package/@botonic/react)
 
-  - [remove getConfig function](https://github.com/hubtype/botonic/pull/2902)
+  - [remove `getConfig` function](https://github.com/hubtype/botonic/pull/2902)
+
+- [@botonic/plugin-flow-builder](https://www.npmjs.com/package/@botonic/plugin-flow-builder)
+
+  - [can resolve `bot-action` nodes at any point of the flow](https://github.com/hubtype/botonic/pull/2898)
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28938,7 +28938,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "extraneous": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23998,11 +23998,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/reconnecting-websocket": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
-      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
-    },
     "node_modules/redact-pii": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/redact-pii/-/redact-pii-3.4.0.tgz",
@@ -27201,14 +27196,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
-    "node_modules/use-async-effect": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/use-async-effect/-/use-async-effect-2.2.7.tgz",
-      "integrity": "sha512-Vq94tKPyo/9Nok4LOapV0GoGgZPhbeDW/bP6bulLPV4+lIoftaBRBBbGjTbM+j5W1Bm2EkUHJgapeu5YnQvKEA==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
@@ -28842,6 +28829,23 @@
         "core-js": "^3.35.1"
       }
     },
+    "packages/botonic-plugin-dialogflow/node_modules/@botonic/core": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.29.0.tgz",
+      "integrity": "sha512-K2SGynylZSaIV0Upbk+Dvlu1C2VV9/+te6gFEtN1BX2T24C3aTruy8dIX3NAijRnfmZsnuyDfU5oTGJnW0e8nA==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "axios": "^1.7.2",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "packages/botonic-plugin-dialogflow/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -28864,6 +28868,23 @@
       "devDependencies": {
         "@types/aws-sdk": "^2.7.0",
         "@types/node": "20.11.17"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/botonic-plugin-dynamodb/node_modules/@botonic/core": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.29.0.tgz",
+      "integrity": "sha512-K2SGynylZSaIV0Upbk+Dvlu1C2VV9/+te6gFEtN1BX2T24C3aTruy8dIX3NAijRnfmZsnuyDfU5oTGJnW0e8nA==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "axios": "^1.7.2",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -28917,20 +28938,9 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "extraneous": true,
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "packages/botonic-plugin-flow-builder/node_modules/react-textarea-autosize": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz",
-      "integrity": "sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "prop-types": "^15.6.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0 <17.0.0"
       }
     },
     "packages/botonic-plugin-google-analytics": {
@@ -28942,6 +28952,23 @@
         "axios": "^1.7.2"
       }
     },
+    "packages/botonic-plugin-google-analytics/node_modules/@botonic/core": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.29.0.tgz",
+      "integrity": "sha512-K2SGynylZSaIV0Upbk+Dvlu1C2VV9/+te6gFEtN1BX2T24C3aTruy8dIX3NAijRnfmZsnuyDfU5oTGJnW0e8nA==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "axios": "^1.7.2",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "packages/botonic-plugin-google-translation": {
       "name": "@botonic/plugin-google-translation",
       "version": "0.30.0",
@@ -28951,6 +28978,23 @@
         "@botonic/core": "^0.30.0",
         "axios": "^1.7.2",
         "jsrsasign": "^10.9.0"
+      }
+    },
+    "packages/botonic-plugin-google-translation/node_modules/@botonic/core": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.29.0.tgz",
+      "integrity": "sha512-K2SGynylZSaIV0Upbk+Dvlu1C2VV9/+te6gFEtN1BX2T24C3aTruy8dIX3NAijRnfmZsnuyDfU5oTGJnW0e8nA==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "axios": "^1.7.2",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "packages/botonic-plugin-hubtype-analytics": {
@@ -28968,6 +29012,23 @@
         "typescript": "^4.9.5"
       }
     },
+    "packages/botonic-plugin-hubtype-analytics/node_modules/@botonic/core": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.29.0.tgz",
+      "integrity": "sha512-K2SGynylZSaIV0Upbk+Dvlu1C2VV9/+te6gFEtN1BX2T24C3aTruy8dIX3NAijRnfmZsnuyDfU5oTGJnW0e8nA==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "axios": "^1.7.2",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "packages/botonic-plugin-hubtype-babel": {
       "name": "@botonic/plugin-hubtype-babel",
       "version": "0.30.0",
@@ -28982,6 +29043,23 @@
         "@types/minipass": "^3.3.5",
         "@types/node": "^20.11.19",
         "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/botonic-plugin-hubtype-babel/node_modules/@botonic/core": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.29.0.tgz",
+      "integrity": "sha512-K2SGynylZSaIV0Upbk+Dvlu1C2VV9/+te6gFEtN1BX2T24C3aTruy8dIX3NAijRnfmZsnuyDfU5oTGJnW0e8nA==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "axios": "^1.7.2",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -29007,6 +29085,23 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.16"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/botonic-plugin-knowledge-bases/node_modules/@botonic/core": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.29.0.tgz",
+      "integrity": "sha512-K2SGynylZSaIV0Upbk+Dvlu1C2VV9/+te6gFEtN1BX2T24C3aTruy8dIX3NAijRnfmZsnuyDfU5oTGJnW0e8nA==",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.9",
+        "axios": "^1.7.2",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/packages/botonic-core/src/core-bot.ts
+++ b/packages/botonic-core/src/core-bot.ts
@@ -275,8 +275,13 @@ export class CoreBot {
 
   private async runRedirectAction(
     previousResponse: BotResponse,
-    { input, session, lastRoutePath }: BotRequest
+    { input, session, lastRoutePath }: BotRequest,
+    numOfRedirects: number = 0
   ) {
+    if (numOfRedirects > 10) {
+      throw new Error('Maximum BotAction recursive calls reached (10)')
+    }
+
     const nextPayload = session._botonic_action?.split(
       BotonicAction.Redirect
     )[1]
@@ -306,11 +311,15 @@ export class CoreBot {
 
     // Recursive call to handle multiple bot actions in a row
     if (response.session._botonic_action?.startsWith(BotonicAction.Redirect)) {
-      return await this.runRedirectAction(response, {
-        input,
-        session,
-        lastRoutePath,
-      })
+      return await this.runRedirectAction(
+        response,
+        {
+          input,
+          session,
+          lastRoutePath,
+        },
+        numOfRedirects + 1
+      )
     }
 
     return response

--- a/packages/botonic-core/src/core-bot.ts
+++ b/packages/botonic-core/src/core-bot.ts
@@ -322,6 +322,16 @@ export class CoreBot {
       )
     }
 
+    if (
+      response.session._botonic_action?.startsWith(BotonicAction.CreateTestCase)
+    ) {
+      return await this.runFollowUpTestIntegrationInput(response, {
+        input,
+        session,
+        lastRoutePath,
+      })
+    }
+
     return response
   }
 }

--- a/packages/botonic-core/src/core-bot.ts
+++ b/packages/botonic-core/src/core-bot.ts
@@ -283,7 +283,7 @@ export class CoreBot {
     }
 
     const nextPayload = session._botonic_action?.split(
-      BotonicAction.Redirect
+      `${BotonicAction.Redirect}:`
     )[1]
 
     const inputWithBotActionPayload: Input = {

--- a/packages/botonic-core/src/handoff.ts
+++ b/packages/botonic-core/src/handoff.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 import { PATH_PAYLOAD_IDENTIFIER } from './constants'
-import { BotonicAction, Session } from './models'
+import { BotonicAction, BotonicActionType, Session } from './models'
 
 const HUBTYPE_API_URL = 'https://api.hubtype.com'
 
@@ -250,9 +250,9 @@ async function _humanHandOff(
     params.bot_event = botEvent
   }
   if (!session.is_test_integration) {
-    session._botonic_action = `${BotonicAction.CreateCase}${JSON.stringify(params)}`
+    session._botonic_action = `${BotonicAction.CreateCase}:${JSON.stringify(params)}`
   } else {
-    session._botonic_action = `${BotonicAction.CreateTestCase}${params.on_finish || ''}`
+    session._botonic_action = `${BotonicAction.CreateTestCase}:${params.on_finish || ''}`
   }
 }
 
@@ -330,11 +330,11 @@ export function cancelHandoff(
   session: Session,
   typification: string | null = null
 ): void {
-  let action = 'discard_case'
+  let action: BotonicActionType = BotonicAction.DiscardCase
   if (typification) action = `${action}:${JSON.stringify({ typification })}`
   session._botonic_action = action
 }
 
 export function deleteUser(session: Session): void {
-  session._botonic_action = `delete_user`
+  session._botonic_action = BotonicAction.DeleteUser
 }

--- a/packages/botonic-core/src/handoff.ts
+++ b/packages/botonic-core/src/handoff.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 import { PATH_PAYLOAD_IDENTIFIER } from './constants'
-import { Session } from './models'
+import { BotonicAction, Session } from './models'
 
 const HUBTYPE_API_URL = 'https://api.hubtype.com'
 
@@ -250,9 +250,9 @@ async function _humanHandOff(
     params.bot_event = botEvent
   }
   if (!session.is_test_integration) {
-    session._botonic_action = `create_case:${JSON.stringify(params)}`
+    session._botonic_action = `${BotonicAction.CreateCase}${JSON.stringify(params)}`
   } else {
-    session._botonic_action = `create_test_integration_case:${params.on_finish || ''}`
+    session._botonic_action = `${BotonicAction.CreateTestCase}${params.on_finish || ''}`
   }
 }
 

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -316,3 +316,9 @@ export type MatchingProp =
   | 'request'
 
 export type Matcher = string | RegExp | ((args) => boolean)
+
+export enum BotonicAction {
+  Redirect = 'redirect_action:',
+  CreateCase = 'create_case:',
+  CreateTestCase = 'create_test_integration_case:',
+}

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -196,7 +196,7 @@ export interface Session {
   organization: string
   user: SessionUser
   // after handoff
-  _botonic_action?: string
+  _botonic_action?: BotonicActionType
   _hubtype_case_status?: CaseStatusType
   _hubtype_case_id?: string
   _hubtype_case_typification?: string
@@ -317,8 +317,22 @@ export type MatchingProp =
 
 export type Matcher = string | RegExp | ((args) => boolean)
 
+type BotonicActionSeparator = ':'
+
 export enum BotonicAction {
-  Redirect = 'redirect_action:',
-  CreateCase = 'create_case:',
-  CreateTestCase = 'create_test_integration_case:',
+  Redirect = 'redirect_action',
+  CreateCase = 'create_case',
+  CreateTestCase = 'create_test_integration_case',
+  DeleteUser = 'delete_user',
+  DiscardCase = 'discard_case',
 }
+
+export enum BotonicActionWithoutParams {}
+
+export type BotonicActionType =
+  | `${BotonicAction.CreateCase}${BotonicActionSeparator}${string}`
+  | `${BotonicAction.CreateTestCase}${BotonicActionSeparator}${string}`
+  | `${BotonicAction.Redirect}${BotonicActionSeparator}${string}`
+  | `${BotonicAction.DiscardCase}${BotonicActionSeparator}${string}`
+  | BotonicAction.DiscardCase
+  | BotonicAction.DeleteUser

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -317,6 +317,14 @@ export type MatchingProp =
 
 export type Matcher = string | RegExp | ((args) => boolean)
 
+export type BotonicActionType =
+  | `${BotonicAction.CreateCase}${BotonicActionSeparator}${string}`
+  | `${BotonicAction.CreateTestCase}${BotonicActionSeparator}${string}`
+  | `${BotonicAction.Redirect}${BotonicActionSeparator}${string}`
+  | `${BotonicAction.DiscardCase}${BotonicActionSeparator}${string}`
+  | `${BotonicAction.DiscardCase}`
+  | `${BotonicAction.DeleteUser}`
+
 type BotonicActionSeparator = ':'
 
 export enum BotonicAction {
@@ -326,13 +334,3 @@ export enum BotonicAction {
   DeleteUser = 'delete_user',
   DiscardCase = 'discard_case',
 }
-
-export enum BotonicActionWithoutParams {}
-
-export type BotonicActionType =
-  | `${BotonicAction.CreateCase}${BotonicActionSeparator}${string}`
-  | `${BotonicAction.CreateTestCase}${BotonicActionSeparator}${string}`
-  | `${BotonicAction.Redirect}${BotonicActionSeparator}${string}`
-  | `${BotonicAction.DiscardCase}${BotonicActionSeparator}${string}`
-  | BotonicAction.DiscardCase
-  | BotonicAction.DeleteUser

--- a/packages/botonic-core/tests/core-bot/core-bot.test.ts
+++ b/packages/botonic-core/tests/core-bot/core-bot.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 import { HandOffBuilder } from '../../src'
+import { BotonicAction } from '../../src/models'
 import {
   developerLocales,
   developerRoutes,
@@ -223,7 +224,7 @@ it('input returns the follow up when a handoff is done in a test integration', a
   // Arrange
   const session = {
     is_test_integration: true,
-    _botonic_action: 'create_test_integration_case:payload1',
+    _botonic_action: `${BotonicAction.CreateTestCase}:payload1`,
   }
 
   const coreBot = initCoreBotWithDeveloperConfig({

--- a/packages/botonic-core/tests/core-bot/core-bot.test.ts
+++ b/packages/botonic-core/tests/core-bot/core-bot.test.ts
@@ -1,6 +1,4 @@
 // @ts-nocheck
-
-import { HandOffBuilder } from '../../src'
 import { BotonicAction } from '../../src/models'
 import {
   developerLocales,
@@ -268,6 +266,60 @@ it('input returns the follow up when a handoff is done in a test integration', a
   expect(botResponse.response[1].actions).toEqual([
     null,
     'Follow up action',
+    null,
+  ])
+})
+
+it('input returns two actions when first returen a _botonic_action redirect', async () => {
+  // Arrange
+  const session = {
+    _botonic_action: `${BotonicAction.Redirect}:after-rating|'{"value:":5}'`,
+  }
+
+  const coreBot = initCoreBotWithDeveloperConfig({
+    routes: [
+      {
+        path: 'rating-action',
+        text: 'rating',
+        action: 'Can you rate the agent?',
+      },
+      {
+        path: 'after-rating-action',
+        payload: /^after-rating.*/,
+        action: 'Thanks for your rating',
+      },
+    ],
+  })
+
+  // Act
+  const botResponse = await coreBot.input({
+    input: { type: 'text', data: 'rating' },
+    session,
+    lastRoutePath: 'rating-action',
+  })
+  console.log({ botResponse })
+  // Assert
+  expect(botResponse.input).toEqual({
+    type: 'postback',
+    data: undefined,
+    payload: `after-rating|'{"value:":5}'`,
+    text: undefined,
+  })
+  expect(botResponse.session).toEqual({
+    _botonic_action: undefined,
+    __locale: 'en',
+    __retries: 0,
+    is_first_interaction: false,
+  })
+  expect(botResponse.lastRoutePath).toEqual('after-rating-action')
+  expect(botResponse.response[0].actions).toEqual([
+    null,
+    'Can you rate the agent?',
+    null,
+  ])
+  expect(botResponse.response[1].actions).toEqual([
+    null,
+    'Thanks for your rating',
     null,
   ])
 })

--- a/packages/botonic-core/tests/handoff.test.ts
+++ b/packages/botonic-core/tests/handoff.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { PATH_PAYLOAD_IDENTIFIER } from '../src'
+import { BotonicAction, PATH_PAYLOAD_IDENTIFIER } from '../src'
 import { HandOffBuilder, humanHandOff } from '../src/handoff'
 
 describe('Handoff', () => {
@@ -54,7 +54,7 @@ describe('Handoff', () => {
       new HandOffBuilder({}).withOnFinishPath('path1'),
     ],
     [
-      `create_case:` +
+      `${BotonicAction.CreateCase}:` +
         JSON.stringify({
           force_assign_if_not_available: true,
           agent_id: '1234',
@@ -72,7 +72,7 @@ describe('Handoff', () => {
     )
     builder.handOff()
     const expectedBotonicAction =
-      'create_case:' +
+      `${BotonicAction.CreateCase}:` +
       JSON.stringify({
         force_assign_if_not_available: true,
         auto_idle_message: 'the case is in IDLE status',
@@ -90,7 +90,7 @@ describe('Handoff', () => {
       const value = forceAssign ?? true
       builder.handOff()
       const expectedBotonicAction =
-        'create_case:' +
+        `${BotonicAction.CreateCase}:` +
         JSON.stringify({ force_assign_if_not_available: value })
       expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
     }
@@ -108,7 +108,8 @@ describe('Handoff', () => {
       const params = autoAssignOnWaiting
         ? { ...defaultParams, auto_assign_on_waiting: true }
         : defaultParams
-      const expectedBotonicAction = 'create_case:' + JSON.stringify(params)
+      const expectedBotonicAction =
+        `${BotonicAction.CreateCase}:` + JSON.stringify(params)
       expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
     }
   )
@@ -120,7 +121,7 @@ describe('Handoff', () => {
     })
     builder.handOff()
     const expectedBotonicAction =
-      'create_case:' +
+      `${BotonicAction.CreateCase}:` +
       JSON.stringify({
         force_assign_if_not_available: true,
         case_extra_data: { language: 'en', location: 'Spain' },
@@ -133,7 +134,7 @@ describe('Handoff', () => {
       is_test_integration: true,
     }).withOnFinishPayload('payload1')
     builder.handOff()
-    const expectedBotonicAction = 'create_test_integration_case:payload1'
+    const expectedBotonicAction = `${BotonicAction.CreateTestCase}:payload1`
     expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
   })
 })

--- a/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
@@ -1,5 +1,5 @@
 import { FlowBuilderApi } from '../api'
-import { BOT_ACTION_PAYLOAD_PREFIX, MAIN_FLOW_NAME } from '../constants'
+import { MAIN_FLOW_NAME } from '../constants'
 import { FlowContent } from '../content-fields'
 import BotonicPluginFlowBuilder from '../index'
 import { getNodeByUserInput } from '../user-input'
@@ -49,12 +49,6 @@ async function getContentsByUserInput({
 
   if (request.input.payload === conversationStartId) {
     return []
-  }
-
-  if (request.input.payload?.startsWith(BOT_ACTION_PAYLOAD_PREFIX)) {
-    request.input.payload = flowBuilderPlugin.replaceBotActionPayload(
-      request.input.payload
-    )
   }
 
   const contentsByKeywordsOrIntents = await getContentsByPayload({

--- a/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
@@ -1,6 +1,6 @@
 import { FlowBuilderApi } from '../api'
 import { MAIN_FLOW_NAME } from '../constants'
-import { FlowContent } from '../content-fields'
+import { FlowBotAction, FlowContent } from '../content-fields'
 import BotonicPluginFlowBuilder from '../index'
 import { getNodeByUserInput } from '../user-input'
 import { inputHasTextData } from '../utils'
@@ -16,6 +16,12 @@ export async function getContentsByFirstInteraction({
 }: FlowBuilderContext): Promise<FlowContent[]> {
   const firstInteractionContents =
     await flowBuilderPlugin.getStartContents(resolvedLocale)
+
+  // If the first interaction has a FlowBotAction, it should be the last content
+  // and avoid to render the match with keywords,intents or knowledge base
+  if (firstInteractionContents.at(-1) instanceof FlowBotAction) {
+    return firstInteractionContents
+  }
 
   if (inputHasTextData(request.input)) {
     const contentsByUserInput = await getContentsByUserInput({

--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -21,9 +21,10 @@ export class FlowBuilderAction extends React.Component<FlowBuilderActionProps> {
   static contextType = RequestContext
 
   static async botonicInit(
-    request: ActionRequest
+    request: ActionRequest,
+    contentID?: string
   ): Promise<FlowBuilderActionProps> {
-    const contents = await getContents(request)
+    const contents = await getContents(request, contentID)
     await trackFlowContent(request, contents)
 
     const handoffContent = contents.find(
@@ -62,7 +63,10 @@ export class FlowBuilderMultichannelAction extends FlowBuilderAction {
   }
 }
 
-async function getContents(request: ActionRequest): Promise<FlowContent[]> {
+async function getContents(
+  request: ActionRequest,
+  contentID?: string
+): Promise<FlowContent[]> {
   const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)
   const cmsApi = flowBuilderPlugin.cmsApi
   const locale = flowBuilderPlugin.getLocale(request.session)
@@ -72,13 +76,14 @@ async function getContents(request: ActionRequest): Promise<FlowContent[]> {
     flowBuilderPlugin,
     request,
     resolvedLocale,
+    contentID,
   }
 
   if (request.session.is_first_interaction) {
     return await getContentsByFirstInteraction(context)
   }
 
-  if (request.input.payload) {
+  if (request.input.payload || contentID) {
     return await getContentsByPayload(context)
   }
 
@@ -97,4 +102,5 @@ export interface FlowBuilderContext {
   flowBuilderPlugin: BotonicPluginFlowBuilder
   request: ActionRequest
   resolvedLocale: string
+  contentID?: string
 }

--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { FlowBuilderApi } from '../api'
 import { FlowContent, FlowHandoff } from '../content-fields'
+import { FlowBotAction } from '../content-fields/flow-bot-action'
 import { getFlowBuilderPlugin } from '../helpers'
 import BotonicPluginFlowBuilder from '../index'
 import { trackFlowContent } from '../tracking'
@@ -31,6 +32,14 @@ export class FlowBuilderAction extends React.Component<FlowBuilderActionProps> {
     if (handoffContent) {
       await handoffContent.doHandoff(request)
     }
+
+    const botActionContent = contents.find(
+      content => content instanceof FlowBotAction
+    ) as FlowBotAction
+    if (botActionContent) {
+      botActionContent.doBotAction(request)
+    }
+
     return { contents }
   }
 

--- a/packages/botonic-plugin-flow-builder/src/action/payload.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/payload.ts
@@ -7,10 +7,12 @@ export async function getContentsByPayload({
   flowBuilderPlugin,
   request,
   resolvedLocale,
+  contentID,
 }: FlowBuilderContext): Promise<FlowContent[]> {
-  const targetNode = request.input.payload
-    ? cmsApi.getNodeById<HtNodeWithContent>(request.input.payload)
-    : undefined
+  const id = contentID
+    ? cmsApi.getNodeByContentID(contentID)?.id
+    : request.input.payload
+  const targetNode = id ? cmsApi.getNodeById<HtNodeWithContent>(id) : undefined
 
   if (targetNode) {
     return await flowBuilderPlugin.getContentsByNode(targetNode, resolvedLocale)

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -1,11 +1,7 @@
 import { Input, PluginPreRequest } from '@botonic/core'
 import axios from 'axios'
 
-import {
-  BOT_ACTION_PAYLOAD_PREFIX,
-  KNOWLEDGE_BASE_FLOW_NAME,
-  SEPARATOR,
-} from './constants'
+import { KNOWLEDGE_BASE_FLOW_NAME, SEPARATOR } from './constants'
 import {
   HtBotActionNode,
   HtFallbackNode,
@@ -163,10 +159,6 @@ export class FlowBuilderApi {
   getPayload(target?: HtNodeLink): string | undefined {
     if (!target) {
       return undefined
-    }
-
-    if (target.type === HtNodeWithoutContentType.BOT_ACTION) {
-      return `${BOT_ACTION_PAYLOAD_PREFIX}${target.id}`
     }
 
     return target.id

--- a/packages/botonic-plugin-flow-builder/src/constants.ts
+++ b/packages/botonic-plugin-flow-builder/src/constants.ts
@@ -2,7 +2,6 @@ export const FLOW_BUILDER_API_URL_PROD =
   'https://api.ent0.flowbuilder.prod.hubtype.com'
 export const SEPARATOR = '|'
 export const SOURCE_INFO_SEPARATOR = `${SEPARATOR}source_`
-export const BOT_ACTION_PAYLOAD_PREFIX = `ba${SEPARATOR}`
 export const VARIABLE_PATTERN = /{([^}]+)}/g
 export const ACCESS_TOKEN_VARIABLE_KEY = '_access_token'
 export const REG_EXP_PATTERN = /^\/(.*)\/([gimyus]*)$/

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-bot-action.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-bot-action.tsx
@@ -7,8 +7,6 @@ import { HtBotActionNode } from './hubtype-fields'
 export class FlowBotAction extends ContentFieldsBase {
   public code: string
   public payload: string
-  public payloadId: string
-  public payloadParams?: string
 
   static fromHubtypeCMS(
     cmsBotAction: HtBotActionNode,
@@ -17,8 +15,6 @@ export class FlowBotAction extends ContentFieldsBase {
   ): FlowBotAction {
     const newBotAction = new FlowBotAction(cmsBotAction.id)
     newBotAction.code = cmsBotAction.code
-    newBotAction.payloadId = cmsBotAction.content.payload_id
-    newBotAction.payloadParams = cmsBotAction.content.payload_params
     newBotAction.payload = cmsApi.createPayloadWithParams(cmsBotAction)
 
     return newBotAction

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-bot-action.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-bot-action.tsx
@@ -22,7 +22,7 @@ export class FlowBotAction extends ContentFieldsBase {
   }
 
   doBotAction(request: ActionRequest): void {
-    request.session._botonic_action = `${BotonicAction.Redirect}${this.payload}`
+    request.session._botonic_action = `${BotonicAction.Redirect}:${this.payload}`
   }
 
   toBotonic(): JSX.Element {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-bot-action.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-bot-action.tsx
@@ -1,0 +1,34 @@
+import { ActionRequest } from '@botonic/react'
+
+import { FlowBuilderApi } from '../api'
+import { ContentFieldsBase } from './content-fields-base'
+import { HtBotActionNode } from './hubtype-fields'
+
+export class FlowBotAction extends ContentFieldsBase {
+  public code: string
+  public payload: string
+  public payloadId: string
+  public payloadParams?: string
+
+  static fromHubtypeCMS(
+    cmsBotAction: HtBotActionNode,
+    _locale: string,
+    cmsApi: FlowBuilderApi
+  ): FlowBotAction {
+    const newBotAction = new FlowBotAction(cmsBotAction.id)
+    newBotAction.code = cmsBotAction.code
+    newBotAction.payloadId = cmsBotAction.content.payload_id
+    newBotAction.payloadParams = cmsBotAction.content.payload_params
+    newBotAction.payload = cmsApi.createPayloadWithParams(cmsBotAction)
+
+    return newBotAction
+  }
+
+  doBotAction(request: ActionRequest): void {
+    request.session._botonic_action = `flow_builder_bot_action:${this.payload}`
+  }
+
+  toBotonic(): JSX.Element {
+    return <></>
+  }
+}

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-bot-action.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-bot-action.tsx
@@ -1,3 +1,4 @@
+import { BotonicAction } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
 import { FlowBuilderApi } from '../api'
@@ -21,7 +22,7 @@ export class FlowBotAction extends ContentFieldsBase {
   }
 
   doBotAction(request: ActionRequest): void {
-    request.session._botonic_action = `flow_builder_bot_action:${this.payload}`
+    request.session._botonic_action = `${BotonicAction.Redirect}${this.payload}`
   }
 
   toBotonic(): JSX.Element {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/bot-action.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/bot-action.ts
@@ -1,9 +1,9 @@
 import { HtBaseNode } from './common'
-import { HtNodeWithoutContentType } from './node-types'
+import { HtNodeWithContentType } from './node-types'
 
 export interface HtBotActionNode extends HtBaseNode {
   id: string
-  type: HtNodeWithoutContentType.BOT_ACTION
+  type: HtNodeWithContentType.BOT_ACTION
   content: {
     payload_id: string
     payload_params?: string

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/node-types.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/node-types.ts
@@ -12,13 +12,13 @@ export enum HtNodeWithContentType {
   WHATSAPP_BUTTON_LIST = 'whatsapp-button-list',
   WHATSAPP_CTA_URL_BUTTON = 'whatsapp-cta-url-button',
   KNOWLEDGE_BASE = 'knowledge-base',
+  BOT_ACTION = 'bot-action',
 }
 
 export enum HtNodeWithoutContentType {
   URL = 'url',
   PAYLOAD = 'payload',
   GO_TO_FLOW = 'go-to-flow',
-  BOT_ACTION = 'bot-action',
 }
 
 export enum HtButtonStyle {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
@@ -30,11 +30,8 @@ export type HtNodeWithContent =
   | HtWhatsappCTAUrlButtonNode
   | HtSmartIntentNode
   | HtKnowledgeBaseNode
-
-export type HtNodeWithoutContent =
-  | HtUrlNode
-  | HtPayloadNode
-  | HtGoToFlow
   | HtBotActionNode
+
+export type HtNodeWithoutContent = HtUrlNode | HtPayloadNode | HtGoToFlow
 
 export type HtNodeComponent = HtNodeWithContent | HtNodeWithoutContent

--- a/packages/botonic-plugin-flow-builder/src/content-fields/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/index.ts
@@ -1,3 +1,4 @@
+import { FlowBotAction } from './flow-bot-action'
 import { FlowCarousel } from './flow-carousel'
 import { FlowHandoff } from './flow-handoff'
 import { FlowImage } from './flow-image'
@@ -11,6 +12,7 @@ export { ContentFieldsBase } from './content-fields-base'
 export { FlowButton } from './flow-button'
 export { FlowElement } from './flow-element'
 export {
+  FlowBotAction,
   FlowCarousel,
   FlowImage,
   FlowKnowledgeBase,
@@ -30,3 +32,4 @@ export type FlowContent =
   | FlowWhatsappCtaUrlButtonNode
   | FlowHandoff
   | FlowKnowledgeBase
+  | FlowBotAction

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -279,7 +279,6 @@ export default class BotonicPluginFlowBuilder implements Plugin {
 }
 
 export * from './action'
-export { BOT_ACTION_PAYLOAD_PREFIX } from './constants'
 export * from './content-fields'
 export { trackFlowContent } from './tracking'
 export {

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -164,8 +164,14 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     if (content) {
       contents.push(content)
     }
+
+    // If node is BOT_ACTION not add more contents to render, next nodes render after execute action
+    if (node.type === HtNodeWithContentType.BOT_ACTION) {
+      return contents
+    }
+
     // TODO: prevent infinite recursive calls
-    if (node.follow_up && !(content instanceof FlowBotAction)) {
+    if (node.follow_up) {
       return this.getContentsById(node.follow_up.id, resolvedLocale, contents)
     }
 

--- a/packages/botonic-plugin-flow-builder/tests/bot-action.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/bot-action.test.ts
@@ -1,15 +1,12 @@
-import { INPUT } from '@botonic/core'
+import { BotonicAction, INPUT } from '@botonic/core'
 import { describe, test } from '@jest/globals'
 
-import { BOT_ACTION_PAYLOAD_PREFIX } from '../src/constants'
 import { FlowText } from '../src/index'
 import { ProcessEnvNodeEnvs } from '../src/types'
 import { basicFlow } from './helpers/flows/basic'
 import {
   createFlowBuilderPlugin,
   createFlowBuilderPluginAndGetContents,
-  createRequest,
-  getContentsAfterPreAndBotonicInit,
 } from './helpers/utils'
 
 describe('The user clicks on a button that is connected to a BotActionNode', () => {
@@ -17,7 +14,11 @@ describe('The user clicks on a button that is connected to a BotActionNode', () 
   const flowBuilderPlugin = createFlowBuilderPlugin({ flow: basicFlow })
   const ratingMessageUuid = '578b30eb-d230-4162-8a36-6c7fa18ff0db'
   const botActionUuid = '85dbeb56-81c9-419d-a235-4ebf491b4fc9'
-  test('The button has  a payload equal to ba|botActionUuid', async () => {
+  const ratingPayload = 'rating'
+  const payloadParms = '{"value":1,"followUpContentID":"SORRY"}'
+  const ratingPayloadWithParams = `${ratingPayload}|${payloadParms}`
+
+  test('The button has a payload equal to botActionUuid', async () => {
     const { contents } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: { flow: basicFlow },
       requestArgs: {
@@ -29,42 +30,29 @@ describe('The user clicks on a button that is connected to a BotActionNode', () 
     })
 
     const nextPaylod = (contents[0] as FlowText).buttons[0].payload
-    expect(nextPaylod).toBe(`${BOT_ACTION_PAYLOAD_PREFIX}${botActionUuid}`)
+    expect(nextPaylod).toBe(botActionUuid)
   })
 
-  test('The bot routes receive the correct payload', async () => {
-    const request = createRequest({
-      input: {
-        type: INPUT.POSTBACK,
-        payload: `${BOT_ACTION_PAYLOAD_PREFIX}${botActionUuid}`,
-      },
-      plugins: {
-        // @ts-ignore
-        flowBuilderPlugin,
+  test('The request.session._botonic_action have redirect:nextPayload', async () => {
+    const { contents, request } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: { flow: basicFlow },
+      requestArgs: {
+        input: {
+          type: INPUT.POSTBACK,
+          payload: botActionUuid,
+        },
       },
     })
 
-    await flowBuilderPlugin.pre(request)
-    expect(request.input.payload).toBe(
-      'rating|{"value":1,"followUpContentID":"SORRY"}'
+    expect(contents.length).toBe(1)
+    expect(request.session._botonic_action).toBe(
+      `${BotonicAction.Redirect}:${ratingPayloadWithParams}`
     )
   })
 
   test('In the custom action the payloadParmas defined in the BotActionNode are obtained', async () => {
-    const request = createRequest({
-      input: {
-        type: INPUT.POSTBACK,
-        payload: `${BOT_ACTION_PAYLOAD_PREFIX}${botActionUuid}`,
-      },
-      plugins: {
-        // @ts-ignore
-        flowBuilderPlugin,
-      },
-    })
-
-    await flowBuilderPlugin.pre(request)
     const payloadParams = flowBuilderPlugin.getPayloadParams(
-      request.input.payload as string
+      ratingPayloadWithParams
     )
     expect(payloadParams).toEqual(
       JSON.parse('{"value":1,"followUpContentID":"SORRY"}')

--- a/packages/botonic-react/src/webchat/utils.ts
+++ b/packages/botonic-react/src/webchat/utils.ts
@@ -1,0 +1,7 @@
+import { BotonicAction, BotonicActionType } from '@botonic/core'
+
+export const getParsedAction = (botonicAction: BotonicActionType) => {
+  const splittedAction = botonicAction.split(`${BotonicAction.CreateCase}:`)
+  if (splittedAction.length <= 1) return undefined
+  return JSON.parse(splittedAction[1])
+}

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -55,14 +55,9 @@ import { WebchatMessageList } from './message-list'
 import { WebchatReplies } from './replies'
 import { TriggerButton } from './trigger-button'
 import { useStorageState } from './use-storage-state-hook'
+import { getParsedAction } from './utils'
 import { WebchatInputPanel } from './webchat-input-panel'
 import { WebviewContainer } from './webview'
-
-export const getParsedAction = botonicAction => {
-  const splittedAction = botonicAction.split(BotonicAction.CreateCase)
-  if (splittedAction.length <= 1) return undefined
-  return JSON.parse(splittedAction[1])
-}
 
 const StyledWebchat = styled.div`
   position: fixed;

--- a/packages/botonic-react/src/webchat/webchat.jsx
+++ b/packages/botonic-react/src/webchat/webchat.jsx
@@ -1,4 +1,9 @@
-import { INPUT, isMobile, params2queryString } from '@botonic/core'
+import {
+  BotonicAction,
+  INPUT,
+  isMobile,
+  params2queryString,
+} from '@botonic/core'
 import merge from 'lodash.merge'
 import React, {
   forwardRef,
@@ -54,7 +59,7 @@ import { WebchatInputPanel } from './webchat-input-panel'
 import { WebviewContainer } from './webview'
 
 export const getParsedAction = botonicAction => {
-  const splittedAction = botonicAction.split('create_case:')
+  const splittedAction = botonicAction.split(BotonicAction.CreateCase)
   if (splittedAction.length <= 1) return undefined
   return JSON.parse(splittedAction[1])
 }
@@ -502,7 +507,7 @@ export const Webchat = forwardRef((props, ref) => {
       if (session) {
         updateSession(merge(session, { user: webchatState.session.user }))
         const action = session._botonic_action || ''
-        const handoff = action.startsWith('create_case')
+        const handoff = action.startsWith(BotonicAction.CreateCase)
         if (handoff && isDev) addMessageComponent(<Handoff />)
         updateHandoff(handoff)
       }


### PR DESCRIPTION
## Description

Be able to use bot-action nodes at any point in the flow builder. For example as follow ups, after a conditional, at the start of a flow etc

The request.input should be immutable. To avoid modifying the request.input in the lambda execution, FlowBuilderAction.botonicInit function accepts as a second parameter the contentID to indicate which content has to be rendered. This contentID is the unique text that is defined in the flow builder frontend. This way you don't need to get the UUID of the content and modify the request.input.payload to indicate to the plugin which content to render.

## Context

Bot-action nodes could only be used connected to a button or after a handoff.
With this solution it will be possible to make flow in a simpler way. There are several use cases in which the flow is greatly simplified by being able to put bot actions after a conditional or at the beginning of a flow.

Flow example:
![Captura de pantalla 2024-09-03 a las 17 11 40](https://github.com/user-attachments/assets/1a85e764-5843-4972-b36c-cd7eced225ab)


## Approach taken / Explain the design

The third commit makes the core bot run again (prePlugins, routes, render, postPlugins). I think this should be the backend in charge of re-executing the lambda of the bot to avoid timeouts if the actions are asynchronous and more than one is chained. This way we would also avoid modifying the request.input.payload in a lambda execution.

IMPORTANT
With this change in the custom actions written in the flow it is necessary to obtain the following contents using the function FlowBuilderAction.botonicInit(request) since this is the one in charge of putting the variable in the session so that if there is another bot action connected to the flow, the bot will continue executing. 

## To document / Usage example

WelcomeAction example
```ts
export class WelcomeAction extends FlowBuilderMultichannelAction {
  static contextType = RequestContext
  static async botonicInit(
    request: BotRequest
  ): Promise<FlowBuilderActionProps> {
    const { cmsPlugin, botContext } = getRequestData(request)
    const contents = await cmsPlugin.getStartContents(botContext.locale)

     return FlowBuilderMultichannelAction.botonicInit(request, contents[0].code)
  }
}
```

## Testing

For now I have not checked the tests, I am aware that they are failing.
