### PR TITLE
plugin-flow-builder: store in session every new flow_thread_id

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/tracking.ts
+++ b/packages/botonic-plugin-flow-builder/src/tracking.ts
@@ -61,6 +61,8 @@ function getContentEventArgs(
   }
 ) {
   const flowThreadId = request.session.flow_thread_id ?? uuid()
+  request.session.flow_thread_id = flowThreadId
+
   return {
     flowThreadId,
     flowId: contentInfo.flowId,


### PR DESCRIPTION
## Description

Save the flow_thread_id in the session each time a new flowThreadId is generated

## Context

When a bot does not go through the conversation start of the flow, the plugin was not saving the flow_thread_id in the session.
