### PR TITLE
plugin-flow-builder: nluResolution available in first interaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25086,7 +25086,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.34.1",
+      "version": "0.34.2-alpha.0",
       "dependencies": {
         "@botonic/react": "^0.34.0",
         "axios": "^1.7.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24822,7 +24822,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -25086,7 +25086,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.34.2-alpha.1",
+      "version": "0.34.2",
       "dependencies": {
         "@botonic/react": "^0.34.0",
         "axios": "^1.7.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25086,7 +25086,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.34.2-alpha.0",
+      "version": "0.34.2-alpha.1",
       "dependencies": {
         "@botonic/react": "^0.34.0",
         "axios": "^1.7.9",

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -157,6 +157,7 @@ export interface NluResult {
 export enum NluType {
   Keyword = 'keyword',
   SmartIntent = 'smart-intent',
+  Intent = 'intent',
 }
 
 export interface Input extends Partial<NluResult> {
@@ -177,6 +178,7 @@ export interface Input extends Partial<NluResult> {
   nluResolution?: {
     type: NluType
     matchedValue: string
+    payload: string
   }
 }
 

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -178,7 +178,7 @@ export interface Input extends Partial<NluResult> {
   nluResolution?: {
     type: NluType
     matchedValue: string
-    payload: string
+    payload?: string
   }
 }
 

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to Botonic will be documented in this file.
 
 </details>
 
+## [0.34.2] - 2025-04-02
+
+- [PR-3004](https://github.com/hubtype/botonic/pull/3004/files): nluResolution available in first interaction
+
 ## [0.34.1] - 2025-04-02
 
 ### Added

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.34.1",
+  "version": "0.34.2-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.34.2-alpha.0",
+  "version": "0.34.2-alpha.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.34.2-alpha.1",
+  "version": "0.34.2",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -100,9 +100,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     })
 
     const checkUserTextInput =
-      inputHasTextData(request.input) &&
-      !request.input.payload &&
-      !request.session.is_first_interaction
+      inputHasTextData(request.input) && !request.input.payload
 
     if (checkUserTextInput) {
       const locale = this.getLocale(request.session)

--- a/packages/botonic-plugin-flow-builder/src/user-input/intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/intent.ts
@@ -19,7 +19,7 @@ export async function getIntentNodeByInput(
       const targetPayload = cmsApi.getPayload(intentNode.target)
 
       request.input.nluResolution = {
-        type: NluType.Keyword,
+        type: NluType.Intent,
         matchedValue: request.input.intent,
         payload: targetPayload,
       }

--- a/packages/botonic-plugin-flow-builder/src/user-input/intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/intent.ts
@@ -1,3 +1,4 @@
+import { NluType } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
 import { FlowBuilderApi } from '../api'
@@ -15,6 +16,13 @@ export async function getIntentNodeByInput(
     await trackIntentEvent(request, intentNode)
 
     if (isIntentValid(intentNode, request, cmsApi)) {
+      const targetPayload = cmsApi.getPayload(intentNode.target)
+
+      request.input.nluResolution = {
+        type: NluType.Keyword,
+        matchedValue: intentNode.content.title,
+        payload: targetPayload,
+      }
       return intentNode
     }
   }

--- a/packages/botonic-plugin-flow-builder/src/user-input/intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/intent.ts
@@ -20,7 +20,7 @@ export async function getIntentNodeByInput(
 
       request.input.nluResolution = {
         type: NluType.Keyword,
-        matchedValue: intentNode.content.title,
+        matchedValue: request.input.intent,
         payload: targetPayload,
       }
       return intentNode

--- a/packages/botonic-plugin-flow-builder/src/user-input/keyword.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/keyword.ts
@@ -36,9 +36,12 @@ export class KeywordMatcher {
     if (!keywordNode || !this.matchedKeyword) {
       return undefined
     }
+    const targetPayload = this.cmsApi.getPayload(keywordNode.target)
+
     this.request.input.nluResolution = {
       type: NluType.Keyword,
       matchedValue: this.matchedKeyword,
+      payload: targetPayload,
     }
     await this.trackKeywordEvent()
     return keywordNode

--- a/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
@@ -46,11 +46,15 @@ export class SmartIntentsApi {
         smartIntentNode =>
           smartIntentNode.content.title === response.data.smart_intent_title
       )
+
       if (smartIntentNode) {
+        const targetPayload = this.cmsApi.getPayload(smartIntentNode.target)
         this.currentRequest.input.nluResolution = {
           type: NluType.SmartIntent,
           matchedValue: smartIntentNode.content.title,
+          payload: targetPayload,
         }
+
         await trackEvent(this.currentRequest, EventAction.IntentSmart, {
           nluIntentSmartTitle: response.data.smart_intent_title,
           nluIntentSmartNumUsed: response.data.smart_intents_used.length,
@@ -60,6 +64,7 @@ export class SmartIntentsApi {
           flowId: smartIntentNode.flow_id,
           flowNodeId: smartIntentNode.id,
         })
+
         return smartIntentNode
       }
     } catch (e) {

--- a/packages/botonic-plugin-flow-builder/tests/first-interaction.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/first-interaction.test.ts
@@ -137,7 +137,6 @@ describe('Check the contents returned by the plugin in first interaction with kn
         isFirstInteraction: true,
       },
     })
-    console.log({ contents })
 
     expect((contents[0] as FlowText).text).toBe('Welcome')
     expect(contents.length).toBe(4)

--- a/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/keyword.test.ts
@@ -25,10 +25,8 @@ describe('Check the contents returned by the plugin using keywords', () => {
         })
 
       expect((contents[0] as FlowText).text).toBe('Welcome message')
-      expect(request.input.nluResolution).toEqual({
-        type: 'keyword',
-        matchedValue: keyword,
-      })
+      expect(request.input.nluResolution?.type).toEqual('keyword')
+      expect(request.input.nluResolution?.matchedValue).toEqual(keyword)
 
       flowBuilderPluginPost({
         ...request,

--- a/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
@@ -28,10 +28,8 @@ describe('Check the contents returned by the plugin when match a smart intent', 
     expect((contents[0] as FlowText).text).toBe(
       'Message explaining how to add a bag'
     )
-    expect(request.input.nluResolution).toEqual({
-      type: 'smart-intent',
-      matchedValue: 'Add a bag',
-    })
+    expect(request.input.nluResolution?.type).toEqual('smart-intent')
+    expect(request.input.nluResolution?.matchedValue).toEqual('Add a bag')
 
     flowBuilderPluginPost({
       ...request,


### PR DESCRIPTION
## Description

In order to have available the detection of keywords, smart-intents and intents-babel in the first interaction, as long as the user input is of text type and there is no payload, a match with keywords, smart-intents or intents-babel will be searched. This information is stored in the request.inpu.nluResolution together with the payload pointing to the matched node.

In this way it is no longer necessary to look for the match within the action when it is the first interaction, since the necessary payload will be stored in the input.nluResolution.payload.


## Testing

Update tests
