### PR TITLE
improve flowbuilder webview contents #BLT-1131 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to Botonic will be documented in this file.
 - [@botonic/plugin-flow-builder](https://www.npmjs.com/package/@botonic/plugin-flow-builder)
 
   - [Use `message feedback` in knowledge base messages](https://github.com/hubtype/botonic/pull/2859)
+  - [improve `flowbuilder webview contents`](https://github.com/hubtype/botonic/pull/2913)
 
 - [@botonic/plugin-hubtype-analytics](https://www.npmjs.com/package/@botonic/plugin-hubtype-analytics)
 

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -81,7 +81,8 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   async pre(request: PluginPreRequest): Promise<void> {
     this.currentRequest = request
     this.cmsApi = await FlowBuilderApi.create({
-      url: this.resolveFlowUrl(request),
+      flowUrl: this.resolveFlowUrl(request),
+      url: this.apiUrl,
       flow: this.flow,
       accessToken: this.getAccessToken(request.session),
       request: this.currentRequest,

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -29,6 +29,7 @@ export type KnowledgeBaseFunction = (
 
 export interface FlowBuilderApiOptions {
   url: string
+  flowUrl: string
   flow?: HtFlowBuilderData
   accessToken: string
   request: PluginPreRequest

--- a/packages/botonic-plugin-flow-builder/src/webview/use-webview-contents.ts
+++ b/packages/botonic-plugin-flow-builder/src/webview/use-webview-contents.ts
@@ -37,23 +37,22 @@ export function useWebviewContents<T extends MapContentsType>({
       return
     }
 
-    if (
-      textContents[0].content.text.some(text => text.locale === currentLocale)
-    ) {
+    const locales = textContents[0].content.text.map(text => text.locale)
+    const language = currentLocale.split('-')[0]
+
+    if (locales.includes(currentLocale)) {
       setCurrentLocale(currentLocale)
       return
     }
 
-    const language = currentLocale.split('-')[0]
-    if (textContents[0].content.text.some(text => text.locale === language)) {
+    if (locales.includes(language)) {
       setCurrentLocale(language)
       return
     }
 
     console.error(
-      `locale: ${currentLocale} cannot be resolved with: ${textContents?.[0].content.text.map(text => text.locale).join(', ')}`
+      `locale: ${currentLocale} cannot be resolved with: ${locales.join(', ')}`
     )
-    return
   }
 
   const getTextContent = (contentID: string): string => {

--- a/packages/botonic-plugin-flow-builder/src/webview/use-webview-contents.ts
+++ b/packages/botonic-plugin-flow-builder/src/webview/use-webview-contents.ts
@@ -32,9 +32,12 @@ export function useWebviewContents<T extends MapContentsType>({
   const [error, setError] = useState(false)
 
   const updateCurrentLocale = (textContents?: WebviewTextContent[]) => {
+    if (!textContents || textContents.length === 0) {
+      console.log('There is no text contents to check the locale')
+      return
+    }
+
     if (
-      textContents &&
-      textContents?.length > 0 &&
       textContents[0].content.text.some(text => text.locale === currentLocale)
     ) {
       setCurrentLocale(currentLocale)
@@ -42,7 +45,7 @@ export function useWebviewContents<T extends MapContentsType>({
     }
 
     const language = currentLocale.split('-')[0]
-    if (textContents?.[0].content.text.some(text => text.locale === language)) {
+    if (textContents[0].content.text.some(text => text.locale === language)) {
       setCurrentLocale(language)
       return
     }

--- a/packages/botonic-plugin-flow-builder/src/webview/use-webview-contents.ts
+++ b/packages/botonic-plugin-flow-builder/src/webview/use-webview-contents.ts
@@ -31,6 +31,28 @@ export function useWebviewContents<T extends MapContentsType>({
   const [isLoading, setLoading] = useState(true)
   const [error, setError] = useState(false)
 
+  const updateCurrentLocale = (textContents?: WebviewTextContent[]) => {
+    if (
+      textContents &&
+      textContents?.length > 0 &&
+      textContents[0].content.text.some(text => text.locale === currentLocale)
+    ) {
+      setCurrentLocale(currentLocale)
+      return
+    }
+
+    const language = currentLocale.split('-')[0]
+    if (textContents?.[0].content.text.some(text => text.locale === language)) {
+      setCurrentLocale(language)
+      return
+    }
+
+    console.error(
+      `locale: ${currentLocale} cannot be resolved with: ${textContents?.[0].content.text.map(text => text.locale).join(', ')}`
+    )
+    return
+  }
+
   const getTextContent = (contentID: string): string => {
     return (
       textContents
@@ -76,6 +98,8 @@ export function useWebviewContents<T extends MapContentsType>({
           webviewContent => webviewContent.type === WebviewContentType.IMAGE
         ) as WebviewImageContent[]
         setImageContents(imageResponseContents)
+
+        updateCurrentLocale(textResponseContents)
       } catch (error) {
         console.error('Error fetching webview contents:', error)
         setError(true)


### PR DESCRIPTION
## Description

- Resolve locale as a language when get webview contents. For example if locale is en-GB and your contents are only in en
- set organzation_id and bot_id in session when bot is in local development.

## Context

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
