### PR TITLE
plugin-flow-builder: not show log when check if payload is from bot action node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25511,7 +25511,7 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.30.5-alpha.0",
+      "version": "0.30.5",
       "license": "MIT",
       "dependencies": {
         "@botonic/core": "^0.30.0",

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -1,7 +1,7 @@
 import { Input, PluginPreRequest } from '@botonic/core'
 import axios from 'axios'
 
-import { KNOWLEDGE_BASE_FLOW_NAME, SEPARATOR } from './constants'
+import { KNOWLEDGE_BASE_FLOW_NAME, SEPARATOR, UUID_REGEXP } from './constants'
 import {
   HtBotActionNode,
   HtFallbackNode,
@@ -177,6 +177,18 @@ export class FlowBuilderApi {
     }
 
     return target.id
+  }
+
+  isBotAction(id: string): boolean {
+    if (!this.isUUID(id)) {
+      return false
+    }
+    const node = this.getNodeById(id)
+    return node?.type === HtNodeWithContentType.BOT_ACTION
+  }
+
+  private isUUID(str: string): boolean {
+    return UUID_REGEXP.test(str)
   }
 
   createPayloadWithParams(botActionNode: HtBotActionNode): string {

--- a/packages/botonic-plugin-flow-builder/src/constants.ts
+++ b/packages/botonic-plugin-flow-builder/src/constants.ts
@@ -5,6 +5,8 @@ export const SOURCE_INFO_SEPARATOR = `${SEPARATOR}source_`
 export const VARIABLE_PATTERN = /{([^}]+)}/g
 export const ACCESS_TOKEN_VARIABLE_KEY = '_access_token'
 export const REG_EXP_PATTERN = /^\/(.*)\/([gimyus]*)$/
+export const UUID_REGEXP =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export const MAIN_FLOW_NAME = 'Main'
 export const KNOWLEDGE_BASE_FLOW_NAME = 'Knowledge base'

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -112,24 +112,20 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   private updateRequestBeforeRoutes(request: PluginPreRequest): void {
     if (request.input.payload) {
       request.input.payload = this.removeSourceSufix(request.input.payload)
-    }
 
-    if (request.input.payload && this.isBotAction(request.input.payload)) {
-      const cmsBotAction = this.cmsApi.getNodeById<HtBotActionNode>(
-        request.input.payload
-      )
+      if (this.cmsApi.isBotAction(request.input.payload)) {
+        const cmsBotAction = this.cmsApi.getNodeById<HtBotActionNode>(
+          request.input.payload
+        )
 
-      request.input.payload = this.cmsApi.createPayloadWithParams(cmsBotAction)
+        request.input.payload =
+          this.cmsApi.createPayloadWithParams(cmsBotAction)
+      }
     }
   }
 
   private removeSourceSufix(payload: string): string {
     return payload.split(SOURCE_INFO_SEPARATOR)[0]
-  }
-
-  private isBotAction(payload: string): boolean {
-    const node = this.cmsApi.getNodeById(payload)
-    return node?.type === HtNodeWithContentType.BOT_ACTION
   }
 
   async getContentsByContentID(


### PR DESCRIPTION
## Description

Avoid using getNodeById inside the isBotAction function to not show a log `Node with id X is not found` every time that bot received a custom payload