### PR TITLE
fixed the env not recognized bug by instaling cross-env and changing …

### DIFF
--- a/packages/botonic-cli/src/util/download-gzip.ts
+++ b/packages/botonic-cli/src/util/download-gzip.ts
@@ -96,6 +96,20 @@ export async function editPackageJsonName(outputPath: string, botName: string) {
   // Modify the value of the attribute 'version'
   jsonData.version = '0.1.0'
 
+  jsonData.devDependencies = {
+    ...jsonData.devDependencies,
+    'cross-env': '^7.0.3',
+  }
+
+  // Prefix `build` and `start` with cross-env
+  const scripts = jsonData.scripts || {}
+  for (const scriptName of ['build', 'start']) {
+    if (scripts[scriptName] && !scripts[scriptName].startsWith('cross-env')) {
+      scripts[scriptName] = `cross-env ${scripts[scriptName]}`
+    }
+  }
+  jsonData.scripts = scripts
+
   // Convert the modified object back to JSON format
   const updatedJsonData = JSON.stringify(jsonData, null, 2)
 


### PR DESCRIPTION
…the build and start commands

<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description
in the editPackageJsonName function inside the  packages\botonic-cli\src\util\download-gzip.ts directory added functionality so that the projects package.json file comes with cross-env which should fix this error

## Context
this should prevent the error when the user starts or builds the project

## Approach taken / Explain the design
simply added one function
```
 jsonData.devDependencies = {
    ...jsonData.devDependencies,
    'cross-env': '^7.0.3',
  }

  // Prefix `build` and `start` with cross-env
  const scripts = jsonData.scripts || {}
  for (const scriptName of ['build', 'start']) {
    if (scripts[scriptName] && !scripts[scriptName].startsWith('cross-env')) {
      scripts[scriptName] = `cross-env ${scripts[scriptName]}`
    }
  }
  jsonData.scripts = scripts

```

## To document / Usage example


## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
