### PR TITLE
plugin-flow-builder: no need to receive the locale in any function #BLT-1593 

### DIFF
--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Botonic will be documented in this file.
 ### Added
 
 - [PR-3008](https://github.com/hubtype/botonic/pull/3008/files): Use new user fields and default_locale_code
+- [PR-3013](https://github.com/hubtype/botonic/pull/3013): no need to receive the locale in any function
 
 ### Changed
 

--- a/packages/botonic-plugin-flow-builder/src/action/fallback.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/fallback.ts
@@ -9,13 +9,10 @@ export async function getContentsByFallback({
   cmsApi,
   flowBuilderPlugin,
   request,
-  resolvedLocale,
 }: FlowBuilderContext): Promise<FlowContent[]> {
   const fallbackNode = await getFallbackNode(cmsApi, request)
-  const fallbackContents = await flowBuilderPlugin.getContentsByNode(
-    fallbackNode,
-    resolvedLocale
-  )
+  const fallbackContents =
+    await flowBuilderPlugin.getContentsByNode(fallbackNode)
 
   return fallbackContents
 }

--- a/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
@@ -10,9 +10,8 @@ import { getContentsByPayload } from './payload'
 export async function getContentsByFirstInteraction(
   context: FlowBuilderContext
 ): Promise<FlowContent[]> {
-  const { flowBuilderPlugin, request, resolvedLocale } = context
-  const firstInteractionContents =
-    await flowBuilderPlugin.getStartContents(resolvedLocale)
+  const { flowBuilderPlugin, request } = context
+  const firstInteractionContents = await flowBuilderPlugin.getStartContents()
 
   // If the first interaction has a FlowBotAction, it should be the last content
   // and avoid to render the match with keywords,intents or knowledge base
@@ -54,7 +53,6 @@ async function getContentsByUserInput({
 
     const hasRepeatedContent = await checkRepeatedContents(
       flowBuilderPlugin,
-      resolvedLocale,
       contentsByKeywordsOrIntents
     )
 
@@ -85,10 +83,9 @@ function getConversationStartId(cmsApi: FlowBuilderApi) {
 
 async function checkRepeatedContents(
   flowBuilderPlugin: BotonicPluginFlowBuilder,
-  resolvedLocale: string,
   contentsByKeywordsOrIntents: FlowContent[]
 ) {
-  const startContents = await flowBuilderPlugin.getStartContents(resolvedLocale)
+  const startContents = await flowBuilderPlugin.getStartContents()
   const contentIds = new Set(
     contentsByKeywordsOrIntents.map(content => content.id)
   )

--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -121,8 +121,7 @@ function getContext(
 ): FlowBuilderContext {
   const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)
   const cmsApi = flowBuilderPlugin.cmsApi
-  const locale = flowBuilderPlugin.getLocale(request.session)
-  const resolvedLocale = flowBuilderPlugin.cmsApi.getResolvedLocale(locale)
+  const resolvedLocale = flowBuilderPlugin.cmsApi.getResolvedLocale()
   return {
     cmsApi,
     flowBuilderPlugin,

--- a/packages/botonic-plugin-flow-builder/src/action/knowledge-bases.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/knowledge-bases.ts
@@ -15,7 +15,6 @@ export async function getContentsByKnowledgeBase({
   cmsApi,
   flowBuilderPlugin,
   request,
-  resolvedLocale,
 }: FlowBuilderContext): Promise<FlowContent[]> {
   if (isKnowledgeBasesAllowed(request)) {
     const startNodeKnowledgeBaseFlow = cmsApi.getStartNodeKnowledgeBaseFlow()
@@ -25,8 +24,7 @@ export async function getContentsByKnowledgeBase({
     }
 
     const contents = await flowBuilderPlugin.getContentsByNode(
-      startNodeKnowledgeBaseFlow,
-      resolvedLocale
+      startNodeKnowledgeBaseFlow
     )
 
     const knowledgeBaseContent = contents.find(

--- a/packages/botonic-plugin-flow-builder/src/action/payload.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/payload.ts
@@ -6,7 +6,6 @@ export async function getContentsByPayload({
   cmsApi,
   flowBuilderPlugin,
   request,
-  resolvedLocale,
   contentID,
 }: FlowBuilderContext): Promise<FlowContent[]> {
   const id = contentID
@@ -15,7 +14,7 @@ export async function getContentsByPayload({
   const targetNode = id ? cmsApi.getNodeById<HtNodeWithContent>(id) : undefined
 
   if (targetNode) {
-    return await flowBuilderPlugin.getContentsByNode(targetNode, resolvedLocale)
+    return await flowBuilderPlugin.getContentsByNode(targetNode)
   }
 
   return []

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -207,11 +207,29 @@ export class FlowBuilderApi {
   }
 
   getResolvedLocale(): string {
-    const locale = this.request.getSystemLocale()
-    if (locale && this.flow.locales.find(flowLocale => flowLocale === locale)) {
+    const systemLocale = this.request.getSystemLocale()
+
+    const locale = this.resolveAsLocale(systemLocale)
+    if (locale) {
       return locale
     }
 
+    const language = this.resolveAsLanguage(systemLocale)
+    if (language) {
+      return language
+    }
+
+    return this.resolveAsDefaultLocale()
+  }
+
+  private resolveAsLocale(locale: string): string | undefined {
+    if (this.flow.locales.find(flowLocale => flowLocale === locale)) {
+      return locale
+    }
+    return undefined
+  }
+
+  private resolveAsLanguage(locale?: string): string | undefined {
     const language = locale?.split('-')[0]
     if (
       language &&
@@ -220,11 +238,13 @@ export class FlowBuilderApi {
       console.log(`locale: ${locale} has been resolved as ${language}`)
       return language
     }
+    return undefined
+  }
 
+  private resolveAsDefaultLocale(): string {
     console.log(
       `Resolve locale with default locale: ${this.flow.default_locale_code}`
     )
-
     return this.flow.default_locale_code || 'en'
   }
 }

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -206,7 +206,8 @@ export class FlowBuilderApi {
     return this.flow.is_knowledge_base_active || false
   }
 
-  getResolvedLocale(locale?: string): string {
+  getResolvedLocale(): string {
+    const locale = this.request.getSystemLocale()
     if (locale && this.flow.locales.find(flowLocale => flowLocale === locale)) {
       return locale
     }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-handoff.tsx
@@ -55,8 +55,8 @@ export class FlowHandoff extends ContentFieldsBase {
     }
 
     if (this.queue) {
-      const language = request.session.user.extra_data.language
-      const country = request.session.user.extra_data.country
+      const language = request.getSystemLocale()
+      const country = request.getUserCountry()
 
       handOffBuilder.withQueue(this.queue.id)
       handOffBuilder.withBotEvent({

--- a/packages/botonic-plugin-flow-builder/src/functions/conditional-country.ts
+++ b/packages/botonic-plugin-flow-builder/src/functions/conditional-country.ts
@@ -9,6 +9,6 @@ export function conditionalCountry({
   request,
   results,
 }: ConditionalCountryArgs): string {
-  const country = request.session.user.extra_data.country
+  const country = request.getUserCountry()
   return results.find(result => result === country) || 'default'
 }

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -21,7 +21,7 @@ export interface BotonicPluginFlowBuilderOptions<
   jsonVersion?: FlowBuilderJSONVersion
   flow?: HtFlowBuilderData
   customFunctions?: Record<any, any>
-  getLocale: (session: Session) => string
+  getLocale?: (request: BotContext<TPlugins, TExtraData>) => string
   getAccessToken: () => string
   trackEvent?: TrackEventFunction<TPlugins, TExtraData>
   getKnowledgeBaseResponse?: KnowledgeBaseFunction<TPlugins, TExtraData>

--- a/packages/botonic-plugin-flow-builder/tests/conditional-country.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/conditional-country.test.ts
@@ -21,9 +21,10 @@ describe('Check the contents returned by the plugin after conditional country no
         flowBuilderOptions: { flow: basicFlow },
         requestArgs: {
           input: { data: 'countryConditional', type: INPUT.TEXT },
-          extraData: {
-            language: 'en',
+          user: {
+            locale: 'en',
             country: countryISO,
+            systemLocale: 'en',
           },
         },
       })

--- a/packages/botonic-plugin-flow-builder/tests/first-interaction.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/first-interaction.test.ts
@@ -87,16 +87,15 @@ describe('Check the contents returned by the plugin in first interaction with kn
   beforeEach(() => mockSmartIntent('Other'))
   test('The start contents are displayed followed by more contents obtained from knowledge base', async () => {
     const userInput = 'What is Flow Builder?'
-    const language = 'es'
+    const locale = 'es'
     const country = 'ES'
-    const locale = `${language}-${country}`
+    const systemLocale = 'es-ES'
     const answer =
       'Flow Builder is a visual tool used to create and manage Conversational Apps. It allows users to design conversational flows by dragging and dropping elements, connecting them, and adding content to create conversational experiences. The tool is designed to enable non-technical users to create and manage Conversational Apps autonomously.'
 
     const { contents } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: {
         flow: knowledgeBaseTestFlow,
-        locale,
         getKnowledgeBaseResponse: mockKnowledgeBaseResponse({
           userInput,
           answer,
@@ -109,9 +108,10 @@ describe('Check the contents returned by the plugin in first interaction with kn
           data: userInput,
           type: INPUT.TEXT,
         },
-        extraData: {
-          language,
+        user: {
+          locale,
           country,
+          systemLocale,
         },
         isFirstInteraction: true,
       },

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -71,7 +71,6 @@ export function createRequest({
   extraData = {},
   shadowing = false,
 }: RequestArgs): PluginPreRequest {
-  console.log({ user })
   return {
     session: {
       is_first_interaction: isFirstInteraction,
@@ -160,11 +159,6 @@ export async function createFlowBuilderPluginAndGetContents({
     },
   })
 
-  console.log(
-    'UTILS request locale and country',
-    request.getSystemLocale(),
-    request.getUserCountry()
-  )
   const { contents } = await getContentsAfterPreAndBotonicInit(
     request,
     flowBuilderPlugin

--- a/packages/botonic-plugin-flow-builder/tests/knowledge-base.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/knowledge-base.test.ts
@@ -12,15 +12,14 @@ describe('Check the contents returned by the plugin when it use a knowledge base
   process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
 
   const userInput = 'What is Flow Builder?'
-  const language = 'es'
+  const locale = 'es'
   const country = 'ES'
-  const locale = `${language}-${country}`
+  const systemLocale = 'es'
 
   test('When the knowledge base answer is correct, (with knowledge and without hallucinations) the answer is used to display a knowledge base node', async () => {
     const { contents } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: {
         flow: knowledgeBaseTestFlow,
-        locale,
         getKnowledgeBaseResponse: mockKnowledgeBaseResponse({
           userInput,
           answer:
@@ -34,9 +33,10 @@ describe('Check the contents returned by the plugin when it use a knowledge base
           data: userInput,
           type: INPUT.TEXT,
         },
-        extraData: {
-          language,
+        user: {
+          locale,
           country,
+          systemLocale,
         },
       },
     })
@@ -54,7 +54,6 @@ describe('Check the contents returned by the plugin when it use a knowledge base
     const { contents } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: {
         flow: knowledgeBaseTestFlow,
-        locale,
         getKnowledgeBaseResponse: mockKnowledgeBaseResponse({
           userInput,
           answer:
@@ -68,9 +67,10 @@ describe('Check the contents returned by the plugin when it use a knowledge base
           data: userInput,
           type: INPUT.TEXT,
         },
-        extraData: {
-          language,
+        user: {
+          locale,
           country,
+          systemLocale,
         },
         shadowing: true,
       },
@@ -83,7 +83,6 @@ describe('Check the contents returned by the plugin when it use a knowledge base
     const { contents } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: {
         flow: knowledgeBaseTestFlow,
-        locale,
         inShadowing: { allowKnowledgeBases: true },
         getKnowledgeBaseResponse: mockKnowledgeBaseResponse({
           userInput,
@@ -98,9 +97,10 @@ describe('Check the contents returned by the plugin when it use a knowledge base
           data: userInput,
           type: INPUT.TEXT,
         },
-        extraData: {
-          language,
+        user: {
+          locale,
           country,
+          systemLocale,
         },
         shadowing: true,
       },
@@ -123,7 +123,6 @@ describe('Check the contents returned by the plugin when it use a knowledge base
     const { contents } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: {
         flow: knowledgeBaseTestFlow,
-        locale: 'es-FR',
         getKnowledgeBaseResponse: mockKnowledgeBaseResponse({
           userInput,
           answer,
@@ -136,9 +135,10 @@ describe('Check the contents returned by the plugin when it use a knowledge base
           data: userInput,
           type: INPUT.TEXT,
         },
-        extraData: {
-          language: 'es',
+        user: {
+          locale: 'es',
           country: 'FR',
+          systemLocale: 'es-FR',
         },
       },
     })
@@ -152,7 +152,6 @@ describe('Check the contents returned by the plugin when it use a knowledge base
     const { contents } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: {
         flow: knowledgeBaseTestFlow,
-        locale,
         getKnowledgeBaseResponse: mockKnowledgeBaseResponse({
           userInput,
           answer: 'This answer is incorrect',
@@ -165,9 +164,10 @@ describe('Check the contents returned by the plugin when it use a knowledge base
           data: userInput,
           type: INPUT.TEXT,
         },
-        extraData: {
-          language,
+        user: {
+          locale,
           country,
+          systemLocale,
         },
       },
     })

--- a/packages/botonic-plugin-flow-builder/tests/tracking/track-knowledge-base.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/tracking/track-knowledge-base.test.ts
@@ -22,7 +22,6 @@ describe('Check tracked events when a bot generates a response using a knowledge
     await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: {
         flow: knowledgeBaseTestFlow,
-        locale,
         trackEvent: trackEventMock,
         getKnowledgeBaseResponse: mockKnowledgeBaseResponse({
           userInput,
@@ -37,9 +36,10 @@ describe('Check tracked events when a bot generates a response using a knowledge
           data: userInput,
           type: INPUT.TEXT,
         },
-        extraData: {
-          language,
+        user: {
+          locale,
           country,
+          systemLocale: locale,
         },
       },
     })

--- a/packages/botonic-react/src/util/webchat.ts
+++ b/packages/botonic-react/src/util/webchat.ts
@@ -51,15 +51,11 @@ export const initSession = (
 }
 
 export function updateUserLocaleAndCountry(user: Partial<ClientUser>) {
-  const locale = getLocale(user)
-  const country = getCountry(user)
+  user.locale = getLocale(user)
+  user.country = getCountry(user)
+  user.system_locale = getSystemLocale(user)
 
-  return {
-    ...user,
-    locale,
-    country,
-    system_locale: locale,
-  }
+  return user
 }
 
 function getLocale(user: Partial<ClientUser>) {
@@ -82,6 +78,13 @@ function getCountry(user: Partial<ClientUser>) {
   return user.extra_data?.country
     ? (user.extra_data?.country as string)
     : userCountry
+}
+
+function getSystemLocale(user: Partial<ClientUser>) {
+  if (user.system_locale) {
+    return user.system_locale
+  }
+  return getLocale(user)
 }
 
 export const shouldKeepSessionOnReload = ({

--- a/packages/botonic-react/src/webchat/webchat.tsx
+++ b/packages/botonic-react/src/webchat/webchat.tsx
@@ -248,8 +248,7 @@ const Webchat = forwardRef<WebchatRef | null, WebchatProps>((props, ref) => {
       setTimeout(() => {
         if (typeof props.onInit === 'function') {
           props.onInit()
-          const user = updateUserLocaleAndCountry(session.user)
-          updateSession({ ...session, user })
+          session.user = updateUserLocaleAndCountry(session.user)
         }
       }, 100)
     }
@@ -453,6 +452,7 @@ const Webchat = forwardRef<WebchatRef | null, WebchatProps>((props, ref) => {
   */
 
   const updateSessionWithUser = (userToUpdate: any) => {
+    console.log('userToUpdate', userToUpdate)
     updateSession(merge(webchatState.session, { user: userToUpdate }))
   }
 


### PR DESCRIPTION
## Description

plugin-flow-builder does not need to receive the locale in any function. Always use system_locale from session to generate contents.

## Testing

Update all tests
