### PR TITLE
feat: remove files from package.json

### DIFF
--- a/examples/flow-builder-typescript/package.json
+++ b/examples/flow-builder-typescript/package.json
@@ -38,12 +38,6 @@
     "source-map-loader": "^0.2.4",
     "unorm": "^1.6.0"
   },
-  "files": [
-    "doc/**",
-    "lib/**",
-    "src/**",
-    "README.md"
-  ],
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=10.0.0"


### PR DESCRIPTION
## Description

It is necessary to publish everything inside the folder for the example to work properly, just like the other examples. 
When applying the src/** filter, neither the rspack-entires folder nor the rspack.config.ts file was published.

