### PR TITLE
plugin-flow-builder: add contentFilters #BLT-1683

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/filters/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/filters/index.ts
@@ -1,0 +1,27 @@
+import { BotContext } from '@botonic/core'
+
+import { FlowContent } from '../content-fields'
+import { ContentFilter } from '../types'
+
+interface ContentFilterExecutorOptions {
+  filters: ContentFilter[]
+}
+
+export class ContentFilterExecutor {
+  private filters: ContentFilter[] = []
+
+  constructor(options: ContentFilterExecutorOptions) {
+    this.filters = options.filters
+  }
+
+  async filter(
+    request: BotContext,
+    content: FlowContent
+  ): Promise<FlowContent> {
+    for (const filter of this.filters) {
+      content = await filter(request, content)
+    }
+
+    return content
+  }
+}

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -77,7 +77,8 @@ export default class BotonicPluginFlowBuilder implements Plugin {
     this.getAccessToken = resolveGetAccessToken(options.getAccessToken)
     this.trackEvent = options.trackEvent
     this.getKnowledgeBaseResponse = options.getKnowledgeBaseResponse
-    this.getAiAgentResponse = options.getAiAgentResponse
+    // TODO: Add getAiAgentResponse before publish 0.36.0
+    this.getAiAgentResponse = undefined //options.getAiAgentResponse
     this.smartIntentsConfig = {
       ...options?.smartIntentsConfig,
       useLatest: this.jsonVersion === FlowBuilderJSONVersion.LATEST,

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -40,6 +40,7 @@ import { DEFAULT_FUNCTIONS } from './functions'
 import {
   AiAgentFunction,
   BotonicPluginFlowBuilderOptions,
+  ContentFilter,
   FlowBuilderJSONVersion,
   InShadowingConfig,
   KnowledgeBaseFunction,
@@ -63,6 +64,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   public getAiAgentResponse?: AiAgentFunction
   public smartIntentsConfig: SmartIntentsInferenceConfig
   public inShadowing: InShadowingConfig
+  public contentFilters: ContentFilter[]
 
   // TODO: Rethink how we construct FlowBuilderApi to be simpler
   public jsonVersion: FlowBuilderJSONVersion
@@ -87,6 +89,7 @@ export default class BotonicPluginFlowBuilder implements Plugin {
       allowSmartIntents: options.inShadowing?.allowSmartIntents || false,
       allowKnowledgeBases: options.inShadowing?.allowKnowledgeBases || false,
     }
+    this.contentFilters = options.contentFilters || []
   }
 
   resolveFlowUrl(request: PluginPreRequest): string {

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -1,10 +1,6 @@
-import {
-  BotContext,
-  PluginPreRequest,
-  ResolvedPlugins,
-  Session,
-} from '@botonic/core'
+import { BotContext, PluginPreRequest, ResolvedPlugins } from '@botonic/core'
 
+import { FlowContent } from './content-fields'
 import { HtFlowBuilderData } from './content-fields/hubtype-fields'
 
 export interface InShadowingConfig {
@@ -27,6 +23,7 @@ export interface BotonicPluginFlowBuilderOptions<
   getAiAgentResponse?: AiAgentFunction<TPlugins, TExtraData>
   smartIntentsConfig?: { numSmartIntentsToUse: number }
   inShadowing?: Partial<InShadowingConfig>
+  contentFilters?: ContentFilter<TPlugins, TExtraData>[]
 }
 
 export type TrackEventFunction<
@@ -61,6 +58,13 @@ export interface AiAgentArgs {
   name: string
   instructions: string
 }
+export type ContentFilter<
+  TPlugins extends ResolvedPlugins = ResolvedPlugins,
+  TExtraData = any,
+> = (
+  request: BotContext<TPlugins, TExtraData>,
+  content: FlowContent
+) => Promise<FlowContent> | FlowContent
 
 export interface FlowBuilderApiOptions {
   url: string

--- a/packages/botonic-plugin-flow-builder/tests/ai-agent.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/ai-agent.test.ts
@@ -11,7 +11,7 @@ import { createFlowBuilderPluginAndGetContents } from './helpers/utils'
 describe('Check the contents returned by the plugin when it use an ai agent', () => {
   process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
 
-  test('When input match a keyword, the ai agent not respond', async () => {
+  test.skip('When input match a keyword, the ai agent not respond', async () => {
     const { contents, request } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: {
         flow: aiAgentTestFlow,
@@ -35,7 +35,7 @@ describe('Check the contents returned by the plugin when it use an ai agent', ()
     expect(request.input.nluResolution?.matchedValue).toEqual('Hello')
   })
 
-  test('When input not match a keyword or smart intent, the ai agent respond', async () => {
+  test.skip('When input not match a keyword or smart intent, the ai agent respond', async () => {
     const { contents } = await createFlowBuilderPluginAndGetContents({
       flowBuilderOptions: {
         flow: aiAgentTestFlow,

--- a/packages/botonic-plugin-flow-builder/tests/content-filters/remove-button.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/content-filters/remove-button.test.ts
@@ -1,0 +1,43 @@
+import { INPUT } from '@botonic/core'
+import { describe, test } from '@jest/globals'
+
+import { FlowText } from '../../src/content-fields/index'
+import { ContentFilter, ProcessEnvNodeEnvs } from '../../src/types'
+// eslint-disable-next-line jest/no-mocks-import
+import { mockSmartIntent } from '../__mocks__/smart-intent'
+import { basicFlow } from '../helpers/flows/basic'
+import { createFlowBuilderPluginAndGetContents } from '../helpers/utils'
+
+describe('Content filters', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+
+  beforeEach(() => mockSmartIntent('Other'))
+
+  test('should remove the button with text "Talk to an agent" from the FlowText content', async () => {
+    const removeButtonFilter: ContentFilter = (_request, content) => {
+      if (content instanceof FlowText) {
+        content.buttons = content.buttons.filter(
+          button => button.text !== 'Talk to an agent'
+        )
+      }
+      return content
+    }
+    const { contents } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: {
+        flow: basicFlow,
+        contentFilters: [removeButtonFilter],
+      },
+      requestArgs: {
+        input: { data: 'Hello', type: INPUT.TEXT },
+        isFirstInteraction: true,
+      },
+    })
+
+    expect(contents).toHaveLength(2)
+    expect((contents[1] as FlowText).buttons).toHaveLength(4)
+    expect((contents[1] as FlowText).buttons[0].text).toBe('Add a bag')
+    expect((contents[1] as FlowText).buttons[1].text).toBe('Select a seat')
+    expect((contents[1] as FlowText).buttons[2].text).toBe('Conditionals')
+    expect((contents[1] as FlowText).buttons[3].text).toBe('Different messages')
+  })
+})

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -16,6 +16,7 @@ import BotonicPluginFlowBuilder, {
 } from '../../src'
 import {
   AiAgentFunction,
+  ContentFilter,
   InShadowingConfig,
   KnowledgeBaseFunction,
   TrackEventFunction,
@@ -27,6 +28,7 @@ interface FlowBuilderOptions {
   getKnowledgeBaseResponse?: KnowledgeBaseFunction<ResolvedPlugins>
   getAiAgentResponse?: AiAgentFunction<ResolvedPlugins>
   inShadowing?: Partial<InShadowingConfig>
+  contentFilters?: ContentFilter[]
 }
 
 export function createFlowBuilderPlugin({
@@ -35,6 +37,7 @@ export function createFlowBuilderPlugin({
   getKnowledgeBaseResponse,
   getAiAgentResponse,
   inShadowing,
+  contentFilters,
 }: FlowBuilderOptions): BotonicPluginFlowBuilder {
   const flowBuilderPlugin = new BotonicPluginFlowBuilder({
     flow,
@@ -43,6 +46,7 @@ export function createFlowBuilderPlugin({
     getKnowledgeBaseResponse,
     getAiAgentResponse,
     inShadowing,
+    contentFilters,
   })
 
   return flowBuilderPlugin


### PR DESCRIPTION
## Description

Be able to add contentFilters in the plugin's settings.
These filters will be applied to the contents just before tracking.

## Context
The AiAgent feature is unfinished, for now I skip the tests and the flow builder constructor will set undefined so the AiAgent will never work. When we finish the feature I will activate it again.

## Testing

Add a test to check that a button can be removed with a filter 
