### PR TITLE
plugin-flow-builder: use an ai agent from flow builder #BLT-1644 

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/action/ai-agent.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/ai-agent.ts
@@ -1,0 +1,52 @@
+import { FlowContent } from '../content-fields'
+import { FlowAiAgent } from '../content-fields/flow-ai-agent'
+import { AiAgentResponse } from '../types'
+import { FlowBuilderContext } from './index'
+
+export async function getContentsByAiAgent({
+  cmsApi,
+  flowBuilderPlugin,
+  request,
+}: FlowBuilderContext): Promise<FlowContent[]> {
+  const startNodeAiAgentFlow = cmsApi.getStartNodeAiAgentFlow()
+  if (!startNodeAiAgentFlow) {
+    return []
+  }
+
+  const contents =
+    await flowBuilderPlugin.getContentsByNode(startNodeAiAgentFlow)
+  const aiAgentContent = contents.find(
+    content => content instanceof FlowAiAgent
+  ) as FlowAiAgent
+
+  if (!aiAgentContent) {
+    return []
+  }
+
+  const aiAgentResponse = await flowBuilderPlugin.getAiAgentResponse?.(
+    request,
+    {
+      name: aiAgentContent.name,
+      instructions: aiAgentContent.instructions,
+    }
+  )
+
+  if (!aiAgentResponse) {
+    return []
+  }
+
+  return updateContentsWithAiAgentResponse(contents, aiAgentResponse)
+}
+
+function updateContentsWithAiAgentResponse(
+  contents: FlowContent[],
+  aiAgentResponse: AiAgentResponse
+): FlowContent[] {
+  return contents.map(content => {
+    if (content instanceof FlowAiAgent) {
+      content.text = aiAgentResponse.message.content
+    }
+
+    return content
+  })
+}

--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -9,6 +9,7 @@ import { getFlowBuilderPlugin } from '../helpers'
 import BotonicPluginFlowBuilder from '../index'
 import { trackFlowContent } from '../tracking'
 import { inputHasTextData } from '../utils'
+import { getContentsByAiAgent } from './ai-agent'
 import { getContentsByFallback } from './fallback'
 import { getContentsByFirstInteraction } from './first-interaction'
 import { getContentsByKnowledgeBase } from './knowledge-bases'
@@ -106,6 +107,10 @@ async function getContents(
   }
 
   if (inputHasTextData(request.input)) {
+    const aiAgentContents = await getContentsByAiAgent(context)
+    if (aiAgentContents.length > 0) {
+      return aiAgentContents
+    }
     const knowledgeBaseContents = await getContentsByKnowledgeBase(context)
     if (knowledgeBaseContents.length > 0) {
       return knowledgeBaseContents

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -1,7 +1,12 @@
 import { Input, PluginPreRequest } from '@botonic/core'
 import axios from 'axios'
 
-import { KNOWLEDGE_BASE_FLOW_NAME, SEPARATOR, UUID_REGEXP } from './constants'
+import {
+  AI_AGENTS_FLOW_NAME,
+  KNOWLEDGE_BASE_FLOW_NAME,
+  SEPARATOR,
+  UUID_REGEXP,
+} from './constants'
 import {
   HtBotActionNode,
   HtFallbackNode,
@@ -200,6 +205,18 @@ export class FlowBuilderApi {
       return undefined
     }
     return this.getNodeById<HtNodeWithContent>(knowledgeBaseFlow.start_node_id)
+  }
+
+  getStartNodeAiAgentFlow(): HtNodeWithContent | undefined {
+    const aiAgentFlow = this.flow.flows.find(
+      flow => flow.name === AI_AGENTS_FLOW_NAME
+    )
+
+    if (!aiAgentFlow) {
+      return undefined
+    }
+
+    return this.getNodeById<HtNodeWithContent>(aiAgentFlow.start_node_id)
   }
 
   isKnowledgeBaseEnabled(): boolean {

--- a/packages/botonic-plugin-flow-builder/src/constants.ts
+++ b/packages/botonic-plugin-flow-builder/src/constants.ts
@@ -10,4 +10,5 @@ export const UUID_REGEXP =
 
 export const MAIN_FLOW_NAME = 'Main'
 export const KNOWLEDGE_BASE_FLOW_NAME = 'Knowledge base'
+export const AI_AGENTS_FLOW_NAME = 'AI agents'
 export const FALLBACK_FLOW_NAME = 'Fallback'

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent.tsx
@@ -1,0 +1,23 @@
+import { Text } from '@botonic/react'
+
+import { ContentFieldsBase } from './content-fields-base'
+import { HtAiAgentNode } from './hubtype-fields/ai-agent'
+
+export class FlowAiAgent extends ContentFieldsBase {
+  public code: string = ''
+  public name: string = ''
+  public instructions: string = ''
+  public text: string = ''
+
+  static fromHubtypeCMS(component: HtAiAgentNode): FlowAiAgent {
+    const newAiAgent = new FlowAiAgent(component.id)
+    newAiAgent.name = component.content.name
+    newAiAgent.instructions = component.content.instructions
+
+    return newAiAgent
+  }
+
+  toBotonic(id: string): JSX.Element {
+    return <Text key={id}>{this.text}</Text>
+  }
+}

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/ai-agent.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/ai-agent.ts
@@ -1,0 +1,10 @@
+import { HtBaseNode } from './common'
+import { HtNodeWithContentType } from './node-types'
+
+export interface HtAiAgentNode extends HtBaseNode {
+  type: HtNodeWithContentType.AI_AGENT
+  content: {
+    name: string
+    instructions: string
+  }
+}

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/node-types.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/node-types.ts
@@ -12,6 +12,7 @@ export enum HtNodeWithContentType {
   WHATSAPP_CTA_URL_BUTTON = 'whatsapp-cta-url-button',
   KNOWLEDGE_BASE = 'knowledge-base',
   BOT_ACTION = 'bot-action',
+  AI_AGENT = 'ai-agent',
 }
 
 export enum HtNodeWithoutContentType {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/nodes.ts
@@ -1,3 +1,4 @@
+import { HtAiAgentNode } from './ai-agent'
 import { HtBotActionNode } from './bot-action'
 import { HtCarouselNode } from './carousel'
 import { HtFallbackNode } from './fallback'
@@ -29,6 +30,7 @@ export type HtNodeWithContent =
   | HtSmartIntentNode
   | HtKnowledgeBaseNode
   | HtBotActionNode
+  | HtAiAgentNode
 
 export type HtNodeWithoutContent = HtUrlNode | HtPayloadNode | HtGoToFlow
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/index.ts
@@ -1,3 +1,4 @@
+import { FlowAiAgent } from './flow-ai-agent'
 import { FlowBotAction } from './flow-bot-action'
 import { FlowCarousel } from './flow-carousel'
 import { FlowHandoff } from './flow-handoff'
@@ -10,21 +11,21 @@ import { FlowText } from './flow-text'
 import { FlowVideo } from './flow-video'
 import { FlowWhatsappCtaUrlButtonNode } from './flow-whatsapp-cta-url-button'
 import { FlowWhatsappButtonList } from './whatsapp-button-list/flow-whatsapp-button-list'
-
 export { ContentFieldsBase } from './content-fields-base'
 export { FlowButton } from './flow-button'
 export { FlowElement } from './flow-element'
 export {
+  FlowAiAgent,
   FlowBotAction,
   FlowCarousel,
+  FlowHandoff,
   FlowImage,
   FlowKnowledgeBase,
   FlowText,
   FlowVideo,
   FlowWhatsappButtonList,
+  FlowWhatsappCtaUrlButtonNode,
 }
-export { FlowHandoff } from './flow-handoff'
-export { FlowWhatsappCtaUrlButtonNode } from './flow-whatsapp-cta-url-button'
 
 export type FlowContent =
   | FlowCarousel
@@ -36,5 +37,6 @@ export type FlowContent =
   | FlowHandoff
   | FlowKnowledgeBase
   | FlowBotAction
+  | FlowAiAgent
 
 export { DISABLED_MEMORY_LENGTH }

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -14,6 +14,7 @@ import {
   SOURCE_INFO_SEPARATOR,
 } from './constants'
 import {
+  FlowAiAgent,
   FlowBotAction,
   FlowCarousel,
   FlowContent,
@@ -37,6 +38,7 @@ import {
 } from './content-fields/hubtype-fields'
 import { DEFAULT_FUNCTIONS } from './functions'
 import {
+  AiAgentFunction,
   BotonicPluginFlowBuilderOptions,
   FlowBuilderJSONVersion,
   InShadowingConfig,
@@ -58,6 +60,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   public getAccessToken: (session: Session) => string
   public trackEvent?: TrackEventFunction
   public getKnowledgeBaseResponse?: KnowledgeBaseFunction
+  public getAiAgentResponse?: AiAgentFunction
   public smartIntentsConfig: SmartIntentsInferenceConfig
   public inShadowing: InShadowingConfig
 
@@ -72,6 +75,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     this.getAccessToken = resolveGetAccessToken(options.getAccessToken)
     this.trackEvent = options.trackEvent
     this.getKnowledgeBaseResponse = options.getKnowledgeBaseResponse
+    this.getAiAgentResponse = options.getAiAgentResponse
     this.smartIntentsConfig = {
       ...options?.smartIntentsConfig,
       useLatest: this.jsonVersion === FlowBuilderJSONVersion.LATEST,
@@ -229,6 +233,9 @@ export default class BotonicPluginFlowBuilder implements Plugin {
 
       case HtNodeWithContentType.KNOWLEDGE_BASE:
         return FlowKnowledgeBase.fromHubtypeCMS(hubtypeContent)
+
+      case HtNodeWithContentType.AI_AGENT:
+        return FlowAiAgent.fromHubtypeCMS(hubtypeContent)
 
       case HtNodeWithContentType.BOT_ACTION:
         return FlowBotAction.fromHubtypeCMS(hubtypeContent, locale, this.cmsApi)

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -24,6 +24,7 @@ export interface BotonicPluginFlowBuilderOptions<
   getAccessToken: () => string
   trackEvent?: TrackEventFunction<TPlugins, TExtraData>
   getKnowledgeBaseResponse?: KnowledgeBaseFunction<TPlugins, TExtraData>
+  getAiAgentResponse?: AiAgentFunction<TPlugins, TExtraData>
   smartIntentsConfig?: { numSmartIntentsToUse: number }
   inShadowing?: Partial<InShadowingConfig>
 }
@@ -47,6 +48,19 @@ export type KnowledgeBaseFunction<
   messageId: string,
   memoryLength: number
 ) => Promise<KnowledgeBaseResponse>
+
+export type AiAgentFunction<
+  TPlugins extends ResolvedPlugins = ResolvedPlugins,
+  TExtraData = any,
+> = (
+  request: BotContext<TPlugins, TExtraData>,
+  aiAgentArgs: AiAgentArgs
+) => Promise<AiAgentResponse>
+
+export interface AiAgentArgs {
+  name: string
+  instructions: string
+}
 
 export interface FlowBuilderApiOptions {
   url: string
@@ -72,6 +86,10 @@ export interface KnowledgeBaseResponse {
   isFaithful: boolean
   chunkIds: string[]
   answer: string
+}
+
+export interface AiAgentResponse {
+  message: { role: string; content: string }
 }
 
 export interface SmartIntentResponse {


### PR DESCRIPTION
## Description

- Add node of type AiAgent
- Add Ai Agents flow
- Infer getAiAgentResponse by plugin constructor from bot plugins
- Use getAiAgentResponse to create text messages from ai agent

## Context

In bot you should pass the getAiAgentResponse to flow builder, the same way as getKnowledgeBaseResponse:

src/server/config.ts
```typescript
...

function getFlowBuilderConfig(
  env: ENVIRONMENT
): BotonicPluginFlowBuilderOptions<BotPlugins, UserData> {
  return {
    getAccessToken: () => '82ff9243e97ad293705424e358866b', // Used locally,
    trackEvent: async (request: BotRequest, eventName, args) => {
      await trackEvent(request, eventName, args)
    },
    getAiAgentResponse: async (
      request: BotRequest,
      aiAgentArgs: {
        name: string
        instructions: string
      }
    ) => {
      const aiAgentPlugin = request.plugins.aiAgent
      return await aiAgentPlugin.getInference(request, aiAgentArgs)
    },
    getKnowledgeBaseResponse: async (
 ...
  }
}
```

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
