### PR TITLE
FlowBuilder: Fix isLoading attribute in useWebviewContents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25086,7 +25086,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "dependencies": {
         "@botonic/react": "^0.31.0",
         "axios": "^1.7.9",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/webview/use-webview-contents.ts
+++ b/packages/botonic-plugin-flow-builder/src/webview/use-webview-contents.ts
@@ -28,7 +28,6 @@ export function useWebviewContents<T extends MapContentsType>({
     {} as Record<keyof T, string>
   )
   const [currentLocale, setCurrentLocale] = useState(locale)
-  const [isLoading, setLoading] = useState(true)
   const [error, setError] = useState(false)
 
   const updateCurrentLocale = (textContents?: WebviewTextContent[]) => {
@@ -105,15 +104,13 @@ export function useWebviewContents<T extends MapContentsType>({
       } catch (error) {
         console.error('Error fetching webview contents:', error)
         setError(true)
-      } finally {
-        setLoading(false)
       }
     }
     getResponseContents()
   }, [])
 
   return {
-    isLoading,
+    isLoading: Object.keys(contents).length === 0,
     error,
     webviewContentsContext: {
       getTextContent,


### PR DESCRIPTION
## Description
Remove the `isLoading` state variable in the `useWebviewContents` hook and return it as the length of the fetched `contents` so if the contents object has no keys, it means that the contents are still loading.

## Context
After the migration from React 16 to React 18 the `useWebviewContents` hook was not working as expected because the `isLoading` variable was being set to false before the `contents` variable was set in the state so the webview was trying to access to an empty `contents` object.

## Testing

The pull request has no tests.
