### PR TITLE
botonic-react: messenger markdown not applied #BLT-1152 

### DIFF
--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -287,12 +287,15 @@ export const MultichannelText = props => {
     return (
       <>
         {texts &&
-          texts.map((e, i) => (
+          texts.map((message, i) => (
             <Text key={i} {...propsWithoutChildren}>
-              {e}
+              {whatsappMarkdown(text)}
             </Text>
           ))}
-        <Text {...propsLastText}>{propsLastText.children}</Text>
+        <Text {...propsLastText}>
+          {/* TODO: Review how render buttons and replies in Facebook with markdown */}
+          {whatsappMarkdown(propsLastText.children)}
+        </Text>
       </>
     )
   }

--- a/packages/botonic-react/src/components/multichannel/whatsapp/markdown.ts
+++ b/packages/botonic-react/src/components/multichannel/whatsapp/markdown.ts
@@ -15,6 +15,11 @@ const MARKDOWN_BOLD_AND_ITALIC_OPTION2 = /(\*__)(.*?)(__\*)/g
 const MARKDOWN_BOLD_AND_ITALIC_OPTION3 = /(__\*)(.*?)(\*__)/g
 
 export function whatsappMarkdown(text: string) {
+  const textWithItalicAndBold = replaceItalicAndBold(text)
+  return replaceMarkdownLinks(textWithItalicAndBold)
+}
+
+export function replaceItalicAndBold(text: string) {
   const textNormalized = normalizeMarkdown(text)
   const matches = textNormalized.match(MARKDOWN_BOLD_OR_ITALIC_REGEX)
   if (matches) {
@@ -26,6 +31,7 @@ export function whatsappMarkdown(text: string) {
           MARKDOWN_WHATSAPP_BOLD
         )
       }
+
       if (match.startsWith(MARKDOWN_BOLD_OPTION_2)) {
         return replaceAllOccurrences(
           match,
@@ -33,6 +39,7 @@ export function whatsappMarkdown(text: string) {
           MARKDOWN_WHATSAPP_BOLD
         )
       }
+
       if (match.startsWith(MARKDOWN_ITALIC_OPTION_1)) {
         return replaceAllOccurrences(
           match,
@@ -40,8 +47,10 @@ export function whatsappMarkdown(text: string) {
           MARKDOWN_WHATSAPP_ITALIC
         )
       }
+
       return match
     })
+
     let textWhatsapp = textNormalized
     for (let i = 0; i < matches.length; i++) {
       textWhatsapp = replaceAllOccurrences(
@@ -50,8 +59,10 @@ export function whatsappMarkdown(text: string) {
         matchesResult[i]
       )
     }
+
     return textWhatsapp
   }
+
   return text
 }
 
@@ -85,4 +96,10 @@ function replaceAllOccurrences(
   replaceValue: string
 ) {
   return text.split(searchValue).join(replaceValue)
+}
+
+const REGEX_MARKDOWN_LINK = /\[([^\]]+)\]\(([^)]+)\)/g
+
+function replaceMarkdownLinks(markdown: string) {
+  return markdown.replace(REGEX_MARKDOWN_LINK, '$1: $2')
 }


### PR DESCRIPTION
## Description

Apply the same whatsapp markdown for Facebook.
Replace markdown for links `[text](url)` for ` text: url` for both whatsapp and facebook

## Context

Facebook markdown https://www.facebook.com/help/147348452522644
Whatsapp markdown https://faq.whatsapp.com/539178204879377/?cms_platform=web

