### PR TITLE
feat(botonic-cli): Use v3 of users' endpoints and sign-up specific endpoint, and simplify the Me type

### DIFF
--- a/packages/botonic-cli/src/botonic-api-service.ts
+++ b/packages/botonic-cli/src/botonic-api-service.ts
@@ -248,7 +248,7 @@ export class BotonicAPIService {
     const accessToken = this.getOauth().access_token
     this.setHeaders(accessToken)
 
-    const meResponse = await this.apiGet<Me>({ path: 'users/me' })
+    const meResponse = await this.getMe()
     if (meResponse) {
       this.me = meResponse.data
     }
@@ -261,7 +261,7 @@ export class BotonicAPIService {
     campaign: any
   ): Promise<any> {
     const signupData = { email, password, org_name: orgName, campaign }
-    return this.apiPost({ path: 'users/', body: signupData })
+    return this.apiPost({ path: 'sign-up/', body: signupData })
   }
 
   async createBot(botName: string): Promise<AxiosPromise> {
@@ -278,8 +278,8 @@ export class BotonicAPIService {
     return resp
   }
 
-  private async getMe(): AxiosPromise<Me> {
-    return this.apiGet({ path: 'users/me/' })
+  private async getMe(): AxiosResponse<Me> {
+    return this.apiGet({ path: 'users/me/', apiVersion: 'v3' })
   }
 
   async getBots(): Promise<AxiosResponse<PaginatedResponse<BotListItem>, any>> {

--- a/packages/botonic-cli/src/botonic-api-service.ts
+++ b/packages/botonic-cli/src/botonic-api-service.ts
@@ -278,7 +278,7 @@ export class BotonicAPIService {
     return resp
   }
 
-  private async getMe(): AxiosResponse<Me> {
+  private async getMe(): Promise<AxiosResponse<Me>> {
     return this.apiGet({ path: 'users/me/', apiVersion: 'v3' })
   }
 

--- a/packages/botonic-cli/src/interfaces.ts
+++ b/packages/botonic-cli/src/interfaces.ts
@@ -20,27 +20,11 @@ export interface OAuth {
 
 export interface Me {
   id: string
-  username: string
   email: string
   first_name: string
   last_name: string
-  role: string
-  pic: string
-  queues: string[]
-  projects: string[]
-  must_change_password: boolean
-  created_by_id: string
-  status: string
   organization_id: string
-  notifications_new_case: boolean
-  notifications_new_message: boolean
-  notifications_duration: number
-  is_staff: boolean
-  fb_info: string
-  is_read_only: boolean
-  preferred_product: string
   campaign: string
-  managers_settings_json: any
 }
 
 export interface AnalyticsInfo {


### PR DESCRIPTION
## Description

The v1 and v2 of users endpoints are deprecated.
Ideally we should have a `v?/users/me/` in the external API, but at least it allows to remove the v1 and v2 endpoitns from the back end.
Also it uses the /v1/sign-up/ endpoint for creation

It removes all teh unnecessary attributes from Me interface to leave only the ones that makes sense for botonic.

## Context

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
