### PR TITLE
feat(core/plugin-flow-builder): add support for notifying queue position changed #BLT-1449

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24822,7 +24822,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.32.0",
+      "version": "0.33.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -25051,6 +25051,25 @@
         "core-js": "^3.35.1"
       }
     },
+    "packages/botonic-plugin-dialogflow/node_modules/@botonic/core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.32.0.tgz",
+      "integrity": "sha512-KvVpKinXQ9zpFkAZhnYvgInZmiVpHR+KrrsZbmF3a4fhViSaZJmvcnTOuV6Evm0ZzDurFbpUUdMO2rR3jc2GMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.7.9",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
     "packages/botonic-plugin-dynamodb": {
       "name": "@botonic/plugin-dynamodb",
       "version": "0.32.0",
@@ -25065,6 +25084,25 @@
       "devDependencies": {
         "@types/aws-sdk": "^2.7.0",
         "@types/node": "20.11.17"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-plugin-dynamodb/node_modules/@botonic/core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.32.0.tgz",
+      "integrity": "sha512-KvVpKinXQ9zpFkAZhnYvgInZmiVpHR+KrrsZbmF3a4fhViSaZJmvcnTOuV6Evm0ZzDurFbpUUdMO2rR3jc2GMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.7.9",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -25086,9 +25124,9 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.33.0-alpha.1",
+      "version": "0.33.0-alpha.2",
       "dependencies": {
-        "@botonic/react": "^0.32.0",
+        "@botonic/react": "0.33.0-alpha.0",
         "axios": "^1.7.9",
         "uuid": "^10.0.0"
       },
@@ -25113,6 +25151,25 @@
         "npm": ">=10.0.0"
       }
     },
+    "packages/botonic-plugin-google-analytics/node_modules/@botonic/core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.32.0.tgz",
+      "integrity": "sha512-KvVpKinXQ9zpFkAZhnYvgInZmiVpHR+KrrsZbmF3a4fhViSaZJmvcnTOuV6Evm0ZzDurFbpUUdMO2rR3jc2GMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.7.9",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
     "packages/botonic-plugin-google-translation": {
       "name": "@botonic/plugin-google-translation",
       "version": "0.32.0",
@@ -25122,6 +25179,25 @@
         "@botonic/core": "^0.32.0",
         "axios": "^1.7.9",
         "jsrsasign": "^10.9.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-plugin-google-translation/node_modules/@botonic/core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.32.0.tgz",
+      "integrity": "sha512-KvVpKinXQ9zpFkAZhnYvgInZmiVpHR+KrrsZbmF3a4fhViSaZJmvcnTOuV6Evm0ZzDurFbpUUdMO2rR3jc2GMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.7.9",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -25141,6 +25217,25 @@
         "@types/node": "^20.11.17",
         "@types/react": "^16.14.0",
         "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-plugin-hubtype-analytics/node_modules/@botonic/core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.32.0.tgz",
+      "integrity": "sha512-KvVpKinXQ9zpFkAZhnYvgInZmiVpHR+KrrsZbmF3a4fhViSaZJmvcnTOuV6Evm0ZzDurFbpUUdMO2rR3jc2GMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.7.9",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -25179,6 +25274,25 @@
         "npm": ">=10.0.0"
       }
     },
+    "packages/botonic-plugin-hubtype-babel/node_modules/@botonic/core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.32.0.tgz",
+      "integrity": "sha512-KvVpKinXQ9zpFkAZhnYvgInZmiVpHR+KrrsZbmF3a4fhViSaZJmvcnTOuV6Evm0ZzDurFbpUUdMO2rR3jc2GMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.7.9",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
     "packages/botonic-plugin-inbenta": {
       "name": "@botonic/plugin-inbenta",
       "version": "0.32.0",
@@ -25199,6 +25313,25 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.16"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-plugin-knowledge-bases/node_modules/@botonic/core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.32.0.tgz",
+      "integrity": "sha512-KvVpKinXQ9zpFkAZhnYvgInZmiVpHR+KrrsZbmF3a4fhViSaZJmvcnTOuV6Evm0ZzDurFbpUUdMO2rR3jc2GMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.7.9",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -25238,10 +25371,10 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.32.0",
+      "version": "0.33.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@botonic/core": "^0.32.0",
+        "@botonic/core": "0.33.0-alpha.0",
         "axios": "^1.7.9",
         "emoji-picker-react": "^4.12.0",
         "lodash.merge": "^4.6.2",

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.32.0",
+  "version": "0.33.0-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-core/src/handoff.ts
+++ b/packages/botonic-core/src/handoff.ts
@@ -37,7 +37,7 @@ interface BotEventData {
 export enum HelpdeskEvent {
   StatusChanged = 'status_changed',
   AgentMessageCreated = 'agent_message_created',
-  InitialQueuePosition = 'initial_queue_position',
+  QueuePositionChanged = 'queue_position_changed',
 }
 
 function contextDefaults(context: any): BackendContext {

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -73,7 +73,7 @@ export enum INPUT {
   WHATSAPP_BUTTON_LIST = 'whatsapp-button-list',
   WHATSAPP_CTA_URL_BUTTON = 'whatsapp-cta-url-button',
   EVENT_AGENT_MESSAGE_CREATED = 'case_event_agent_message_created',
-  EVENT_INITIAL_QUEUE_POSITION = 'case_event_initial_queue_position',
+  EVENT_QUEUE_POSITION_CHANGED = 'case_event_queue_position_changed',
   WHATSAPP_CATALOG = 'whatsapp-catalog',
   WHATSAPP_PRODUCT = 'whatsapp-product',
   WHATSAPP_PRODUCT_LIST = 'whatsapp-product-list',
@@ -121,7 +121,7 @@ export type InputType =
   | INPUT.WHATSAPP_BUTTON_LIST
   | INPUT.WHATSAPP_CTA_URL_BUTTON
   | INPUT.EVENT_AGENT_MESSAGE_CREATED
-  | INPUT.EVENT_INITIAL_QUEUE_POSITION
+  | INPUT.EVENT_QUEUE_POSITION_CHANGED
   | INPUT.WHATSAPP_CATALOG
   | INPUT.WHATSAPP_PRODUCT
   | INPUT.WHATSAPP_PRODUCT_LIST

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -367,7 +367,7 @@ export enum BotonicAction {
 }
 
 export interface CaseEventQueuePositionChangedInput {
-  type: 'case_event_queue_position_changed'
+  type: INPUT.EVENT_QUEUE_POSITION_CHANGED
   case_id: string
   prev_queue_position: number | null
   prev_queue_position_notified_at: string | null

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -365,3 +365,13 @@ export enum BotonicAction {
   DeleteUser = 'delete_user',
   DiscardCase = 'discard_case',
 }
+
+export interface CaseEventQueuePositionChangedInput {
+  type: 'case_event_queue_position_changed'
+  case_id: string
+  prev_queue_position: number | null
+  prev_queue_position_notified_at: string | null
+  current_queue_position: number
+  current_queue_position_notified_at: string
+  total_queue_waiting_cases_number: number
+}

--- a/packages/botonic-core/tests/handoff.test.ts
+++ b/packages/botonic-core/tests/handoff.test.ts
@@ -146,12 +146,12 @@ describe('Handoff', () => {
     const expectedBotonicAction = `${BotonicAction.CreateCase}:{"force_assign_if_not_available":true,"on_finish":"payload1","subscribe_helpdesk_events":["agent_message_created"]}`
     expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
   })
-  test('Create a handoff and subscribe to initial_queue_position', () => {
+  test('Create a handoff and subscribe to queue_position_changed', () => {
     const builder = new HandOffBuilder({})
-      .withSubscribeHelpdeskEvents([HelpdeskEvent.InitialQueuePosition])
+      .withSubscribeHelpdeskEvents([HelpdeskEvent.QueuePositionChanged])
       .withOnFinishPayload('payload1')
     builder.handOff()
-    const expectedBotonicAction = `${BotonicAction.CreateCase}:{"force_assign_if_not_available":true,"on_finish":"payload1","subscribe_helpdesk_events":["initial_queue_position"]}`
+    const expectedBotonicAction = `${BotonicAction.CreateCase}:{"force_assign_if_not_available":true,"on_finish":"payload1","subscribe_helpdesk_events":["queue_position_changed"]}`
     expect(builder._session._botonic_action).toEqual(expectedBotonicAction)
   })
 })

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.33.0-alpha.1",
+  "version": "0.33.0-alpha.2",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -14,7 +14,7 @@
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"
   },
   "dependencies": {
-    "@botonic/react": "^0.32.0",
+    "@botonic/react": "0.33.0-alpha.0",
     "axios": "^1.7.9",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -84,7 +84,7 @@ async function getContents(
     return await getContentsByFirstInteraction(context)
   }
   // TODO: Add needed logic when we can define contents for multilocale queue position message
-  if (request.input.type === INPUT.EVENT_INITIAL_QUEUE_POSITION) {
+  if (request.input.type === INPUT.EVENT_QUEUE_POSITION_CHANGED) {
     return []
   }
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
@@ -16,7 +16,7 @@ export class FlowHandoff extends ContentFieldsBase {
   public queue?: HtQueueLocale
   public onFinishPayload?: string
   public handoffAutoAssign: boolean
-  public hasInitialQueuePositionEnabled: boolean
+  public hasQueuePositionChangedNotificationsEnabled: boolean
   public isTestIntegration: boolean
 
   static fromHubtypeCMS(
@@ -29,8 +29,8 @@ export class FlowHandoff extends ContentFieldsBase {
     newHandoff.queue = this.getQueueByLocale(locale, cmsHandoff.content.queue)
     newHandoff.onFinishPayload = this.getOnFinishPayload(cmsHandoff, cmsApi)
     newHandoff.handoffAutoAssign = cmsHandoff.content.has_auto_assign
-    newHandoff.hasInitialQueuePositionEnabled =
-      cmsHandoff.content.has_initial_queue_position_enabled
+    newHandoff.hasQueuePositionChangedNotificationsEnabled =
+      cmsHandoff.content.has_queue_position_changed_notifications_enabled
     return newHandoff
   }
 
@@ -49,9 +49,9 @@ export class FlowHandoff extends ContentFieldsBase {
     const handOffBuilder = new HandOffBuilder(request.session)
     handOffBuilder.withAutoAssignOnWaiting(this.handoffAutoAssign)
 
-    if (this.hasInitialQueuePositionEnabled) {
+    if (this.hasQueuePositionChangedNotificationsEnabled) {
       handOffBuilder.withSubscribeHelpdeskEvents([
-        HelpdeskEvent.InitialQueuePosition,
+        HelpdeskEvent.QueuePositionChanged,
       ])
     }
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/handoff.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/handoff.ts
@@ -7,6 +7,6 @@ export interface HtHandoffNode extends HtBaseNode {
     queue: HtQueueLocale[]
     payload: HtPayloadLocale[]
     has_auto_assign: boolean
-    has_initial_queue_position_enabled: boolean
+    has_queue_position_changed_notifications_enabled: boolean
   }
 }

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.32.0",
+  "version": "0.33.0-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",
@@ -20,7 +20,7 @@
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' '*.js' 'src/**/*.js*' --fix"
   },
   "dependencies": {
-    "@botonic/core": "^0.32.0",
+    "@botonic/core": "0.33.0-alpha.0",
     "axios": "^1.7.9",
     "emoji-picker-react": "^4.12.0",
     "lodash.merge": "^4.6.2",

--- a/packages/botonic-react/src/index-types.ts
+++ b/packages/botonic-react/src/index-types.ts
@@ -213,3 +213,5 @@ interface UpdateMessageInfoEvent {
   message: MessageInfo
   isError?: boolean
 }
+
+export { CaseEventQueuePositionChangedInput } from '@botonic/core'


### PR DESCRIPTION
## Description
* Modify `InitialQueuePosition` event to be the new `QueuePositionChanged`.
* Update related necessary logic in flow builder plugin.


## Usage
```
// routes.js
import Thanks from './actions/thanks'
import TransferAgent from './actions/transfer-agent'
import QueuePositionChanged from './actions/queue-position-changed'

export const routes = function ({ input }) {
  return [
    {
      path: 'queue-position-changed',
      type: 'case_event_queue_position_changed',
      action: QueuePositionChanged,
    },
    { path: 'agent', text: /^handoff$/i, action: TransferAgent },
    { path: 'thanks-for-contacting', action: Thanks },
  ]
}
```

```
// transfer-agent.jsx
import { HandOffBuilder, HelpdeskEvent } from '@botonic/core'
import { Text } from '@botonic/react'
import React from 'react'

export default class extends React.Component {
  static async botonicInit({ input, session, params, lastRoutePath }) {
    /*
      Uncomment the lines below before deploying the bot to Hubtype
      in order to test the getOpenQueues call for 'Customer Support'.
    */
    // let openQueues = await getOpenQueues(session)

    const handOffBuilder = new HandOffBuilder(session)
    handOffBuilder.withOnFinishPath('thanks-for-contacting') // or handOffBuilder.withOnFinishPayload('thanks-for-contacting')
    handOffBuilder.withSubscribeHelpdeskEvents([
      HelpdeskEvent.QueuePositionChanged,
    ])
    await handOffBuilder.handOff()
  }

  render() {
    return <Text>You are being transferred to an agent!</Text>
  }
}
```

```
// queue-position-changed.jsx
import { Text } from '@botonic/react'
import React from 'react'

export default class extends React.Component {
  static async botonicInit({ input, session, params, lastRoutePath }) {
    return { input }
  }

  render() {
    return <Text>{JSON.stringify(this.props.input)}</Text>
  }
}
```
## Output produced

**1st notification (output from queue-position-changed.jsx)**: This notification was received after having 1 waiting case in the queue, for a total of 2.
```
{
  "type": "case_event_queue_position_changed",
  "case_id": "019547f8-b7c5-7e70-aadd-91df4e490dce",
  "prev_queue_position": null,
  "prev_queue_position_notified_at": null,
  "current_queue_position": 2,
  "current_queue_position_notified_at": "2025-02-27T15:13:57.336374+00:00",
  "total_queue_waiting_cases_number": 2
}
```

**Subsequent notifications (output from queue-position-changed.jsx)**: This notification was received after 1 minute. In this window of time, the first case went to status attending so this one received the notification that it has gone from position 2 to 1.
```
{
  "type": "case_event_queue_position_changed",
  "case_id": "019547f8-b7c5-7e70-aadd-91df4e490dce",
  "prev_queue_position": 2,
  "prev_queue_position_notified_at": "2025-02-27T15:13:57.336374+00:00",
  "current_queue_position": 1,
  "current_queue_position_notified_at": "2025-02-27T15:14:16.674782+00:00",
  "total_queue_waiting_cases_number": 1
}
```