### PR TITLE
Add needs escalation as a webview end fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26597,7 +26597,7 @@
     },
     "packages/botonic-plugin-hubtype-analytics": {
       "name": "@botonic/plugin-hubtype-analytics",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26551,7 +26551,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.30.7",
+      "version": "0.30.8",
       "dependencies": {
         "@botonic/react": "^0.30.5",
         "axios": "^1.7.2",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -291,6 +291,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
 
 export * from './action'
 export * from './content-fields'
+export { HtBotActionNode } from './content-fields/hubtype-fields'
 export { trackFlowContent } from './tracking'
 export {
   BotonicPluginFlowBuilderOptions,

--- a/packages/botonic-plugin-hubtype-analytics/package.json
+++ b/packages/botonic-plugin-hubtype-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-hubtype-analytics",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "Plugin for tracking in the Hubtype backend to see the results in the Hubtype Dashbord",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/botonic-plugin-hubtype-analytics/src/types.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/types.ts
@@ -154,6 +154,7 @@ export interface EventWebviewEnd extends HtBaseEventProps {
 export enum WebviewEndFailType {
   CanceledByUser = 'canceled_by_user',
   ApiError = 'api_error',
+  NeedsEscalation = 'needs_escalation',
 }
 
 export interface EventCustom extends HtBaseEventProps {


### PR DESCRIPTION
## Description

@botonic/plugin-hubtype-analytics published in 0.30.2
Add a `needs_escalation` as a new WebviewEndFileType

@botonic/plugin-flow-builder published in 0.30.8
export type HtBotActionNode
