### PR TITLE
plugin-flow-builder: when user clicks on old button send fallback #BLT-1070 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Botonic will be documented in this file.
 - [@botonic/plugin-flow-builder](https://www.npmjs.com/package/@botonic/plugin-flow-builder)
 
   - [can resolve `bot-action` nodes at any point of the flow](https://github.com/hubtype/botonic/pull/2898)
+  - [when user clicks on old button send fallback](https://github.com/hubtype/botonic/pull/2909)
 
 ### Fixed
 

--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -84,7 +84,12 @@ async function getContents(
   }
 
   if (request.input.payload || contentID) {
-    return await getContentsByPayload(context)
+    const contentsByPayload = await getContentsByPayload(context)
+    if (contentsByPayload.length > 0) {
+      return contentsByPayload
+    }
+
+    return await getContentsByFallback(context)
   }
 
   if (inputHasTextData(request.input)) {

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -51,8 +51,8 @@ export class FlowBuilderApi {
 
   getNodeById<T extends HtNodeComponent>(id: string): T {
     const node = this.flow.nodes.find(node => node.id === id)
-    if (!node) throw Error(`Node with id: '${id}' not found`)
-    if (node.type === HtNodeWithoutContentType.GO_TO_FLOW) {
+    if (!node) console.error(`Node with id: '${id}' not found`)
+    if (node?.type === HtNodeWithoutContentType.GO_TO_FLOW) {
       return this.getNodeByFlowId(node.content.flow_id) as T
     }
     return node as T

--- a/packages/botonic-plugin-flow-builder/tests/payload.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/payload.test.ts
@@ -1,0 +1,44 @@
+import { INPUT } from '@botonic/core'
+import { describe, test } from '@jest/globals'
+
+import { FlowText } from '../src/index'
+import { ProcessEnvNodeEnvs } from '../src/types'
+// eslint-disable-next-line jest/no-mocks-import
+import { mockSmartIntent } from './__mocks__/smart-intent'
+import { basicFlow } from './helpers/flows/basic'
+import { createFlowBuilderPluginAndGetContents } from './helpers/utils'
+
+describe('Check the contents returned by the plugin when user clicks a button', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+
+  beforeEach(() => mockSmartIntent('Other'))
+  test('When button exist in flow the following contents are displayed', async () => {
+    const { contents } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: { flow: basicFlow },
+      requestArgs: {
+        input: {
+          payload: 'eb877738-3cf4-4a57-9f46-3122e18f1cc7',
+          type: INPUT.POSTBACK,
+        },
+      },
+    })
+
+    expect((contents[0] as FlowText).text).toBe('Message after button text 1')
+    expect(contents.length).toBe(2)
+  })
+
+  test('When button no exist in flow the fallback contents are displayed', async () => {
+    const { contents } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: { flow: basicFlow },
+      requestArgs: {
+        input: {
+          payload: 'fake-id-that-does-not-exist',
+          type: INPUT.POSTBACK,
+        },
+      },
+    })
+
+    expect((contents[0] as FlowText).text).toBe('fallback 1st message')
+    expect(contents.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Description

When user clicks on old button that is no longer in the published flow, the bot will respond with fallback content.

## Context

Until now when the user clicked on an old button and the published flow no longer has this button the bot did not respond

## Approach taken / Explain the design

If a content id is not found, the bot will respond with a fallback.

## Testing

Add two tests to check contents displayed after click a button with payload
