### PR TITLE
WIP: load initialState from localStorage

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -57,7 +57,10 @@ export class FlowBuilderApi {
       headers: { Authorization: `Bearer ${token}` },
     })
     this.request.session.organization_id = response.data.organization_id
-    this.request.session.bot.id = response.data.bot_id
+    this.request.session.bot = {
+      ...this.request.session.bot,
+      id: response.data.bot_id,
+    }
   }
 
   getNodeByFlowId(id: string): HtNodeWithContent {

--- a/packages/botonic-react/src/index-types.ts
+++ b/packages/botonic-react/src/index-types.ts
@@ -18,6 +18,7 @@ import {
   WebchatSettingsProps,
 } from './components'
 import { CloseWebviewOptions } from './contexts'
+import { DevSettings } from './webchat/context/types'
 import { UseWebchat } from './webchat/context/use-webchat'
 import {
   CoverComponentOptions,
@@ -90,7 +91,7 @@ export interface WebchatArgs {
   defaultTyping?: number
   storage?: Storage | null
   storageKey?: string
-  onInit?: (app: WebchatApp, args: any) => void
+  onInit?: (app: WebchatApp, args: any) => Promise<void>
   onOpen?: (app: WebchatApp, args: any) => void
   onClose?: (app: WebchatApp, args: any) => void
   onMessage?: (app: WebchatApp, message: WebchatMessage) => void
@@ -102,18 +103,18 @@ export interface WebchatArgs {
 }
 
 export interface WebchatProps {
-  webchatHooks?: UseWebchat
+  webchatHooks: UseWebchat
   initialSession?: any
-  initialDevSettings?: any
+  initialDevSettings?: DevSettings
   onStateChange: (args: OnStateChangeArgs) => void
 
   shadowDOM?: any
   theme?: WebchatTheme
-  storage?: Storage | null
-  storageKey?: string | (() => string)
+  storage: Storage
+  storageKey: string
   defaultDelay?: number
   defaultTyping?: number
-  onInit?: (args?: any) => void
+  onInit?: (args?: any) => Promise<void>
   onOpen?: (args?: any) => void
   onClose?: (args?: any) => void
   onUserInput(args: OnUserInputArgs): Promise<void>

--- a/packages/botonic-react/src/util/webchat.ts
+++ b/packages/botonic-react/src/util/webchat.ts
@@ -90,7 +90,7 @@ function getSystemLocale(user: Partial<ClientUser>) {
 export const shouldKeepSessionOnReload = ({
   initialDevSettings,
   devSettings,
-}) => !initialDevSettings || (devSettings && devSettings.keepSessionOnReload)
+}) => !initialDevSettings || devSettings?.keepSessionOnReload
 
 //TODO: Review param serverConfig if is of type ServerConfig this never have errorMessage
 export const getServerErrorMessage = serverConfig => {

--- a/packages/botonic-react/src/webchat-app.tsx
+++ b/packages/botonic-react/src/webchat-app.tsx
@@ -27,6 +27,7 @@ import {
   WebchatTheme,
 } from './webchat/theme/types'
 import { Webchat } from './webchat/webchat'
+import { WebchatHooks } from './webchat/webchat-hooks'
 
 export class WebchatApp {
   public theme?: Partial<WebchatTheme>
@@ -41,9 +42,9 @@ export class WebchatApp {
   public shadowDOM?: boolean | (() => boolean)
   public defaultDelay?: number
   public defaultTyping?: number
-  public storage?: Storage | null
+  public storage: Storage
   public storageKey: string
-  public onInit?: (app: WebchatApp, args: any) => void
+  public onInit?: (app: WebchatApp, args: any) => Promise<void>
   public onOpen?: (app: WebchatApp, args: any) => void
   public onClose?: (app: WebchatApp, args: any) => void
   public onMessage?: (app: WebchatApp, message: WebchatMessage) => void
@@ -107,7 +108,7 @@ export class WebchatApp {
     this.hostId = hostId || WEBCHAT.DEFAULTS.HOST_ID
     this.defaultDelay = defaultDelay
     this.defaultTyping = defaultTyping
-    this.storage = storage === undefined ? localStorage : storage
+    this.storage = !storage ? localStorage : storage
     this.storageKey = storageKey || WEBCHAT.DEFAULTS.STORAGE_KEY
     this.onInit = onInit
     this.onOpen = onOpen
@@ -175,8 +176,8 @@ export class WebchatApp {
     return node
   }
 
-  onInitWebchat(...args: [any]) {
-    this.onInit && this.onInit(this, ...args)
+  async onInitWebchat(...args: [any]) {
+    this.onInit && (await this.onInit(this, ...args))
   }
 
   onOpenWebchat(...args: [any]) {
@@ -485,7 +486,31 @@ export class WebchatApp {
     this.createRootElement(host)
 
     return (
-      <Webchat
+      // <Webchat
+      // {...webchatOptions}
+      // ref={this.webchatRef}
+      // host={this.host}
+      // shadowDOM={this.shadowDOM}
+      // theme={theme as WebchatTheme}
+      // storage={this.storage}
+      // storageKey={this.storageKey}
+      // defaultDelay={defaultDelay}
+      // defaultTyping={defaultTyping}
+      // onInit={(...args: [any]) => this.onInitWebchat(...args)}
+      // onOpen={(...args: [any]) => this.onOpenWebchat(...args)}
+      // onClose={(...args: [any]) => this.onCloseWebchat(...args)}
+      // onUserInput={(...args: [any]) => this.onUserInput(...args)}
+      // onStateChange={(args: OnStateChangeArgs) => {
+      //   this.onStateChange(args)
+      // }}
+      // onTrackEvent={(
+      //   request: ActionRequest,
+      //   eventName: string,
+      //   args?: EventArgs
+      // ) => this.onTrackEventWebchat(request, eventName, args)}
+      // server={server}
+      // />
+      <WebchatHooks
         {...webchatOptions}
         ref={this.webchatRef}
         host={this.host}

--- a/packages/botonic-react/src/webchat/use-botonic-storage.ts
+++ b/packages/botonic-react/src/webchat/use-botonic-storage.ts
@@ -1,0 +1,40 @@
+import { Session } from 'node:inspector'
+
+import { WebchatMessage } from '../index-types'
+import { stringifyWithRegexs } from '../util/regexs'
+import { DevSettings } from './context/types'
+import { WebchatTheme } from './theme/types'
+
+export interface BotonicStorage {
+  messages: WebchatMessage[]
+  session: Session
+  lastRoutePath: string
+  devSettings: DevSettings
+  lastMessageUpdate: string
+  themeUpdates: WebchatTheme
+}
+
+export function useBotonicStorage(storage: Storage, storageKey: string) {
+  const getBotonicStorage = (): BotonicStorage | undefined => {
+    const botonicStorage = storage.getItem(storageKey)
+    return botonicStorage ? JSON.parse(botonicStorage) : undefined
+  }
+
+  const getBotonicStorageAttribute = <T = any>(key: string): T => {
+    const botonicStorage = getBotonicStorage()
+    return botonicStorage?.[key]
+  }
+
+  const setBotonicStorage = (value: any) => {
+    const stringValueJSON = JSON.stringify(
+      JSON.parse(stringifyWithRegexs(value))
+    )
+    storage.setItem(storageKey, stringValueJSON)
+  }
+
+  return {
+    getBotonicStorage,
+    setBotonicStorage,
+    getBotonicStorageAttribute,
+  }
+}

--- a/packages/botonic-react/src/webchat/use-storage-state-hook.js
+++ b/packages/botonic-react/src/webchat/use-storage-state-hook.js
@@ -6,7 +6,7 @@ const IS_BROWSER =
   typeof navigator !== 'undefined' &&
   typeof document !== 'undefined'
 
-export function useStorageState(storage, key, defaultValue) {
+export function useStorageState(storage, key) {
   let evtTarget
 
   try {
@@ -17,7 +17,7 @@ export function useStorageState(storage, key, defaultValue) {
 
   const raw = storage?.getItem(key)
 
-  const [value, setValue] = useState(raw ? JSON.parse(raw) : defaultValue)
+  const [value, setValue] = useState(raw ? JSON.parse(raw) : undefined)
 
   const updater = useCallback(
     (updatedValue, remove = false) => {
@@ -32,8 +32,6 @@ export function useStorageState(storage, key, defaultValue) {
     },
     [key]
   )
-
-  defaultValue != null && !raw && updater(defaultValue)
 
   useEffect(() => {
     const listener = ({ detail }) => {
@@ -51,5 +49,5 @@ export function useStorageState(storage, key, defaultValue) {
   if (storage === null) {
     return [undefined, undefined]
   }
-  return [value, updater, () => updater(null, true)]
+  return [value, updater]
 }

--- a/packages/botonic-react/src/webchat/webchat-dev.jsx
+++ b/packages/botonic-react/src/webchat/webchat-dev.jsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 
 import { useWebchat } from './context/use-webchat'
 import { SessionView } from './session-view'
+import { useBotonicStorage } from './use-botonic-storage'
 import { Webchat } from './webchat'
 
 export const DebugTab = styled.div`
@@ -46,7 +47,24 @@ const initialSession = {
 
 // eslint-disable-next-line react/display-name
 export const WebchatDev = forwardRef((props, ref) => {
-  const webchatHooks = useWebchat()
+  const { getBotonicStorage } = useBotonicStorage(
+    props.storage,
+    props.storageKey
+  )
+  const devSettings =
+    getBotonicStorage()?.devSettings || props.initialDevSettings
+
+  console.log('devSettings', {
+    keepSessionOnReload: devSettings?.keepSessionOnReload,
+    showSessionView: devSettings?.showSessionView,
+  })
+
+  const webchatHooks = useWebchat(
+    undefined,
+    getBotonicStorage(),
+    initialSession,
+    devSettings
+  )
   const { webchatState, updateTheme } = webchatHooks
 
   /* TODO: webchatState.theme should be included in the dependencies array
@@ -63,7 +81,7 @@ export const WebchatDev = forwardRef((props, ref) => {
         {...props}
         ref={ref}
         webchatHooks={webchatHooks}
-        initialSession={initialSession}
+        // initialSession={initialSession}
         initialDevSettings={{
           keepSessionOnReload: webchatState.devSettings.keepSessionOnReload,
           showSessionView: webchatState.devSettings.showSessionView,

--- a/packages/botonic-react/src/webchat/webchat-hooks.tsx
+++ b/packages/botonic-react/src/webchat/webchat-hooks.tsx
@@ -1,0 +1,35 @@
+import React, { forwardRef } from 'react'
+
+import { WebchatProps, WebchatRef } from '../index-types'
+import { useWebchat } from './context/use-webchat'
+import { useBotonicStorage } from './use-botonic-storage'
+import { Webchat } from './webchat'
+
+export const WebchatHooks = forwardRef<
+  WebchatRef | null,
+  Omit<WebchatProps, 'webchatHooks'>
+>((props, ref) => {
+  const { getBotonicStorage } = useBotonicStorage(
+    props.storage,
+    props.storageKey
+  )
+
+  const devSettings =
+    getBotonicStorage()?.devSettings || props.initialDevSettings
+
+  console.log('devSettings', {
+    keepSessionOnReload: devSettings?.keepSessionOnReload,
+    showSessionView: devSettings?.showSessionView,
+  })
+
+  const webchatHooks = useWebchat(
+    props.theme,
+    getBotonicStorage(),
+    props.initialSession,
+    devSettings
+  )
+
+  return <Webchat {...props} ref={ref} webchatHooks={webchatHooks} />
+})
+
+WebchatHooks.displayName = 'WebchatHooks'


### PR DESCRIPTION
## Description

Load the `initialState` in the context using the `localStorage` data. 
Do not condition the call to the hook `useWebchat` inside the Webchat component. Always use the `prop.webchatHooks`. To achieve this I have added a component between the `WebchatApp` and the Webchat called `WebchatHooks` that uses the hook `useWebchat` and passes the `webchatHooks` as props.

## Context

<!--
- What problem is trying to solve this pull request?
- What are the reasons or business goals of this implementation?
- Can I provide visual resources or links to understand better the situation?
-->

## Approach taken / Explain the design

<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->

## To document / Usage example

<!--
- How this is used?
- If possible, provide a snippet of code with a usage example.
-->

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
