### PR TITLE
botonic-react: fix mixed markdowns used in the same text #BLT-1177 

### DIFF
--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -284,17 +284,18 @@ export const MultichannelText = props => {
     const multichannelFacebook = new MultichannelFacebook()
     const { texts, propsLastText, propsWithoutChildren } =
       multichannelFacebook.convertText(props, text[0])
+
+    const [lastText, ...buttonsAndReplies] = propsLastText.children
     return (
       <>
-        {texts &&
-          texts.map((message, i) => (
-            <Text key={i} {...propsWithoutChildren}>
-              {convertToMarkdownMeta(message)}
-            </Text>
-          ))}
+        {texts?.map((message, i) => (
+          <Text key={i} {...propsWithoutChildren}>
+            {convertToMarkdownMeta(message)}
+          </Text>
+        ))}
         <Text {...propsLastText}>
-          {/* TODO: Review how render buttons and replies in Facebook with markdown */}
-          {propsLastText.children}
+          {convertToMarkdownMeta(lastText)}
+          {buttonsAndReplies}
         </Text>
       </>
     )

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -21,7 +21,7 @@ import {
   WHATSAPP_LIST_MAX_BUTTONS,
   WHATSAPP_MAX_BUTTONS,
 } from './multichannel-utils'
-import { whatsappMarkdown } from './whatsapp/markdown'
+import { convertToMarkdownMeta } from './whatsapp/markdown'
 
 export const MultichannelText = props => {
   const requestContext = useContext(RequestContext)
@@ -116,7 +116,7 @@ export const MultichannelText = props => {
     const { postbackButtons, urlButtons, webviewButtons } = getWhatsappButtons()
 
     const textElements = texts.map(text => {
-      const textWithMarkdown = whatsappMarkdown(text)
+      const textWithMarkdown = convertToMarkdownMeta(text)
       return (props.newline || '') + textWithMarkdown
     })
 
@@ -289,12 +289,12 @@ export const MultichannelText = props => {
         {texts &&
           texts.map((message, i) => (
             <Text key={i} {...propsWithoutChildren}>
-              {whatsappMarkdown(text)}
+              {convertToMarkdownMeta(message)}
             </Text>
           ))}
         <Text {...propsLastText}>
           {/* TODO: Review how render buttons and replies in Facebook with markdown */}
-          {whatsappMarkdown(propsLastText.children)}
+          {propsLastText.children}
         </Text>
       </>
     )

--- a/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
+++ b/packages/botonic-react/src/components/multichannel/multichannel-text.jsx
@@ -21,7 +21,7 @@ import {
   WHATSAPP_LIST_MAX_BUTTONS,
   WHATSAPP_MAX_BUTTONS,
 } from './multichannel-utils'
-import { convertToMarkdownMeta } from './whatsapp/markdown'
+import { convertToMarkdownMeta } from './whatsapp/markdown-meta'
 
 export const MultichannelText = props => {
   const requestContext = useContext(RequestContext)

--- a/packages/botonic-react/src/components/multichannel/whatsapp/markdown-meta.ts
+++ b/packages/botonic-react/src/components/multichannel/whatsapp/markdown-meta.ts
@@ -18,19 +18,19 @@ const WHATSAPP_ITALIC = '_'
 
 // Convert markdown to WhatsApp and Facebook format
 export function convertToMarkdownMeta(text: string): string {
-  const textWithItalicAndBold = replaceItalicAndBold(text)
+  const textWithBoldAndItalic = replaceBoldAndItalic(text)
 
-  return replaceMarkdownLinks(textWithItalicAndBold)
+  return replaceMarkdownLinks(textWithBoldAndItalic)
 }
 
-function replaceItalicAndBold(text: string) {
-  const normalizedText = normalizeMarkdown(text)
-  const boldAndItalicText = convertNormalizedToWhatsApp(normalizedText)
+function replaceBoldAndItalic(text: string) {
+  const normalizedText = normalizeBoldAndItalic(text)
+  const boldAndItalicText = normalizedToMarkdownMeta(normalizedText)
 
   return boldAndItalicText
 }
 
-function normalizeMarkdown(text: string): string {
+function normalizeBoldAndItalic(text: string): string {
   // Normalize bold
   text = text.replace(
     REGEX_MARKDOWN_BOLD,
@@ -45,7 +45,7 @@ function normalizeMarkdown(text: string): string {
   return text
 }
 
-function convertNormalizedToWhatsApp(text: string): string {
+function normalizedToMarkdownMeta(text: string): string {
   // convert &%BOLD%&text&%BOLD%& to *text*
   text = text.replace(
     REGEX_NORMALIZED_BOLD,

--- a/packages/botonic-react/src/components/whatsapp-button-list.tsx
+++ b/packages/botonic-react/src/components/whatsapp-button-list.tsx
@@ -5,7 +5,7 @@ import { truncateText } from '../util'
 import { renderComponent } from '../util/react'
 import { Message } from './message'
 import { WHATSAPP_MAX_BUTTON_CHARS } from './multichannel/multichannel-utils'
-import { convertToMarkdownMeta } from './multichannel/whatsapp/markdown'
+import { convertToMarkdownMeta } from './multichannel/whatsapp/markdown-meta'
 
 // TODO: Add validation in component
 

--- a/packages/botonic-react/src/components/whatsapp-button-list.tsx
+++ b/packages/botonic-react/src/components/whatsapp-button-list.tsx
@@ -5,7 +5,7 @@ import { truncateText } from '../util'
 import { renderComponent } from '../util/react'
 import { Message } from './message'
 import { WHATSAPP_MAX_BUTTON_CHARS } from './multichannel/multichannel-utils'
-import { whatsappMarkdown } from './multichannel/whatsapp/markdown'
+import { convertToMarkdownMeta } from './multichannel/whatsapp/markdown'
 
 // TODO: Add validation in component
 
@@ -85,7 +85,7 @@ export const WhatsappButtonList = (props: WhatsappButtonListProps) => {
       // @ts-ignore Property 'message' does not exist on type 'JSX.IntrinsicElements'.
       <message
         {...props}
-        body={whatsappMarkdown(props.body)}
+        body={convertToMarkdownMeta(props.body)}
         button={truncateText(props.button, WHATSAPP_MAX_BUTTON_CHARS)}
         sections={JSON.stringify(trucateSectionsContents(props.sections))}
         type={INPUT.WHATSAPP_BUTTON_LIST}

--- a/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
+++ b/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
@@ -11,7 +11,7 @@ import {
   WHATSAPP_MAX_FOOTER_CHARS,
   WHATSAPP_MAX_HEADER_CHARS,
 } from './multichannel/multichannel-utils'
-import { whatsappMarkdown } from './multichannel/whatsapp/markdown'
+import { convertToMarkdownMeta } from './multichannel/whatsapp/markdown'
 
 export interface WhatsappCTAUrlButtonCommonProps {
   header?: string
@@ -61,7 +61,10 @@ export const WhatsappCTAUrlButton = (props: WhatsappCTAUrlButtonProps) => {
       header: props.header
         ? truncateText(props.header, WHATSAPP_MAX_HEADER_CHARS)
         : undefined,
-      body: truncateText(whatsappMarkdown(props.body), WHATSAPP_MAX_BODY_CHARS),
+      body: truncateText(
+        convertToMarkdownMeta(props.body),
+        WHATSAPP_MAX_BODY_CHARS
+      ),
       footer: props.footer
         ? truncateText(props.footer, WHATSAPP_MAX_FOOTER_CHARS)
         : undefined,

--- a/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
+++ b/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
@@ -11,7 +11,7 @@ import {
   WHATSAPP_MAX_FOOTER_CHARS,
   WHATSAPP_MAX_HEADER_CHARS,
 } from './multichannel/multichannel-utils'
-import { convertToMarkdownMeta } from './multichannel/whatsapp/markdown'
+import { convertToMarkdownMeta } from './multichannel/whatsapp/markdown-meta'
 
 export interface WhatsappCTAUrlButtonCommonProps {
   header?: string

--- a/packages/botonic-react/tests/components/multichannel/markdown.test.js
+++ b/packages/botonic-react/tests/components/multichannel/markdown.test.js
@@ -1,0 +1,34 @@
+import { convertToMarkdownMeta } from '../../../src/components/multichannel/whatsapp/markdown'
+
+describe('Markdown to WhatsApp conversion', () => {
+  test('convert bold markdown to WhatsApp format', () => {
+    const input = 'This is **bold** text'
+    const expectedOutput = 'This is *bold* text'
+    expect(convertToMarkdownMeta(input)).toBe(expectedOutput)
+  })
+
+  test('convert italic markdown to WhatsApp format', () => {
+    const input = 'This is *italic* text'
+    const expectedOutput = 'This is _italic_ text'
+    expect(convertToMarkdownMeta(input)).toBe(expectedOutput)
+  })
+
+  test('convert bold and italic markdown to WhatsApp format', () => {
+    const input = 'This is **bold** and *italic* text'
+    const expectedOutput = 'This is *bold* and _italic_ text'
+    expect(convertToMarkdownMeta(input)).toBe(expectedOutput)
+  })
+
+  test('convert markdown links to WhatsApp format', () => {
+    const input = 'This is a [link](http://example.com)'
+    const expectedOutput = 'This is a link: http://example.com'
+    expect(convertToMarkdownMeta(input)).toBe(expectedOutput)
+  })
+
+  test('convert complex markdown to WhatsApp format', () => {
+    const input = '_This is __bold__, italic_, and a [link](http://example.com)'
+    const expectedOutput =
+      '_This is *bold*, italic_, and a link: http://example.com'
+    expect(convertToMarkdownMeta(input)).toBe(expectedOutput)
+  })
+})

--- a/packages/botonic-react/tests/components/multichannel/markdown.test.js
+++ b/packages/botonic-react/tests/components/multichannel/markdown.test.js
@@ -1,4 +1,4 @@
-import { convertToMarkdownMeta } from '../../../src/components/multichannel/whatsapp/markdown'
+import { convertToMarkdownMeta } from '../../../src/components/multichannel/whatsapp/markdown-meta'
 
 describe('Markdown to WhatsApp conversion', () => {
   test('convert bold markdown to WhatsApp format', () => {


### PR DESCRIPTION
## Description

Refactor to simplify the code used to apply markdown in Whatsapp and Facebook 

## Context


A sentence with bold and italic at the same time is not rendered correctly. For example in the following sentence the bold was not applied on the word `agentes`
`_Recuerda que si es por una incidencia en la entrega o recepción, puedes contactar con nuestros __agentes__ para que te ayuden lo antes posible_`


## Approach taken / Explain the design

Instead of normalizing directly with the result * or _ now use the words &%BOLD%& and &%ITALIC%&
I have added the &% symbols at the beginning and end to make it less probable that this is written in the bot message.

## Testing

Adds tests for several markdown use cases
