### PR TITLE
feat(core & plugin-flow-builder): add nluResult in input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24822,7 +24822,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.33.1",
+      "version": "0.33.2",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -25086,7 +25086,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "dependencies": {
         "@botonic/react": "^0.33.0",
         "axios": "^1.7.9",

--- a/packages/botonic-core/CHANGELOG.md
+++ b/packages/botonic-core/CHANGELOG.md
@@ -20,12 +20,20 @@ All notable changes to Botonic will be documented in this file.
 
 </details>
 
+## [0.33.2] - 2025-04-01
+
+### Added
+
+- [PR-2298](https://github.com/hubtype/botonic/pull/2998): Add `request.input.nluResult in Input`
+
+## [0.33.1] - 2025-03-31
+
+### Added
+
+- [PR-2997](https://github.com/hubtype/botonic/pull/2997): add interfaces for `event Inputs`
+
 ## [0.32.0] - 2025-02-18
 
 ### Added
 
 - [BLT-1369](https://hubtype.atlassian.net/browse/BLT-1369): Add new `SubscribeHelpdeskEvents` event `InitialQueuePosition`.
-
-### Changed
-
-### Fixed

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -174,9 +174,9 @@ export interface Input extends Partial<NluResult> {
   bot_interaction_id: string
   catalog_id?: string
   product_items?: ProductItem[]
-  nluResult?: {
+  nluResolution?: {
     type: NluType
-    match: string
+    matchedValue: string
   }
 }
 

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -104,7 +104,7 @@ export interface ResolvedPlugin extends Plugin {
 }
 export type ResolvedPlugins = Record<string, ResolvedPlugin>
 
-type InputType =
+export type InputType =
   | INPUT.AUDIO
   | INPUT.BUTTON_MESSAGE
   | INPUT.CAROUSEL
@@ -154,6 +154,11 @@ export interface NluResult {
   translations: Translations
 }
 
+export enum NluType {
+  Keyword = 'keyword',
+  SmartIntent = 'smart-intent',
+}
+
 export interface Input extends Partial<NluResult> {
   text?: string
   src?: string
@@ -169,6 +174,10 @@ export interface Input extends Partial<NluResult> {
   bot_interaction_id: string
   catalog_id?: string
   product_items?: ProductItem[]
+  nluResult?: {
+    type: NluType
+    match: string
+  }
 }
 
 export interface CaseEventQueuePositionChangedInput {

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to Botonic will be documented in this file.
 
 </details>
 
+## [0.33.1] - 2025-04-01
+
+### Added
+
+- [PR-2298](https://github.com/hubtype/botonic/pull/2998): set and unset `request.input.nluResult in Input`
+
 ## [0.33.0] - 2025-03-04
 
 ### Added

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -131,6 +131,10 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     return payload.split(SOURCE_INFO_SEPARATOR)[0]
   }
 
+  post(request: PluginPreRequest): void {
+    request.input.nluResult = undefined
+  }
+
   async getContentsByContentID(
     contentID: string,
     locale: string,

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -132,7 +132,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   }
 
   post(request: PluginPreRequest): void {
-    request.input.nluResult = undefined
+    request.input.nluResolution = undefined
   }
 
   async getContentsByContentID(

--- a/packages/botonic-plugin-flow-builder/src/user-input/keyword.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/keyword.ts
@@ -36,9 +36,9 @@ export class KeywordMatcher {
     if (!keywordNode || !this.matchedKeyword) {
       return undefined
     }
-    this.request.input.nluResult = {
+    this.request.input.nluResolution = {
       type: NluType.Keyword,
-      match: this.matchedKeyword,
+      matchedValue: this.matchedKeyword,
     }
     await this.trackKeywordEvent()
     return keywordNode

--- a/packages/botonic-plugin-flow-builder/src/user-input/keyword.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/keyword.ts
@@ -1,3 +1,4 @@
+import { NluType } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
 import { FlowBuilderApi } from '../api'
@@ -32,8 +33,12 @@ export class KeywordMatcher {
   async getNodeByInput(userInput: string): Promise<HtKeywordNode | undefined> {
     const keywordNodes = this.cmsApi.getKeywordNodes()
     const keywordNode = this.getNodeByKeyword(userInput, keywordNodes)
-    if (!keywordNode) {
+    if (!keywordNode || !this.matchedKeyword) {
       return undefined
+    }
+    this.request.input.nluResult = {
+      type: NluType.Keyword,
+      match: this.matchedKeyword,
     }
     await this.trackKeywordEvent()
     return keywordNode

--- a/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
@@ -1,3 +1,4 @@
+import { NluType } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 import axios from 'axios'
 
@@ -46,6 +47,10 @@ export class SmartIntentsApi {
           smartIntentNode.content.title === response.data.smart_intent_title
       )
       if (smartIntentNode) {
+        this.currentRequest.input.nluResult = {
+          type: NluType.SmartIntent,
+          match: smartIntentNode.content.title,
+        }
         await trackEvent(this.currentRequest, EventAction.IntentSmart, {
           nluIntentSmartTitle: response.data.smart_intent_title,
           nluIntentSmartNumUsed: response.data.smart_intents_used.length,

--- a/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
@@ -47,9 +47,9 @@ export class SmartIntentsApi {
           smartIntentNode.content.title === response.data.smart_intent_title
       )
       if (smartIntentNode) {
-        this.currentRequest.input.nluResult = {
+        this.currentRequest.input.nluResolution = {
           type: NluType.SmartIntent,
-          match: smartIntentNode.content.title,
+          matchedValue: smartIntentNode.content.title,
         }
         await trackEvent(this.currentRequest, EventAction.IntentSmart, {
           nluIntentSmartTitle: response.data.smart_intent_title,

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {
   Input,
+  PluginPostRequest,
   PluginPreRequest,
   PROVIDER,
   ProviderType,
@@ -113,6 +114,7 @@ export async function createFlowBuilderPluginAndGetContents({
 }: FlowBuilderPluginAndGetContentsArgs): Promise<{
   contents: FlowContent[]
   request: PluginPreRequest
+  flowBuilderPluginPost: (request: PluginPostRequest) => void
 }> {
   const flowBuilderPlugin = createFlowBuilderPlugin(flowBuilderOptions)
 
@@ -129,5 +131,9 @@ export async function createFlowBuilderPluginAndGetContents({
     flowBuilderPlugin
   )
 
-  return { contents, request }
+  const flowBuilderPluginPost = (request: PluginPostRequest) => {
+    flowBuilderPlugin.post(request)
+  }
+
+  return { contents, request, flowBuilderPluginPost }
 }

--- a/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
@@ -12,20 +12,25 @@ describe('Check the contents returned by the plugin using keywords', () => {
   test.each(['reset', 'hola', 'HOLA'])(
     'The initial content is displayed when the user sends the %s text',
     async (inputData: string) => {
-      const { contents, request } = await createFlowBuilderPluginAndGetContents(
-        {
+      const { contents, request, flowBuilderPluginPost } =
+        await createFlowBuilderPluginAndGetContents({
           flowBuilderOptions: { flow: basicFlow },
           requestArgs: {
             input: { data: inputData, type: INPUT.TEXT },
           },
-        }
-      )
+        })
 
       expect((contents[0] as FlowText).text).toBe('Welcome message')
       expect(request.input.nluResult).toEqual({
         type: 'keyword',
         match: inputData,
       })
+
+      flowBuilderPluginPost({
+        ...request,
+        response: (contents[0] as FlowText).text,
+      })
+      expect(request.input.nluResult).toEqual(undefined)
     }
   )
 })

--- a/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
@@ -12,14 +12,20 @@ describe('Check the contents returned by the plugin using keywords', () => {
   test.each(['reset', 'hola', 'HOLA'])(
     'The initial content is displayed when the user sends the %s text',
     async (inputData: string) => {
-      const { contents } = await createFlowBuilderPluginAndGetContents({
-        flowBuilderOptions: { flow: basicFlow },
-        requestArgs: {
-          input: { data: inputData, type: INPUT.TEXT },
-        },
-      })
+      const { contents, request } = await createFlowBuilderPluginAndGetContents(
+        {
+          flowBuilderOptions: { flow: basicFlow },
+          requestArgs: {
+            input: { data: inputData, type: INPUT.TEXT },
+          },
+        }
+      )
 
       expect((contents[0] as FlowText).text).toBe('Welcome message')
+      expect(request.input.nluResult).toEqual({
+        type: 'keyword',
+        match: inputData,
+      })
     }
   )
 })

--- a/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
@@ -21,16 +21,16 @@ describe('Check the contents returned by the plugin using keywords', () => {
         })
 
       expect((contents[0] as FlowText).text).toBe('Welcome message')
-      expect(request.input.nluResult).toEqual({
+      expect(request.input.nluResolution).toEqual({
         type: 'keyword',
-        match: inputData,
+        matchedValue: inputData,
       })
 
       flowBuilderPluginPost({
         ...request,
         response: (contents[0] as FlowText).text,
       })
-      expect(request.input.nluResult).toEqual(undefined)
+      expect(request.input.nluResolution).toEqual(undefined)
     }
   )
 })

--- a/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
@@ -28,16 +28,16 @@ describe('Check the contents returned by the plugin when match a smart intent', 
     expect((contents[0] as FlowText).text).toBe(
       'Message explaining how to add a bag'
     )
-    expect(request.input.nluResult).toEqual({
+    expect(request.input.nluResolution).toEqual({
       type: 'smart-intent',
-      match: 'Add a bag',
+      matchedValue: 'Add a bag',
     })
 
     flowBuilderPluginPost({
       ...request,
       response: (contents[0] as FlowText).text,
     })
-    expect(request.input.nluResult).toEqual(undefined)
+    expect(request.input.nluResolution).toEqual(undefined)
   })
 })
 
@@ -58,6 +58,6 @@ describe('Check the contents returned by the plugin when no match a smart intent
     })
 
     expect((contents[0] as FlowText).text).toBe('fallback 1st message')
-    expect(request.input.nluResult).toEqual(undefined)
+    expect(request.input.nluResolution).toEqual(undefined)
   })
 })

--- a/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
@@ -13,8 +13,8 @@ describe('Check the contents returned by the plugin when match a smart intent', 
 
   beforeEach(() => mockSmartIntent('Add a bag'))
 
-  test('When the smart intent inference returns the intent_name Add a Bag, the contents of the add a bag use case are displayed', async () => {
-    const { contents } = await createFlowBuilderPluginAndGetContents({
+  test('When the smart intent inference returns the intent_name Add a bag, the contents of the add a bag use case are displayed', async () => {
+    const { contents, request } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: { flow: smartIntentsFlow },
       requestArgs: {
         input: {
@@ -27,6 +27,10 @@ describe('Check the contents returned by the plugin when match a smart intent', 
     expect((contents[0] as FlowText).text).toBe(
       'Message explaining how to add a bag'
     )
+    expect(request.input.nluResult).toEqual({
+      type: 'smart-intent',
+      match: 'Add a bag',
+    })
   })
 })
 
@@ -36,7 +40,7 @@ describe('Check the contents returned by the plugin when no match a smart intent
   beforeEach(() => mockSmartIntent('Other'))
 
   test('When the smart intent inference returns the intent_name Other, fallback content are displayed', async () => {
-    const { contents } = await createFlowBuilderPluginAndGetContents({
+    const { contents, request } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: { flow: smartIntentsFlow },
       requestArgs: {
         input: {
@@ -47,5 +51,6 @@ describe('Check the contents returned by the plugin when no match a smart intent
     })
 
     expect((contents[0] as FlowText).text).toBe('fallback 1st message')
+    expect(request.input.nluResult).toEqual(undefined)
   })
 })

--- a/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
@@ -14,15 +14,16 @@ describe('Check the contents returned by the plugin when match a smart intent', 
   beforeEach(() => mockSmartIntent('Add a bag'))
 
   test('When the smart intent inference returns the intent_name Add a bag, the contents of the add a bag use case are displayed', async () => {
-    const { contents, request } = await createFlowBuilderPluginAndGetContents({
-      flowBuilderOptions: { flow: smartIntentsFlow },
-      requestArgs: {
-        input: {
-          data: 'I want to add a bag to my flight booking',
-          type: INPUT.TEXT,
+    const { contents, request, flowBuilderPluginPost } =
+      await createFlowBuilderPluginAndGetContents({
+        flowBuilderOptions: { flow: smartIntentsFlow },
+        requestArgs: {
+          input: {
+            data: 'I want to add a bag to my flight booking',
+            type: INPUT.TEXT,
+          },
         },
-      },
-    })
+      })
 
     expect((contents[0] as FlowText).text).toBe(
       'Message explaining how to add a bag'
@@ -31,6 +32,12 @@ describe('Check the contents returned by the plugin when match a smart intent', 
       type: 'smart-intent',
       match: 'Add a bag',
     })
+
+    flowBuilderPluginPost({
+      ...request,
+      response: (contents[0] as FlowText).text,
+    })
+    expect(request.input.nluResult).toEqual(undefined)
   })
 })
 


### PR DESCRIPTION
## Description

- add nluResult botonic-core in request.input
- set and unset nluResult in plugin-flow-builder

## Testing

Update keyword and smart-intents test to check that request.input.nluResult is set in after pre function and unset after post function
