### PR TITLE
feat: retrieve context for webviews from new external api endpoint for bot session context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25297,6 +25297,50 @@
         "npm": ">=10.0.0"
       }
     },
+    "packages/botonic-plugin-flow-builder/node_modules/@botonic/core": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.35.2.tgz",
+      "integrity": "sha512-CvkEV1MewnV3Tgz7OY8ui/Bf+aCdjXGpUKoJITKDJ+GY4s4zMwlx7iUXUduTKvu5sVzdXj2Um6AnrKMf9NEBsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.9.0",
+        "decode": "^0.3.0",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "ulid": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-plugin-flow-builder/node_modules/@botonic/react": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@botonic/react/-/react-0.35.0.tgz",
+      "integrity": "sha512-j8OonAvfXR3r9ttYMXUSPME5PyPGyE9jG7y/yifP4TNhFj1Od1uIYPX4KMz9IdNmZNQ3Vff4OxM3Zi+D2cCMUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@botonic/core": "^0.35.0",
+        "axios": "^1.9.0",
+        "emoji-picker-react": "^4.12.0",
+        "lodash.merge": "^4.6.2",
+        "markdown-it": "^12.3.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-json-tree": "^0.18.0",
+        "react-router-dom": "^5.3.4",
+        "react-textarea-autosize": "^8.5.5",
+        "styled-components": "^5.3.11",
+        "ua-parser-js": "^1.0.39",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
     "packages/botonic-plugin-google-analytics": {
       "name": "@botonic/plugin-google-analytics",
       "version": "0.35.0",
@@ -25498,7 +25542,7 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.35.0",
+      "version": "0.36.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@botonic/core": "^0.35.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25542,10 +25542,10 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.36.0-alpha.0",
+      "version": "0.36.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@botonic/core": "^0.35.0",
+        "@botonic/core": "^0.36.0-alpha.0",
         "axios": "^1.9.0",
         "emoji-picker-react": "^4.12.0",
         "lodash.merge": "^4.6.2",
@@ -25579,25 +25579,6 @@
         "intersection-observer": "^0.12.2",
         "react-test-renderer": "^18.3.1",
         "typescript": "5.0.4"
-      },
-      "engines": {
-        "node": ">=20.0.0",
-        "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-react/node_modules/@botonic/core": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.35.2.tgz",
-      "integrity": "sha512-CvkEV1MewnV3Tgz7OY8ui/Bf+aCdjXGpUKoJITKDJ+GY4s4zMwlx7iUXUduTKvu5sVzdXj2Um6AnrKMf9NEBsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-runtime": "^7.25.9",
-        "axios": "^1.9.0",
-        "decode": "^0.3.0",
-        "pako": "^2.1.0",
-        "process": "^0.11.10",
-        "pusher-js": "^5.1.1",
-        "ulid": "^2.3.0"
       },
       "engines": {
         "node": ">=20.0.0",

--- a/packages/botonic-react/CHANGELOG.md
+++ b/packages/botonic-react/CHANGELOG.md
@@ -10,11 +10,13 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.35.x] - 2025-mm-dd
+## [0.36.0] - 2025-mm-dd
 
 ### Added
 
 ### Changed
+
+- [PR-3031](https://github.com/hubtype/botonic/pull/3031): Webview get session from backend using new api endpoint.
 
 ### Fixed
 

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.35.0",
+  "version": "0.36.0-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",
@@ -20,7 +20,7 @@
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet '.*.js' '*.js' 'src/**/*.js*' --fix"
   },
   "dependencies": {
-    "@botonic/core": "^0.35.0",
+    "@botonic/core": "^0.36.0-alpha.0",
     "axios": "^1.9.0",
     "emoji-picker-react": "^4.12.0",
     "lodash.merge": "^4.6.2",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.36.0-alpha.0",
+  "version": "0.36.0-alpha.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/webview-app.tsx
+++ b/packages/botonic-react/src/webview-app.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { params2queryString, PROVIDER } from '@botonic/core'
+import { params2queryString, PROVIDER, Session } from '@botonic/core'
 import axios from 'axios'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
@@ -16,6 +16,11 @@ enum WebviewUrlParams {
 
 class App extends React.Component {
   private url: URL
+  private botId: string
+  private userId: string
+  private hubtypeApiUrl: string
+  private state: { session: Session; params: Record<string, string> }
+
   constructor(props) {
     super(props)
     this.url = new URL(window.location.href)
@@ -76,10 +81,9 @@ class App extends React.Component {
 
       const session = this.state.session
       try {
-        const baseUrl = session._hubtype_api || 'https://api.hubtype.com'
-        const url = `${baseUrl}/v1/bots/${session.bot.id}/send_postback/`
+        const url = `${this.hubtypeApiUrl}/v1/bots/${this.botId}/send_postback/`
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const data = { payload: payload, chat_id: session.user.id }
+        const data = { payload: payload, chat_id: this.userId }
         await axios.post(url, data)
       } catch (e) {
         console.log(e)


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

WebviewApp to retrieve user_id and bot_id from new url generated by backend and using them to retrieve bot session via external api.


