### PR TITLE
plugin-hubtype-analytics: hubtype analytics send new fields #BLT-1629

### DIFF
--- a/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event.ts
@@ -4,20 +4,22 @@ import { EventAction, EventType, HtEventProps, RequestData } from '../types'
 export class HtEvent {
   chat_id?: string
   type: EventType
-  chat_language: string
-  chat_country?: string
   format_version?: number
   bot_version?: string
   flow_version?: string
   action: EventAction
   bot_interaction_id?: string
+  user_locale: string
+  user_country: string
+  system_locale: string
 
   constructor(event: HtEventProps, requestData: RequestData) {
     this.chat_id = requestData.userId
-    this.chat_language = requestData.language
-    this.chat_country = requestData.country
-    this.format_version = 2
+    this.format_version = 3
     this.action = event.action
     this.bot_interaction_id = requestData.botInteractionId
+    this.user_locale = requestData.userLocale
+    this.user_country = requestData.userCountry
+    this.system_locale = requestData.systemLocale
   }
 }

--- a/packages/botonic-plugin-hubtype-analytics/src/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/index.ts
@@ -7,13 +7,9 @@ import { createHtEvent } from './utils'
 
 export default class BotonicPluginHubtypeAnalytics implements Plugin {
   eventsBaseUrl: string
-  getLanguage: (request: BotContext) => string
-  getCountry: (request: BotContext) => string
   constructor() {
     const hubtypeUrl = process.env.HUBTYPE_API_URL || 'https://api.hubtype.com'
     this.eventsBaseUrl = `${hubtypeUrl}/external/v2/conversational_apps`
-    this.getLanguage = (request: BotContext) => request.getSystemLocale()
-    this.getCountry = (request: BotContext) => request.getUserCountry()
   }
 
   post(): void {
@@ -34,10 +30,11 @@ export default class BotonicPluginHubtypeAnalytics implements Plugin {
 
   getRequestData(request: BotContext): RequestData {
     return {
-      language: this.getLanguage(request),
-      country: this.getCountry(request),
       userId: this.isLambdaEvent(request) ? request.session.user.id : undefined,
       botInteractionId: request.input?.bot_interaction_id,
+      userLocale: request.getSystemLocale(),
+      userCountry: request.getUserCountry(),
+      systemLocale: request.getSystemLocale(),
     }
   }
 

--- a/packages/botonic-plugin-hubtype-analytics/src/types.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/types.ts
@@ -190,8 +190,9 @@ export type HtEventProps =
   | EventCustom
 
 export interface RequestData {
-  language: string
-  country: string
   userId?: string
   botInteractionId: string
+  userLocale: string
+  userCountry: string
+  systemLocale: string
 }

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-custom.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-custom.test.ts
@@ -17,9 +17,10 @@ describe('Create custom events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.Custom,
       custom_fields: {
         name: 'custom bot event',

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-fallback.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-fallback.test.ts
@@ -13,9 +13,10 @@ describe('Create fallback events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.Fallback,
       user_input: 'userInputTest',
       fallback_out: 1,
@@ -35,9 +36,10 @@ describe('Create fallback events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.Fallback,
       user_input: 'userInputTest',
       fallback_out: 2,
@@ -57,9 +59,10 @@ describe('Create fallback events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.Fallback,
       user_input: 'userInputTest',
       fallback_out: 1,

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-feedback-knowledgebase.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-feedback-knowledgebase.test.ts
@@ -18,9 +18,10 @@ describe('Create feedback knowledgebase event', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.FeedbackKnowledgebase,
       feedback_target_id: 'messageIdTest',
       feedback_group_id: 'groupIdTest',

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-feedback.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-feedback.test.ts
@@ -16,9 +16,10 @@ describe('Create feedback event', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.FeedbackCase,
       feedback_target_id: 'caseId',
       feedback_group_id: 'groupIdTest',
@@ -46,9 +47,10 @@ describe('Create feedback event', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.FeedbackConversation,
       feedback_target_id: 'chatIdTest',
       feedback_group_id: 'groupIdTest',

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-flow.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-flow.test.ts
@@ -16,9 +16,10 @@ describe('Create flow event', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.FlowNode,
       flow_thread_id: 'flowThreadIdTest',
       flow_id: 'flowIdTest',

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-handoff.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-handoff.test.ts
@@ -16,9 +16,10 @@ describe('Create handoff events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.HandoffSuccess,
       handoff_queue_id: 'handoffQueueIdTest',
       handoff_queue_name: 'handoffQueueNameTest',
@@ -43,9 +44,10 @@ describe('Create handoff events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.HandoffFail,
       handoff_queue_id: 'handoffQueueIdTest',
       handoff_queue_name: 'handoffQueueNameTest',
@@ -66,9 +68,10 @@ describe('Create handoff events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.HandoffOption,
       handoff_queue_id: 'handoffQueueIdTest',
       handoff_queue_name: 'handoffQueueNameTest',
@@ -84,9 +87,10 @@ describe('Create handoff events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.HandoffOption,
       bot_interaction_id: 'testInteractionId',
       type: EventType.BotEvent,

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-intent-smart.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-intent-smart.test.ts
@@ -17,9 +17,10 @@ describe('Create nlu intent smart events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.IntentSmart,
       nlu_intent_smart_title: 'ADD_A_BAG',
       nlu_intent_smart_num_used: 2,

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-intent.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-intent.test.ts
@@ -18,9 +18,10 @@ describe('Create nlu intent classic events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.Intent,
       nlu_intent_label: 'ADD_A_BAG',
       nlu_intent_confidence: 0.7,

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-keyword.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-keyword.test.ts
@@ -17,9 +17,10 @@ describe('Create nlu keyword events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.Keyword,
       nlu_keyword_name: 'hello',
       nlu_keyword_is_regex: false,

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-knowledge-base.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-knowledge-base.test.ts
@@ -23,9 +23,10 @@ describe('Create knowledge base events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.Knowledgebase,
       knowledgebase_inference_id: 'knowledgebaseInferenceId',
       knowledgebase_sources_ids: ['sourceId1', 'sourceId2'],
@@ -56,9 +57,10 @@ describe('Create knowledge base events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.Knowledgebase,
       knowledgebase_inference_id: 'knowledgebaseInferenceId',
       knowledgebase_fail_reason: KnowledgebaseFailReason.Hallucination,

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-webview.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-webview.test.ts
@@ -19,9 +19,10 @@ describe('Create webview events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.WebviewStep,
       webview_thread_id: '12345',
       webview_name: 'ADD_A_BAG',
@@ -45,9 +46,10 @@ describe('Create webview events', () => {
 
     expect(htEvent).toEqual({
       chat_id: 'chatIdTest',
-      chat_language: 'es',
-      chat_country: 'ES',
-      format_version: 2,
+      user_locale: 'es',
+      user_country: 'ES',
+      system_locale: 'es',
+      format_version: 3,
       action: EventAction.WebviewEnd,
       webview_thread_id: '12345',
       webview_name: 'ADD_A_BAG',


### PR DESCRIPTION
## Description

Add new `user_locale`, `user_country` and `system_locale` fields for events with format_version = 3.
Remove fields language and country used in format_version = 2

## Testing

Update all tests
