### PR TITLE
plugin-hubtype-analytics: add attributes in nlu events #BLT-1318 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Botonic will be documented in this file.
 
 <details>
   <summary>
-    Changes that have landed in master but are not yet released.
+    Changes that have landed in master-lts but are not yet released.
     Click to see more.
   </summary>
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -25032,33 +25032,17 @@
     },
     "packages/botonic-plugin-hubtype-analytics": {
       "name": "@botonic/plugin-hubtype-analytics",
-      "version": "0.30.2",
+      "version": "0.31.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
-        "@botonic/core": "^0.30.0",
+        "@botonic/core": "0.31.0-alpha.1",
         "axios": "^1.7.2"
       },
       "devDependencies": {
         "@types/node": "^20.11.17",
         "@types/react": "^16.14.0",
         "typescript": "^4.9.5"
-      }
-    },
-    "packages/botonic-plugin-hubtype-analytics/node_modules/@botonic/core": {
-      "version": "0.30.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-runtime": "^7.23.9",
-        "axios": "^1.7.2",
-        "decode": "^0.3.0",
-        "pako": "^2.1.0",
-        "process": "^0.11.10",
-        "pusher-js": "^5.1.1",
-        "ulid": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "packages/botonic-plugin-hubtype-analytics/node_modules/@types/react": {

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to Botonic will be documented in this file.
+
+## [Unreleased]
+
+<details>
+  <summary>
+    Changes that have landed in master-lts but are not yet released.
+    Click to see more.
+  </summary>
+  
+## [0.31.0] - 2024-mm-dd
+
+### Added
+
+### Changed
+
+- [create nlu and knowledgebase events with `flow_thread_id, flow_node_id and flow_id attributes`](https://github.com/hubtype/botonic/pull/2960)
+
+### Fixed
+
+</details>

--- a/packages/botonic-plugin-flow-builder/src/user-input/intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/intent.ts
@@ -32,6 +32,9 @@ async function trackIntentEvent(
     nluIntentThreshold: intentNode?.content.confidence,
     nluIntentMessageId: request.input.message_id,
     userInput: request.input.data,
+    flowThreadId: request.session.flow_thread_id,
+    flowId: intentNode.flow_id,
+    flowNodeId: intentNode.id,
   }
   await trackEvent(request, EventAction.Intent, eventArgs)
 }

--- a/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
@@ -23,7 +23,8 @@ export class SmartIntentsApi {
   constructor(
     public cmsApi: FlowBuilderApi,
     public currentRequest: ActionRequest,
-    public smartIntentsConfig: SmartIntentsInferenceConfig
+    public smartIntentsConfig: SmartIntentsInferenceConfig,
+    public flowId?: string
   ) {}
 
   async getNodeByInput(): Promise<HtSmartIntentNode | undefined> {
@@ -50,6 +51,9 @@ export class SmartIntentsApi {
           nluIntentSmartNumUsed: response.data.smart_intents_used.length,
           nluIntentSmartMessageId: this.currentRequest.input.message_id,
           userInput: this.currentRequest.input.data,
+          flowThreadId: this.currentRequest.session.flow_thread_id,
+          flowId: smartIntentNode.flow_id,
+          flowNodeId: smartIntentNode.id,
         })
         return smartIntentNode
       }

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -72,6 +72,7 @@ export function createRequest({
       _access_token: 'fake_access_token',
       _hubtype_api: 'https://api.hubtype.com',
       is_test_integration: false,
+      flow_thread_id: 'testFlowThreadId',
     },
     input: {
       bot_interaction_id: 'testInteractionId',

--- a/packages/botonic-plugin-flow-builder/tests/tracking/track-keyword.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/tracking/track-keyword.test.ts
@@ -32,7 +32,9 @@ describe('Check tracked events when a contents are displayed', () => {
       expect.anything(),
       'nlu_keyword',
       {
-        nluKeywordId: '8ec6a479-dca5-4623-8bab-41fa49c9d6e8',
+        flowId: '43a736f8-4837-4fbb-a661-021291749b4f',
+        flowNodeId: '8ec6a479-dca5-4623-8bab-41fa49c9d6e8',
+        flowThreadId: 'testFlowThreadId',
         nluKeywordName: 'flowText',
         nluKeywordIsRegex: false,
         nluKeywordMessageId: expect.anything(),

--- a/packages/botonic-plugin-flow-builder/tests/tracking/track-knowledge-base.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/tracking/track-knowledge-base.test.ts
@@ -56,6 +56,9 @@ describe('Check tracked events when a bot generates a response using a knowledge
         knowledgebaseChunksIds: ['sourceChunkId1', 'sourceChunkId2'],
         knowledgebaseMessageId: 'testMessageId',
         userInput: 'What is Flow Builder?',
+        flowId: '4c8acc81-accd-529e-8bb6-d17f4cafafea',
+        flowNodeId: 'b2ac9457-6928-41ea-9474-911133a75ff4',
+        flowThreadId: 'testFlowThreadId',
       }
     )
   })

--- a/packages/botonic-plugin-flow-builder/tests/tracking/track-smart-intent.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/tracking/track-smart-intent.test.ts
@@ -35,6 +35,9 @@ describe('Check tracked events when a contents are displayed after match with sm
         nluIntentSmartNumUsed: 2,
         nluIntentSmartMessageId: expect.anything(),
         userInput: 'How can I add a bag to my booking?',
+        flowId: '8d527e7d-ea6d-5422-b810-5b4c8be7657b',
+        flowNodeId: 'a962b2e5-9424-4fe5-81bd-8cb398b59875',
+        flowThreadId: 'testFlowThreadId',
       }
     )
     expect(trackEventMock).toHaveBeenNthCalledWith(

--- a/packages/botonic-plugin-hubtype-analytics/CHANGELOG.md
+++ b/packages/botonic-plugin-hubtype-analytics/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to Botonic will be documented in this file.
+
+## [Unreleased]
+
+<details>
+  <summary>
+    Changes that have landed in master-lts but are not yet released.
+    Click to see more.
+  </summary>
+  
+## [0.31.0] - 2024-mm-dd
+
+### Added
+
+### Changed
+
+- [`add flow_thread_id, flow_node_id and flow_id` in nlu and knowledgebase events](https://github.com/hubtype/botonic/pull/2960)
+
+### Fixed
+
+</details>

--- a/packages/botonic-plugin-hubtype-analytics/README.md
+++ b/packages/botonic-plugin-hubtype-analytics/README.md
@@ -17,17 +17,19 @@ npm i @botonic/plugin-hubtype-analytics
 You can define two optional functions to obtain the language and the country.
 By default if you do not define these functions it will use the language defined in request.session.user.extra_data.language and country defined in request.session.user.extra_data.country
 
-```
-  export const plugins = [
-    {
-      id: 'hubtype-analytics',
-      resolve: require('@botonic/plugin-hubtype-analytics'),
-      options: {
-        getLaguange?: (request: BotRequest) => request.session.user.extra_data.lang
-        getCountry?: (request: BotRequest) => request.session.user.extra_data.store
-      },
+```typescript
+export const plugins = [
+  {
+    id: 'hubtype-analytics',
+    resolve: require('@botonic/plugin-hubtype-analytics'),
+    options: {
+      getLaguange: (request: BotRequest) =>
+        request.session.user.extra_data.lang,
+      getCountry: (request: BotRequest) =>
+        request.session.user.extra_data.store,
     },
-  ]
+  },
+]
 ```
 
 ## Plugin Options
@@ -60,7 +62,7 @@ export class WelcomeAction extends FlowBuilderMultichannelAction {
 }
 ```
 
-- To track a handoff, you can use an instance of `HandOffBuilder` from `@botonic/core` `handoffBuilder.withBotEvent()` so thaht the backend will create the event after the handoff has been done correctly.
+- To track a handoff, you can use an instance of `HandOffBuilder` from `@botonic/core` `handoffBuilder.withBotEvent()` so that the backend will create the event after the handoff has been done correctly.
 
 ```typescript
 const handOffBuilder = new HandOffBuilder(request.session)

--- a/packages/botonic-plugin-hubtype-analytics/package.json
+++ b/packages/botonic-plugin-hubtype-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-hubtype-analytics",
-  "version": "0.30.2",
+  "version": "0.31.0-alpha.0",
   "description": "Plugin for tracking in the Hubtype backend to see the results in the Hubtype Dashbord",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.21.0",
-    "@botonic/core": "^0.30.0",
+    "@botonic/core": "0.31.0-alpha.1",
     "axios": "^1.7.2"
   },
   "devDependencies": {

--- a/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-intent-smart.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-intent-smart.ts
@@ -6,6 +6,9 @@ export class HtEventIntentSmart extends HtEvent {
   nlu_intent_smart_num_used: number
   nlu_intent_smart_message_id: string
   user_input: string
+  flow_thread_id: string
+  flow_id: string
+  flow_node_id: string
 
   constructor(event: EventIntentSmart, requestData: RequestData) {
     super(event, requestData)
@@ -15,5 +18,8 @@ export class HtEventIntentSmart extends HtEvent {
     this.nlu_intent_smart_num_used = event.nluIntentSmartNumUsed
     this.nlu_intent_smart_message_id = event.nluIntentSmartMessageId
     this.user_input = event.userInput
+    this.flow_thread_id = event.flowThreadId
+    this.flow_id = event.flowId
+    this.flow_node_id = event.flowNodeId
   }
 }

--- a/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-intent.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-intent.ts
@@ -7,6 +7,9 @@ export class HtEventIntent extends HtEvent {
   nlu_intent_threshold: number
   nlu_intent_message_id: string
   user_input: string
+  flow_thread_id: string
+  flow_id: string
+  flow_node_id: string
 
   constructor(event: EventIntent, requestData: RequestData) {
     super(event, requestData)
@@ -17,5 +20,8 @@ export class HtEventIntent extends HtEvent {
     this.nlu_intent_threshold = event.nluIntentThreshold
     this.nlu_intent_message_id = event.nluIntentMessageId
     this.user_input = event.userInput
+    this.flow_thread_id = event.flowThreadId
+    this.flow_id = event.flowId
+    this.flow_node_id = event.flowNodeId
   }
 }

--- a/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-keyword.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-keyword.ts
@@ -2,20 +2,24 @@ import { EventAction, EventKeyword, EventType, RequestData } from '../types'
 import { HtEvent } from './ht-event'
 
 export class HtEventKeyword extends HtEvent {
-  nlu_keyword_id: string
   nlu_keyword_name: string
   nlu_keyword_is_regex: boolean
   nlu_keyword_message_id: string
   user_input: string
+  flow_thread_id: string
+  flow_id: string
+  flow_node_id: string
 
   constructor(event: EventKeyword, requestData: RequestData) {
     super(event, requestData)
     this.type = EventType.BotEvent
     this.action = EventAction.Keyword
-    this.nlu_keyword_id = event.nluKeywordId
     this.nlu_keyword_name = event.nluKeywordName
     this.nlu_keyword_is_regex = event.nluKeywordIsRegex || false
     this.nlu_keyword_message_id = event.nluKeywordMessageId
     this.user_input = event.userInput
+    this.flow_thread_id = event.flowThreadId
+    this.flow_id = event.flowId
+    this.flow_node_id = event.flowNodeId
   }
 }

--- a/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-knowledge-base.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-knowledge-base.ts
@@ -13,6 +13,9 @@ export class HtEventKnowledgeBase extends HtEvent {
   knowledgebase_chunks_ids: string[]
   knowledgebase_message_id: string
   user_input: string
+  flow_thread_id: string
+  flow_id: string
+  flow_node_id: string
 
   constructor(event: EventKnowledgeBase, requestData: RequestData) {
     super(event, requestData)
@@ -24,5 +27,8 @@ export class HtEventKnowledgeBase extends HtEvent {
     this.knowledgebase_chunks_ids = event.knowledgebaseChunksIds
     this.knowledgebase_message_id = event.knowledgebaseMessageId
     this.user_input = event.userInput
+    this.flow_thread_id = event.flowThreadId
+    this.flow_id = event.flowId
+    this.flow_node_id = event.flowNodeId
   }
 }

--- a/packages/botonic-plugin-hubtype-analytics/src/types.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/types.ts
@@ -85,6 +85,9 @@ export interface EventHandoffOption extends HtBaseEventProps {
 
 export interface EventIntent extends HtBaseEventProps {
   action: EventAction.Intent
+  flowThreadId: string
+  flowId: string
+  flowNodeId: string
   nluIntentLabel: string
   nluIntentConfidence: number
   nluIntentThreshold: number
@@ -94,7 +97,9 @@ export interface EventIntent extends HtBaseEventProps {
 
 export interface EventKeyword extends HtBaseEventProps {
   action: EventAction.Keyword
-  nluKeywordId: string
+  flowThreadId: string
+  flowId: string
+  flowNodeId: string
   nluKeywordName: string
   nluKeywordIsRegex?: boolean
   nluKeywordMessageId: string
@@ -103,6 +108,9 @@ export interface EventKeyword extends HtBaseEventProps {
 
 export interface EventIntentSmart extends HtBaseEventProps {
   action: EventAction.IntentSmart
+  flowThreadId: string
+  flowId: string
+  flowNodeId: string
   nluIntentSmartTitle: string
   nluIntentSmartNumUsed: number
   nluIntentSmartMessageId: string
@@ -111,6 +119,9 @@ export interface EventIntentSmart extends HtBaseEventProps {
 
 export interface EventKnowledgeBase extends HtBaseEventProps {
   action: EventAction.Knowledgebase
+  flowThreadId: string
+  flowId: string
+  flowNodeId: string
   knowledgebaseInferenceId: string
   knowledgebaseFailReason?: KnowledgebaseFailReason
   knowledgebaseSourcesIds: string[]

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-intent-smart.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-intent-smart.test.ts
@@ -10,6 +10,9 @@ describe('Create nlu intent smart events', () => {
       nluIntentSmartNumUsed: 2,
       nluIntentSmartMessageId: 'messageId',
       userInput: 'Add a bag',
+      flowThreadId: 'flowThreadId',
+      flowId: 'flowId',
+      flowNodeId: 'nluIntentSmartNodeId',
     })
 
     expect(htEvent).toEqual({
@@ -22,6 +25,9 @@ describe('Create nlu intent smart events', () => {
       nlu_intent_smart_num_used: 2,
       nlu_intent_smart_message_id: 'messageId',
       user_input: 'Add a bag',
+      flow_thread_id: 'flowThreadId',
+      flow_id: 'flowId',
+      flow_node_id: 'nluIntentSmartNodeId',
       bot_interaction_id: 'testInteractionId',
       type: EventType.BotEvent,
     })

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-intent.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-intent.test.ts
@@ -11,6 +11,9 @@ describe('Create nlu intent classic events', () => {
       nluIntentThreshold: 0.6,
       nluIntentMessageId: 'nluIntentMessageId',
       userInput: 'Add a bag',
+      flowThreadId: 'flowThreadId',
+      flowId: 'flowId',
+      flowNodeId: 'nluIntentNodeId',
     })
 
     expect(htEvent).toEqual({
@@ -24,6 +27,9 @@ describe('Create nlu intent classic events', () => {
       nlu_intent_threshold: 0.6,
       nlu_intent_message_id: 'nluIntentMessageId',
       user_input: 'Add a bag',
+      flow_thread_id: 'flowThreadId',
+      flow_id: 'flowId',
+      flow_node_id: 'nluIntentNodeId',
       bot_interaction_id: 'testInteractionId',
       type: EventType.BotEvent,
     })

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-keyword.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-keyword.test.ts
@@ -6,11 +6,13 @@ describe('Create nlu keyword events', () => {
   test('should create keyword event', () => {
     const htEvent = createHtEvent(requestData, {
       action: EventAction.Keyword,
-      nluKeywordId: 'keywordId',
       nluKeywordName: 'hello',
       nluKeywordIsRegex: false,
       nluKeywordMessageId: 'messageId',
       userInput: 'hello',
+      flowThreadId: 'flowThreadId',
+      flowId: 'flowId',
+      flowNodeId: 'keywordNodeId',
     })
 
     expect(htEvent).toEqual({
@@ -19,11 +21,13 @@ describe('Create nlu keyword events', () => {
       chat_country: 'ES',
       format_version: 2,
       action: EventAction.Keyword,
-      nlu_keyword_id: 'keywordId',
       nlu_keyword_name: 'hello',
       nlu_keyword_is_regex: false,
       nlu_keyword_message_id: 'messageId',
       user_input: 'hello',
+      flow_thread_id: 'flowThreadId',
+      flow_id: 'flowId',
+      flow_node_id: 'keywordNodeId',
       bot_interaction_id: 'testInteractionId',
       type: EventType.BotEvent,
     })

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-knowledge-base.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-knowledge-base.test.ts
@@ -16,6 +16,9 @@ describe('Create knowledge base events', () => {
       knowledgebaseChunksIds: ['cunkId1', 'chunkId2', 'chunkId3'],
       knowledgebaseMessageId: 'knowledgebaseMessageId',
       userInput: 'What is Flow Builder?',
+      flowThreadId: 'flowThreadId',
+      flowId: 'flowId',
+      flowNodeId: 'knowledgebaseNodeId',
     })
 
     expect(htEvent).toEqual({
@@ -29,6 +32,9 @@ describe('Create knowledge base events', () => {
       knowledgebase_chunks_ids: ['cunkId1', 'chunkId2', 'chunkId3'],
       knowledgebase_message_id: 'knowledgebaseMessageId',
       user_input: 'What is Flow Builder?',
+      flow_thread_id: 'flowThreadId',
+      flow_id: 'flowId',
+      flow_node_id: 'knowledgebaseNodeId',
       bot_interaction_id: 'testInteractionId',
       type: EventType.BotEvent,
     })
@@ -43,6 +49,9 @@ describe('Create knowledge base events', () => {
       knowledgebaseChunksIds: ['cunkId1', 'chunkId2', 'chunkId3'],
       knowledgebaseMessageId: 'knowledgebaseMessageId',
       userInput: 'What is Flow Builder?',
+      flowThreadId: 'flowThreadId',
+      flowId: 'flowId',
+      flowNodeId: 'knowledgebaseNodeId',
     })
 
     expect(htEvent).toEqual({
@@ -57,6 +66,9 @@ describe('Create knowledge base events', () => {
       knowledgebase_chunks_ids: ['cunkId1', 'chunkId2', 'chunkId3'],
       knowledgebase_message_id: 'knowledgebaseMessageId',
       user_input: 'What is Flow Builder?',
+      flow_thread_id: 'flowThreadId',
+      flow_id: 'flowId',
+      flow_node_id: 'knowledgebaseNodeId',
       bot_interaction_id: 'testInteractionId',
       type: EventType.BotEvent,
     })

--- a/packages/botonic-react/CHANGELOG.md
+++ b/packages/botonic-react/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Botonic will be documented in this file.
 
 <details>
   <summary>
-    Changes that have landed in master but are not yet released.
+    Changes that have landed in master-lts but are not yet released.
     Click to see more.
   </summary>
   


### PR DESCRIPTION
## Description

@botonic/plugin-hubtype-analytics
- add flow_thread_id, flow_node_id and flow_id in nlu events (keywords, intents, smart intents and knowledgebase)
- remove nlu_keyword_id, is the same id used for flow_node_id

@botonic/plugin-flow-builder
- add flow_thread_id, flow_node_id and flow_id when generate an events for  keywords, intents, smart intents and knowledgebase

## Testing

Tests updated in boths plugins
