### PR TITLE
botonic-cli: get tools from bot to show on flow builder frontend bot config #BLT-1665

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23425,6 +23425,8 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -25228,7 +25230,7 @@
     },
     "packages/botonic-cli": {
       "name": "@botonic/cli",
-      "version": "0.35.0",
+      "version": "0.36.0-alpha.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -25248,6 +25250,7 @@
         "ora": "^5.4.1",
         "qs": "^6.14.0",
         "tar": "^6.2.1",
+        "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "uuid": "^10.0.0",
         "zip-a-folder": "3.1.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25230,7 +25230,7 @@
     },
     "packages/botonic-cli": {
       "name": "@botonic/cli",
-      "version": "0.36.0-alpha.3",
+      "version": "0.36.0-alpha.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/botonic-cli/README.md
+++ b/packages/botonic-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @botonic/cli
 $ botonic COMMAND
 running command...
 $ botonic (-v|--version|version)
-@botonic/cli/0.36.0-alpha.3 darwin-arm64 node-v22.16.0
+@botonic/cli/0.36.0-alpha.4 darwin-arm64 node-v22.16.0
 $ botonic --help [COMMAND]
 USAGE
   $ botonic COMMAND
@@ -66,7 +66,7 @@ EXAMPLES
   Deploying to AWS...
 ```
 
-_See code: [lib/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.4/lib/commands/deploy.js)_
 
 ## `botonic destroy [PROVIDER]`
 
@@ -81,7 +81,7 @@ EXAMPLE
   Destroying AWS stack...
 ```
 
-_See code: [lib/commands/destroy.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/destroy.js)_
+_See code: [lib/commands/destroy.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.4/lib/commands/destroy.js)_
 
 ## `botonic help [COMMAND]`
 
@@ -112,7 +112,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [lib/commands/login.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/login.js)_
+_See code: [lib/commands/login.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.4/lib/commands/login.js)_
 
 ## `botonic logout`
 
@@ -126,7 +126,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [lib/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/logout.js)_
+_See code: [lib/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.4/lib/commands/logout.js)_
 
 ## `botonic new NAME [PROJECTNAME]`
 
@@ -146,7 +146,7 @@ EXAMPLE
   ✨ test_bot was successfully created!
 ```
 
-_See code: [lib/commands/new.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/new.js)_
+_See code: [lib/commands/new.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.4/lib/commands/new.js)_
 
 ## `botonic serve`
 
@@ -164,7 +164,7 @@ EXAMPLE
   > Project is running at http://localhost:8080/
 ```
 
-_See code: [lib/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.4/lib/commands/serve.js)_
 
 ## `botonic test`
 
@@ -191,5 +191,5 @@ EXAMPLE
   Ran all test suites.
 ```
 
-_See code: [lib/commands/test.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/test.js)_
+_See code: [lib/commands/test.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.4/lib/commands/test.js)_
 <!-- commandsstop -->

--- a/packages/botonic-cli/README.md
+++ b/packages/botonic-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @botonic/cli
 $ botonic COMMAND
 running command...
 $ botonic (-v|--version|version)
-@botonic/cli/0.35.0 darwin-arm64 node-v23.4.0
+@botonic/cli/0.36.0-alpha.3 darwin-arm64 node-v22.16.0
 $ botonic --help [COMMAND]
 USAGE
   $ botonic COMMAND
@@ -66,7 +66,7 @@ EXAMPLES
   Deploying to AWS...
 ```
 
-_See code: [lib/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.35.0/lib/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/deploy.js)_
 
 ## `botonic destroy [PROVIDER]`
 
@@ -81,7 +81,7 @@ EXAMPLE
   Destroying AWS stack...
 ```
 
-_See code: [lib/commands/destroy.js](https://github.com/hubtype/botonic/blob/v0.35.0/lib/commands/destroy.js)_
+_See code: [lib/commands/destroy.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/destroy.js)_
 
 ## `botonic help [COMMAND]`
 
@@ -112,7 +112,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [lib/commands/login.js](https://github.com/hubtype/botonic/blob/v0.35.0/lib/commands/login.js)_
+_See code: [lib/commands/login.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/login.js)_
 
 ## `botonic logout`
 
@@ -126,7 +126,7 @@ OPTIONS
   -p, --path=path  Path to botonic project. Defaults to current dir.
 ```
 
-_See code: [lib/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.35.0/lib/commands/logout.js)_
+_See code: [lib/commands/logout.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/logout.js)_
 
 ## `botonic new NAME [PROJECTNAME]`
 
@@ -146,7 +146,7 @@ EXAMPLE
   ✨ test_bot was successfully created!
 ```
 
-_See code: [lib/commands/new.js](https://github.com/hubtype/botonic/blob/v0.35.0/lib/commands/new.js)_
+_See code: [lib/commands/new.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/new.js)_
 
 ## `botonic serve`
 
@@ -164,7 +164,7 @@ EXAMPLE
   > Project is running at http://localhost:8080/
 ```
 
-_See code: [lib/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.35.0/lib/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/serve.js)_
 
 ## `botonic test`
 
@@ -191,5 +191,5 @@ EXAMPLE
   Ran all test suites.
 ```
 
-_See code: [lib/commands/test.js](https://github.com/hubtype/botonic/blob/v0.35.0/lib/commands/test.js)_
+_See code: [lib/commands/test.js](https://github.com/hubtype/botonic/blob/v0.36.0-alpha.3/lib/commands/test.js)_
 <!-- commandsstop -->

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.36.0-alpha.3",
+  "version": "0.36.0-alpha.4",
   "license": "MIT",
   "bin": {
     "botonic": "./bin/run"

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.35.0",
+  "version": "0.36.0-alpha.3",
   "license": "MIT",
   "bin": {
     "botonic": "./bin/run"
@@ -37,6 +37,7 @@
     "ora": "^5.4.1",
     "qs": "^6.14.0",
     "tar": "^6.2.1",
+    "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
     "uuid": "^10.0.0",
     "zip-a-folder": "3.1.8"

--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -433,8 +433,6 @@ Deploying to AWS...
   /* istanbul ignore next */
   async deploy(): Promise<void> {
     try {
-      // const botConfigJson = await BotConfig.get(process.cwd())
-
       const buildOut = await this.botonicApiService.build(npmCommand)
       if (!buildOut) {
         const error = 'Deploy Botonic Build Error'

--- a/packages/botonic-cli/src/commands/deploy.ts
+++ b/packages/botonic-cli/src/commands/deploy.ts
@@ -433,6 +433,8 @@ Deploying to AWS...
   /* istanbul ignore next */
   async deploy(): Promise<void> {
     try {
+      // const botConfigJson = await BotConfig.get(process.cwd())
+
       const buildOut = await this.botonicApiService.build(npmCommand)
       if (!buildOut) {
         const error = 'Deploy Botonic Build Error'


### PR DESCRIPTION
## Description

We need to save in the backend along with the botConfig the tools, payloads and webviews that the bot can use.

## Context

To achieve this, the bot must have a file in src/bot-config.ts that exports a botConfig object that follows the following interface:

```typescript
interface Tool {
  name: string
  description: string
}

interface Webview {
  name: string
}

interface BotConfigJSON {
  tools: Tool[]
  payloads: string[]
  webviews: Webview[]
}
```

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
