### PR TITLE
plugin-ai-agent: create new plugin-ai-agent #BLT-1633

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6934,6 +6934,10 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/botonic-plugin-agent": {
+      "resolved": "packages/botonic-plugin-agent",
+      "link": true
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "license": "MIT",
@@ -25074,6 +25078,21 @@
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^10.0.0"
+      }
+    },
+    "packages/botonic-plugin-agent": {
+      "version": "0.36.0",
+      "dependencies": {
+        "@botonic/react": "^0.35.0",
+        "axios": "^1.9.0",
+        "uuid": "^10.0.0"
+      },
+      "devDependencies": {
+        "@types/uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "packages/botonic-plugin-contentful": {

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "botonic-plugin-ai-agents",
+  "version": "0.36.0",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "description": "Use AI Agents to generate your contents",
+  "scripts": {
+    "build": "rm -rf lib && ../../node_modules/.bin/tsc -p tsconfig.json && ../../node_modules/.bin/tsc -p tsconfig.esm.json",
+    "build:watch": "npm run build -- --watch",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublishOnly": "rm -rf lib && npm i && npm run build",
+    "lint": "npm run lint_core -- --fix",
+    "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"
+  },
+  "dependencies": {
+    "@botonic/react": "^0.35.0",
+    "axios": "^1.9.0",
+    "uuid": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/uuid": "^10.0.0"
+  },
+  "files": [
+    "lib/**",
+    "src/**",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hubtype/botonic.git"
+  },
+  "keywords": [
+    "bot-framework",
+    "chatbot",
+    "ai-agents",
+    "conversational-app",
+    "typescript",
+    "javascript"
+  ],
+  "author": ""
+}

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -13,7 +13,7 @@
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"
   },
   "dependencies": {
-    "@botonic/react": "^0.35.0",
+    "@botonic/core": "^0.35.0",
     "axios": "^1.9.0",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-plugin-ai-agents/src/ai-agent-client.ts
+++ b/packages/botonic-plugin-ai-agents/src/ai-agent-client.ts
@@ -12,7 +12,7 @@ import {
   Config,
 } from './types'
 
-const url = `${HUBTYPE_API_URL}/external/v1/ai/agent/`
+const url = `${HUBTYPE_API_URL}/external/v1/ai/agent`
 
 export class AiAgentClient {
   async getInference(
@@ -84,7 +84,7 @@ export class AiAgentClient {
   ): Promise<AiAgentResponse> {
     const data = this.getData(request, aiAgentArgs)
     const response = await axios.post<AiAgentResponse>(
-      `${url}run/`,
+      `${url}/run/`,
       data,
       config
     )
@@ -99,7 +99,7 @@ export class AiAgentClient {
   ): Promise<AiAgentResponse> {
     const data = this.getDataTest(request, aiAgentArgs)
     const response = await axios.post<AiAgentResponse>(
-      `${url}test/`,
+      `${url}/test/`,
       data,
       config
     )

--- a/packages/botonic-plugin-ai-agents/src/ai-agent-client.ts
+++ b/packages/botonic-plugin-ai-agents/src/ai-agent-client.ts
@@ -41,7 +41,6 @@ export class AiAgentClient {
     request: BotContext,
     aiAgentArgs: AiAgentArgs
   ): AiAgentRequestDataTest {
-    console.log(aiAgentArgs)
     if (!request.input.data) {
       throw new AiAgentError('No input data provided')
     }
@@ -58,6 +57,8 @@ export class AiAgentClient {
           content: request.input.data,
         },
       ],
+      name: aiAgentArgs.name,
+      instructions: aiAgentArgs.instructions,
     }
   }
 

--- a/packages/botonic-plugin-ai-agents/src/ai-agent-client.ts
+++ b/packages/botonic-plugin-ai-agents/src/ai-agent-client.ts
@@ -1,0 +1,109 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { BotContext, isDev } from '@botonic/core'
+import axios from 'axios'
+
+import { HUBTYPE_API_URL } from './constants'
+import { AiAgentError } from './errors'
+import {
+  AiAgentArgs,
+  AiAgentRequestData,
+  AiAgentRequestDataTest,
+  AiAgentResponse,
+  Config,
+} from './types'
+
+const url = `${HUBTYPE_API_URL}/external/v1/ai/agent/`
+
+export class AiAgentClient {
+  async getInference(
+    request: BotContext,
+    aiAgentArgs: AiAgentArgs
+  ): Promise<AiAgentResponse> {
+    const config = this.getConfig(request)
+
+    if (isDev(request.session)) {
+      return this.agentTestInference(request, config, aiAgentArgs)
+    }
+
+    return this.agentInference(request, config, aiAgentArgs)
+  }
+
+  private getConfig(request: BotContext): Config {
+    return {
+      headers: {
+        Authorization: `Bearer ${request.session._access_token}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  }
+
+  private getDataTest(
+    request: BotContext,
+    aiAgentArgs: AiAgentArgs
+  ): AiAgentRequestDataTest {
+    console.log(aiAgentArgs)
+    if (!request.input.data) {
+      throw new AiAgentError('No input data provided')
+    }
+
+    // TODO: We can get messages from localStorage in Dev mode and transform them to the correct format {role: MessageRole, content: string}
+    // if (isDev(request.session)) {
+    //   const messages = localStorage.getItem('botonicState').
+    // }
+
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: request.input.data,
+        },
+      ],
+    }
+  }
+
+  private getData(
+    request: BotContext,
+    aiAgentArgs: AiAgentArgs
+  ): AiAgentRequestData {
+    if (!request.input.data) {
+      throw new AiAgentError('No input data provided')
+    }
+
+    return {
+      message: request.input.message_id,
+      memory_length: 10,
+      name: aiAgentArgs.name,
+      instructions: aiAgentArgs.instructions,
+    }
+  }
+
+  private async agentInference(
+    request: BotContext,
+    config: Config,
+    aiAgentArgs: AiAgentArgs
+  ): Promise<AiAgentResponse> {
+    const data = this.getData(request, aiAgentArgs)
+    const response = await axios.post<AiAgentResponse>(
+      `${url}run/`,
+      data,
+      config
+    )
+
+    return response.data
+  }
+
+  private async agentTestInference(
+    request: BotContext,
+    config: Config,
+    aiAgentArgs: AiAgentArgs
+  ): Promise<AiAgentResponse> {
+    const data = this.getDataTest(request, aiAgentArgs)
+    const response = await axios.post<AiAgentResponse>(
+      `${url}test/`,
+      data,
+      config
+    )
+
+    return response.data
+  }
+}

--- a/packages/botonic-plugin-ai-agents/src/constants.ts
+++ b/packages/botonic-plugin-ai-agents/src/constants.ts
@@ -1,0 +1,2 @@
+export const HUBTYPE_API_URL =
+  process.env.HUBTYPE_API_URL || 'https://api.hubtype.com'

--- a/packages/botonic-plugin-ai-agents/src/errors.ts
+++ b/packages/botonic-plugin-ai-agents/src/errors.ts
@@ -1,0 +1,6 @@
+export class AiAgentError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AiAgentError'
+  }
+}

--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -1,0 +1,23 @@
+import { BotContext, Plugin } from '@botonic/core'
+
+import { AiAgentClient } from './ai-agent-client'
+import { AiAgentArgs, AiAgentResponse } from './types'
+
+export default class BotonicPluginAiAgents implements Plugin {
+  public aiAgentClient: AiAgentClient
+
+  constructor() {
+    this.aiAgentClient = new AiAgentClient()
+  }
+
+  pre(): void {
+    return
+  }
+
+  async getInference(
+    request: BotContext,
+    aiAgentArgs: AiAgentArgs
+  ): Promise<AiAgentResponse> {
+    return this.aiAgentClient.getInference(request, aiAgentArgs)
+  }
+}

--- a/packages/botonic-plugin-ai-agents/src/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/types.ts
@@ -1,0 +1,30 @@
+export interface AiAgentArgs {
+  name: string
+  instructions: string
+}
+export interface Config {
+  headers: {
+    Authorization: string
+    'Content-Type': string
+  }
+}
+
+export interface AiAgentRequestDataTest {
+  messages: {
+    role: MessageRole
+    content: string
+  }[]
+}
+
+export type MessageRole = 'user' | 'assistant'
+
+export interface AiAgentRequestData {
+  message: string
+  memory_length: number
+  name: string
+  instructions: string
+}
+
+export interface AiAgentResponse {
+  message: { role: string; content: string }
+}

--- a/packages/botonic-plugin-ai-agents/src/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 export interface AiAgentArgs {
   name: string
   instructions: string

--- a/packages/botonic-plugin-ai-agents/src/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/types.ts
@@ -14,6 +14,8 @@ export interface AiAgentRequestDataTest {
     role: MessageRole
     content: string
   }[]
+  name: string
+  instructions: string
 }
 
 export type MessageRole = 'user' | 'assistant'

--- a/packages/botonic-plugin-ai-agents/tsconfig.esm.json
+++ b/packages/botonic-plugin-ai-agents/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.esm.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "./lib/esm"
+  },
+  "include": ["src/"]
+}

--- a/packages/botonic-plugin-ai-agents/tsconfig.json
+++ b/packages/botonic-plugin-ai-agents/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.cjs.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "./lib/cjs"
+  },
+  "include": ["src/"]
+}


### PR DESCRIPTION
## Description

Create a plugin-ai-agent. This plugin have the inference function. This function call a different endpoint when the bot is running in local development because the bot not have the message_id. When the plugin call the test endpoint the agent don't have memory.