### PR TITLE
botonic-react: remove getConfig function #BLT-1036

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to Botonic will be documented in this file.
 
   - [use new endpoint v2 to deploy bots](https://github.com/hubtype/botonic/pull/2884)
 
+- [@botonic/react](https://www.npmjs.com/package/@botonic/react)
+
+  - [remove getConfig function](https://github.com/hubtype/botonic/pull/2902)
+
 ### Fixed
 
 </details>

--- a/packages/botonic-react/src/node-app.jsx
+++ b/packages/botonic-react/src/node-app.jsx
@@ -19,10 +19,4 @@ export class NodeApp {
   input(args) {
     return this.bot.input(args)
   }
-
-  getConfig() {
-    return Object.entries(this.bot.plugins).map(([_, plugin]) => {
-      return { id: plugin.id, name: plugin.name, config: plugin.config }
-    })
-  }
 }


### PR DESCRIPTION
## Description

Remove the getConfig function that is run to get the response from the botonic-config lambda.

## Context

In the new version of cli we will create the bot configuration at the moment of deploying, it will be saved in the database and will be updated in each deploy. We will not only have the plugins configuration.

