### PR TITLE
Some fixes before 0.35.0

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -57,7 +57,6 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   private functions: Record<any, any>
   private currentRequest: PluginPreRequest
   public getAccessToken: (session: Session) => string
-  public getLocale: (request: BotContext) => string
   public trackEvent?: TrackEventFunction
   public getKnowledgeBaseResponse?: KnowledgeBaseFunction
   public smartIntentsConfig: SmartIntentsInferenceConfig
@@ -71,12 +70,6 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     this.apiUrl = options.apiUrl || FLOW_BUILDER_API_URL_PROD
     this.jsonVersion = options.jsonVersion || FlowBuilderJSONVersion.LATEST
     this.flow = options.flow
-    this.getLocale =
-      typeof options.getLocale === 'function'
-        ? options.getLocale
-        : (request: BotContext) => {
-            return request.getSystemLocale()
-          }
     this.getAccessToken = resolveGetAccessToken(options.getAccessToken)
     this.trackEvent = options.trackEvent
     this.getKnowledgeBaseResponse = options.getKnowledgeBaseResponse

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -21,7 +21,6 @@ export interface BotonicPluginFlowBuilderOptions<
   jsonVersion?: FlowBuilderJSONVersion
   flow?: HtFlowBuilderData
   customFunctions?: Record<any, any>
-  getLocale?: (request: BotContext<TPlugins, TExtraData>) => string
   getAccessToken: () => string
   trackEvent?: TrackEventFunction<TPlugins, TExtraData>
   getKnowledgeBaseResponse?: KnowledgeBaseFunction<TPlugins, TExtraData>

--- a/packages/botonic-plugin-google-translation/src/index.ts
+++ b/packages/botonic-plugin-google-translation/src/index.ts
@@ -38,7 +38,7 @@ export default class BotonicPluginGoogleTranslate implements Plugin {
           request.input.translations = translations
         }
         const detectedLanguage = await this.languageDetector.detect(text)
-        request.input.language = detectedLanguage || request.session.__locale
+        request.input.language = detectedLanguage || request.getUserLocale()
       }
     } catch (e) {
       console.error(

--- a/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
@@ -50,7 +50,6 @@ export function createRequest(args?: RequestArgs): BotContext<ResolvedPlugins> {
       message_id: 'testMessageId',
     },
     lastRoutePath: '',
-    getString: () => '',
     getUserCountry: () => args?.country || 'ES',
     getUserLocale: () => args?.language || 'es',
     getSystemLocale: () => args?.language || 'es',

--- a/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
@@ -1,6 +1,12 @@
-import { BotRequest, INPUT, PROVIDER, ProviderType } from '@botonic/core'
+import {
+  BotContext,
+  INPUT,
+  PROVIDER,
+  ProviderType,
+  ResolvedPlugins,
+} from '@botonic/core'
 
-import BotonicPluginHubtypeAnalytics from '../../src'
+import BotonicPluginHubtypeAnalytics from '../../src/index'
 
 interface RequestArgs {
   language?: string
@@ -16,7 +22,7 @@ export function getRequestData(args?: RequestArgs) {
   return hubtypeAnalyticsPlugin.getRequestData(request)
 }
 
-export function createRequest(args?: RequestArgs): BotRequest {
+export function createRequest(args?: RequestArgs): BotContext<ResolvedPlugins> {
   return {
     session: {
       is_first_interaction: args?.isFirstInteraction || false,
@@ -24,12 +30,12 @@ export function createRequest(args?: RequestArgs): BotRequest {
       organization_id: 'orgIdTest',
       bot: { id: 'bid1' },
       user: {
+        locale: args?.language || 'es',
+        country: args?.country || 'ES',
+        system_locale: args?.language || 'es',
         provider: args?.provider || PROVIDER.WEBCHAT,
         id: args?.chatId || 'chatIdTest',
-        extra_data: {
-          country: args?.country || 'ES',
-          language: args?.language || 'es',
-        },
+        extra_data: {},
       },
       __retries: 0,
       _access_token: 'fake_access_token',
@@ -44,5 +50,16 @@ export function createRequest(args?: RequestArgs): BotRequest {
       message_id: 'testMessageId',
     },
     lastRoutePath: '',
+    getString: () => '',
+    getUserCountry: () => args?.country || 'ES',
+    getUserLocale: () => args?.language || 'es',
+    getSystemLocale: () => args?.language || 'es',
+    setUserCountry: () => {},
+    setUserLocale: () => {},
+    setSystemLocale: () => {},
+    defaultDelay: 0,
+    defaultTyping: 0,
+    params: {},
+    plugins: {},
   }
 }

--- a/packages/botonic-plugin-knowledge-bases/src/index.ts
+++ b/packages/botonic-plugin-knowledge-bases/src/index.ts
@@ -1,4 +1,4 @@
-import type { BotRequest, Plugin, PluginPreRequest } from '@botonic/core'
+import type { BotContext, Plugin, PluginPreRequest } from '@botonic/core'
 import { AxiosResponse } from 'axios'
 
 import {
@@ -24,7 +24,7 @@ export default class BotonicPluginKnowledgeBases implements Plugin {
   }
 
   async getInference(
-    request: BotRequest,
+    request: BotContext,
     sources: string[],
     instructions: string,
     messageId: string,
@@ -51,7 +51,7 @@ export default class BotonicPluginKnowledgeBases implements Plugin {
 
   async getTestInference(
     authToken: string,
-    request: BotRequest,
+    request: BotContext,
     instructions: string,
     sources: string[]
   ): Promise<KnowledgeBaseResponse> {
@@ -69,7 +69,7 @@ export default class BotonicPluginKnowledgeBases implements Plugin {
 
   async getInferenceV1(
     authToken: string,
-    request: BotRequest,
+    request: BotContext,
     sources: string[]
   ): Promise<KnowledgeBaseResponse> {
     const response = await this.apiService.inferenceV1(

--- a/packages/botonic-react/src/webchat/tracking.ts
+++ b/packages/botonic-react/src/webchat/tracking.ts
@@ -1,8 +1,67 @@
+import { useContext } from 'react'
+import { v7 as uuidv7 } from 'uuid'
+
+import { ActionRequest } from '../index-types'
+import { WebchatContext } from './context'
+
 export enum EventAction {
   FeedbackKnowledgebase = 'feedback_knowledgebase',
+}
+interface TrackKnowledgebaseFeedbackArgs {
+  messageId: string
+  isUseful: boolean
+  botInteractionId?: string
+  inferenceId?: string
 }
 
 export enum FeedbackOption {
   ThumbsUp = 'thumbsUp',
   ThumbsDown = 'thumbsDown',
+}
+
+export function useTracking() {
+  const { webchatState, trackEvent } = useContext(WebchatContext)
+
+  const getRequest = () => {
+    const request = {
+      session: {
+        ...webchatState.session,
+      },
+      getUserCountry: () => webchatState.session.user?.country || '',
+      getUserLocale: () => webchatState.session.user?.locale || '',
+      getSystemLocale: () => {
+        return webchatState.session.user?.system_locale || ''
+      },
+    } as unknown as ActionRequest
+
+    return request
+  }
+
+  const trackKnowledgebaseFeedback = async ({
+    messageId,
+    isUseful,
+    botInteractionId,
+    inferenceId,
+  }: TrackKnowledgebaseFeedbackArgs) => {
+    if (!trackEvent) {
+      return
+    }
+
+    const args = {
+      knowledgebaseInferenceId: inferenceId,
+      feedbackBotInteractionId: botInteractionId,
+      feedbackTargetId: messageId,
+      feedbackGroupId: uuidv7(),
+      possibleOptions: [FeedbackOption.ThumbsDown, FeedbackOption.ThumbsUp],
+      possibleValues: [0, 1],
+      option: isUseful ? FeedbackOption.ThumbsUp : FeedbackOption.ThumbsDown,
+      value: isUseful ? 1 : 0,
+    }
+
+    const request = getRequest()
+
+    await trackEvent(request, EventAction.FeedbackKnowledgebase, args)
+  }
+
+  return { trackKnowledgebaseFeedback }
 }


### PR DESCRIPTION
## Description

In this PR there are changes in several plugins that are necessary for the next version (0.35.0)

**@botonic/plugin-hubtype-analytics**
- Uses BotContext instead of BotRequest
- Remove the optional functions that could be passed in through the constructor to obtain the locale and the country

**@botonic/react**
- Creates a hook for the feedback tracking function of a knowledge base message. Inside this hook the request is recreated as a BotContext  (in the frontend there is no BotContext) which is what the hubtype analytics plugin needs to receive.

**@botonic/plugin-flow-builder**
- Removes the getLocale function that was passed through the constructor

**@botonic/plugin-knowledge-bases**
- use BotContext instead of BotRequest

**@botonic/plugin-google-translation**
- use getUserLocale instead of __locale