### PR TITLE
feat(plugin-flow-builder): allow shadowing configuration BLT-1539 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25086,7 +25086,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "dependencies": {
         "@botonic/react": "^0.34.0",
         "axios": "^1.7.9",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
@@ -64,7 +64,7 @@ async function getContentsByUserInput({
     resolvedLocale,
   })
 
-  const hasRepeatedContent = await checkRepetedContents(
+  const hasRepeatedContent = await checkRepeatedContents(
     flowBuilderPlugin,
     resolvedLocale,
     contentsByKeywordsOrIntents
@@ -94,7 +94,7 @@ function getConversationStartId(cmsApi: FlowBuilderApi) {
   return conversationStartId
 }
 
-async function checkRepetedContents(
+async function checkRepeatedContents(
   flowBuilderPlugin: BotonicPluginFlowBuilder,
   resolvedLocale: string,
   contentsByKeywordsOrIntents: FlowContent[]

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/intent.ts
@@ -1,6 +1,7 @@
 import { HtBaseNode, HtInputLocale, HtTextLocale } from './common'
 import { HtNodeWithContentType } from './node-types'
 
+// TODO: Remove this because frontend no allow create intents babel
 export interface HtIntentNode extends HtBaseNode {
   type: HtNodeWithContentType.INTENT
   content: {

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -34,6 +34,7 @@ import { DEFAULT_FUNCTIONS } from './functions'
 import {
   BotonicPluginFlowBuilderOptions,
   FlowBuilderJSONVersion,
+  InShadowingConfig,
   KnowledgeBaseFunction,
   PayloadParamsBase,
   TrackEventFunction,
@@ -54,12 +55,13 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   public trackEvent?: TrackEventFunction
   public getKnowledgeBaseResponse?: KnowledgeBaseFunction
   public smartIntentsConfig: SmartIntentsInferenceConfig
+  public inShadowing: InShadowingConfig
 
   // TODO: Rethink how we construct FlowBuilderApi to be simpler
   public jsonVersion: FlowBuilderJSONVersion
   public apiUrl: string
 
-  constructor(readonly options: BotonicPluginFlowBuilderOptions) {
+  constructor(options: BotonicPluginFlowBuilderOptions) {
     this.apiUrl = options.apiUrl || FLOW_BUILDER_API_URL_PROD
     this.jsonVersion = options.jsonVersion || FlowBuilderJSONVersion.LATEST
     this.flow = options.flow
@@ -73,6 +75,11 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     }
     const customFunctions = options.customFunctions || {}
     this.functions = { ...DEFAULT_FUNCTIONS, ...customFunctions }
+    this.inShadowing = {
+      allowKeywords: options.inShadowing?.allowKeywords || false,
+      allowSmartIntents: options.inShadowing?.allowSmartIntents || false,
+      allowKnowledgeBases: options.inShadowing?.allowKnowledgeBases || false,
+    }
   }
 
   resolveFlowUrl(request: PluginPreRequest): string {

--- a/packages/botonic-plugin-flow-builder/src/tracking.ts
+++ b/packages/botonic-plugin-flow-builder/src/tracking.ts
@@ -5,7 +5,6 @@ import { FlowContent } from './content-fields'
 import {
   HtNodeWithContent,
   HtNodeWithContentType,
-  HtNodeWithoutContentType,
 } from './content-fields/hubtype-fields'
 import { getFlowBuilderPlugin } from './helpers'
 

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -3,6 +3,12 @@ import { ActionRequest } from '@botonic/react'
 
 import { HtFlowBuilderData } from './content-fields/hubtype-fields'
 
+export interface InShadowingConfig {
+  allowKeywords: boolean
+  allowSmartIntents: boolean
+  allowKnowledgeBases: boolean
+}
+
 export interface BotonicPluginFlowBuilderOptions {
   apiUrl?: string
   jsonVersion?: FlowBuilderJSONVersion
@@ -13,6 +19,7 @@ export interface BotonicPluginFlowBuilderOptions {
   trackEvent?: TrackEventFunction
   getKnowledgeBaseResponse?: KnowledgeBaseFunction
   smartIntentsConfig?: { numSmartIntentsToUse: number }
+  inShadowing?: Partial<InShadowingConfig>
 }
 
 export type TrackEventFunction = (

--- a/packages/botonic-plugin-flow-builder/src/utils.ts
+++ b/packages/botonic-plugin-flow-builder/src/utils.ts
@@ -1,6 +1,7 @@
 import { INPUT, Input, Session } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
+import { getFlowBuilderPlugin } from './helpers'
 import { BotonicPluginFlowBuilderOptions, ProcessEnvNodeEnvs } from './types'
 
 function getAccessTokenFromSession(session: Session): string {
@@ -50,4 +51,25 @@ function resolveObjectKey(object: any, key: string): any {
 
 export function inputHasTextData(input: Input): boolean {
   return input.data !== undefined && input.type === INPUT.TEXT
+}
+
+function isNluAllowed(
+  request: ActionRequest,
+  nluFlag: 'allowKeywords' | 'allowSmartIntents' | 'allowKnowledgeBases'
+): boolean {
+  const shadowing = Boolean(request.session._shadowing)
+  const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)
+  return !shadowing || (shadowing && flowBuilderPlugin.inShadowing[nluFlag])
+}
+
+export function isKeywordsAllowed(request: ActionRequest): boolean {
+  return isNluAllowed(request, 'allowKeywords')
+}
+
+export function isSmartIntentsAllowed(request: ActionRequest): boolean {
+  return isNluAllowed(request, 'allowSmartIntents')
+}
+
+export function isKnowledgeBasesAllowed(request: ActionRequest): boolean {
+  return isNluAllowed(request, 'allowKnowledgeBases')
 }

--- a/packages/botonic-plugin-flow-builder/src/utils.ts
+++ b/packages/botonic-plugin-flow-builder/src/utils.ts
@@ -2,7 +2,11 @@ import { INPUT, Input, Session } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
 import { getFlowBuilderPlugin } from './helpers'
-import { BotonicPluginFlowBuilderOptions, ProcessEnvNodeEnvs } from './types'
+import {
+  BotonicPluginFlowBuilderOptions,
+  InShadowingConfig,
+  ProcessEnvNodeEnvs,
+} from './types'
 
 function getAccessTokenFromSession(session: Session): string {
   if (!session._access_token) {
@@ -55,7 +59,7 @@ export function inputHasTextData(input: Input): boolean {
 
 function isNluAllowed(
   request: ActionRequest,
-  nluFlag: 'allowKeywords' | 'allowSmartIntents' | 'allowKnowledgeBases'
+  nluFlag: keyof InShadowingConfig
 ): boolean {
   const shadowing = Boolean(request.session._shadowing)
   const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -14,13 +14,18 @@ import BotonicPluginFlowBuilder, {
   FlowBuilderActionProps,
   FlowContent,
 } from '../../src'
-import { KnowledgeBaseFunction, TrackEventFunction } from '../../src/types'
+import {
+  InShadowingConfig,
+  KnowledgeBaseFunction,
+  TrackEventFunction,
+} from '../../src/types'
 
 interface FlowBuilderOptions {
   flow: any
   locale?: string
   trackEvent?: TrackEventFunction
   getKnowledgeBaseResponse?: KnowledgeBaseFunction
+  inShadowing?: Partial<InShadowingConfig>
 }
 
 export function createFlowBuilderPlugin({
@@ -28,6 +33,7 @@ export function createFlowBuilderPlugin({
   locale = 'en',
   trackEvent,
   getKnowledgeBaseResponse,
+  inShadowing,
 }: FlowBuilderOptions) {
   const flowBuilderPlugin = new BotonicPluginFlowBuilder({
     flow,
@@ -35,6 +41,7 @@ export function createFlowBuilderPlugin({
     getAccessToken: () => 'fake_token',
     trackEvent,
     getKnowledgeBaseResponse,
+    inShadowing,
   })
 
   // @ts-ignore
@@ -53,6 +60,7 @@ interface RequestArgs {
   provider?: ProviderType
   isFirstInteraction?: boolean
   extraData?: any
+  shadowing?: boolean
 }
 
 export function createRequest({
@@ -61,6 +69,7 @@ export function createRequest({
   provider = PROVIDER.WEBCHAT,
   isFirstInteraction = false,
   extraData = {},
+  shadowing = false,
 }: RequestArgs): PluginPreRequest {
   return {
     session: {
@@ -69,6 +78,7 @@ export function createRequest({
       organization_id: 'orgIdTest',
       bot: { id: 'bid1' },
       user: { provider, id: 'uid1', extra_data: extraData },
+      _shadowing: shadowing,
       __retries: 0,
       _access_token: 'fake_access_token',
       _hubtype_api: 'https://api.hubtype.com',

--- a/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
@@ -37,4 +37,36 @@ describe('Check the contents returned by the plugin using keywords', () => {
       expect(request.input.nluResolution).toEqual(undefined)
     }
   )
+
+  test('Keywords are not allowed by default when user is in handoff with shadowing', async () => {
+    const { contents, request } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: {
+        flow: basicFlow,
+      },
+      requestArgs: {
+        input: { data: 'hola', type: INPUT.TEXT },
+        shadowing: true,
+      },
+    })
+
+    expect((contents[0] as FlowText).text).toBe('fallback 1st message')
+    expect(request.input.nluResolution?.matchedValue).toEqual(undefined)
+  })
+
+  test('Keywords are allowed if inShadowing.allowKeywords is true when user is in handoff with shadowing', async () => {
+    const { contents, request } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: {
+        flow: basicFlow,
+        inShadowing: { allowKeywords: true },
+      },
+      requestArgs: {
+        input: { data: 'hola', type: INPUT.TEXT },
+        shadowing: true,
+      },
+    })
+
+    expect((contents[0] as FlowText).text).toBe('Welcome message')
+    expect(request.input.nluResolution?.type).toEqual('keyword')
+    expect(request.input.nluResolution?.matchedValue).toEqual('hola')
+  })
 })

--- a/packages/botonic-plugin-flow-builder/tests/knowledge-base.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/knowledge-base.test.ts
@@ -50,6 +50,71 @@ describe('Check the contents returned by the plugin when it use a knowledge base
     )
   })
 
+  test('Knowledge base response is not allowed when user is in handoff with shadowing', async () => {
+    const { contents } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: {
+        flow: knowledgeBaseTestFlow,
+        locale,
+        getKnowledgeBaseResponse: mockKnowledgeBaseResponse({
+          userInput,
+          answer:
+            'Flow Builder is a visual tool used to create and manage Conversational Apps. It allows users to design conversational flows by dragging and dropping elements, connecting them, and adding content to create conversational experiences. The tool is designed to enable non-technical users to create and manage Conversational Apps autonomously.',
+          hasKnowledge: true,
+          isFaithful: true,
+        }),
+      },
+      requestArgs: {
+        input: {
+          data: userInput,
+          type: INPUT.TEXT,
+        },
+        extraData: {
+          language,
+          country,
+        },
+        shadowing: true,
+      },
+    })
+
+    expect((contents[0] as FlowText).text).toBe('fallback 1')
+  })
+
+  test('Knowledge base response is allowed if inShadowing.allowKnowledgeBases is true when user is in handoff with shadowing', async () => {
+    const { contents } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: {
+        flow: knowledgeBaseTestFlow,
+        locale,
+        inShadowing: { allowKnowledgeBases: true },
+        getKnowledgeBaseResponse: mockKnowledgeBaseResponse({
+          userInput,
+          answer:
+            'Flow Builder is a visual tool used to create and manage Conversational Apps. It allows users to design conversational flows by dragging and dropping elements, connecting them, and adding content to create conversational experiences. The tool is designed to enable non-technical users to create and manage Conversational Apps autonomously.',
+          hasKnowledge: true,
+          isFaithful: true,
+        }),
+      },
+      requestArgs: {
+        input: {
+          data: userInput,
+          type: INPUT.TEXT,
+        },
+        extraData: {
+          language,
+          country,
+        },
+        shadowing: true,
+      },
+    })
+
+    expect((contents[0] as FlowText).text).toBe(
+      'message Spain before knowledge response'
+    )
+
+    expect((contents[1] as FlowText).text).toBe(
+      'Flow Builder is a visual tool used to create and manage Conversational Apps. It allows users to design conversational flows by dragging and dropping elements, connecting them, and adding content to create conversational experiences. The tool is designed to enable non-technical users to create and manage Conversational Apps autonomously.'
+    )
+  })
+
   test('When the knowledge base flow does not end with a knowledge base node', async () => {
     const userInput = 'What is Flow Builder?'
     const answer =

--- a/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
@@ -39,6 +39,46 @@ describe('Check the contents returned by the plugin when match a smart intent', 
     })
     expect(request.input.nluResolution).toEqual(undefined)
   })
+
+  test('Smart intent is not allowed by default when user is in handoff with shadowing', async () => {
+    const { contents, request } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: {
+        flow: smartIntentsFlow,
+      },
+      requestArgs: {
+        input: {
+          data: 'I want to add a bag to my flight booking',
+          type: INPUT.TEXT,
+        },
+        shadowing: true,
+      },
+    })
+
+    expect((contents[0] as FlowText).text).toBe('fallback 1st message')
+    expect(request.input.nluResolution).toEqual(undefined)
+  })
+
+  test('Smart intent is allowed if inShadowing.allowSmartIntents is true when user is in handoff with shadowing', async () => {
+    const { contents, request } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: {
+        flow: smartIntentsFlow,
+        inShadowing: { allowSmartIntents: true },
+      },
+      requestArgs: {
+        input: {
+          data: 'I want to add a bag to my flight booking',
+          type: INPUT.TEXT,
+        },
+        shadowing: true,
+      },
+    })
+
+    expect((contents[0] as FlowText).text).toBe(
+      'Message explaining how to add a bag'
+    )
+    expect(request.input.nluResolution?.type).toEqual('smart-intent')
+    expect(request.input.nluResolution?.matchedValue).toEqual('Add a bag')
+  })
 })
 
 describe('Check the contents returned by the plugin when no match a smart intent', () => {


### PR DESCRIPTION
## Description

Add config for handoff with shadowing to allow keywords, smart-intents and knowledge base. By default all this responses are disabled when create a case with shadow

