### PR TITLE
plugin-flow-builder: create executeConversationStart #BLT-1259

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26551,7 +26551,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.30.7-alpha.0",
+      "version": "0.30.7",
       "dependencies": {
         "@botonic/react": "^0.30.5",
         "axios": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26551,7 +26551,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.30.6",
+      "version": "0.30.7-alpha.0",
       "dependencies": {
         "@botonic/react": "^0.30.5",
         "axios": "^1.7.2",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.30.6",
+  "version": "0.30.7-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.30.7-alpha.0",
+  "version": "0.30.7",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",


### PR DESCRIPTION
## Description

Create `executeConversationStart` to allow handoffs and bot actions in typical WelcomeAction. 

## Context

If in a WelcomeAction you get the contents connected to the Conversation Start using 
```
const contents = pluginFlowBuilder.getStartContents()
```
 but you do not execute the `FlowBuilderAction.botonicInit(request, contentID)` where contentID is `contents[0].code` neither the handoffs nor the bot actions are executed.

## To document / Usage example

Now you can write WelcomeAction as: 
```
export class WelcomeAction extends FlowBuilderMultichannelAction {
  static contextType = RequestContext
  static async botonicInit(
    request: BotRequest
  ): Promise<FlowBuilderActionProps> {

   //extra logic

    return await super.executeConversationStart(request)
  }
}
```