### PR TITLE
plugin flow-builder & ai-agents: rename tools to active_tools in flow ai-agent node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25453,7 +25453,7 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.36.0-alpha.3",
+      "version": "0.36.0-alpha.4",
       "dependencies": {
         "@botonic/core": "^0.36.0-alpha.0",
         "@langchain/core": "^0.3.57",
@@ -25623,7 +25623,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.36.0-alpha.4",
+      "version": "0.36.0-alpha.6",
       "dependencies": {
         "@botonic/react": "^0.36.0-alpha.1",
         "axios": "^1.9.0",

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.36.0-alpha.3",
+  "version": "0.36.0-alpha.4",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",

--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -45,7 +45,11 @@ export default class BotonicPluginAiAgents implements Plugin {
         createCustomTool(customTool)
       )
 
-      const tools = [...customTools, ...MANDATORY_TOOLS]
+      const customActiveTools = customTools.filter(tool =>
+        aiAgentArgs.activeTools?.map(tool => tool.name).includes(tool.name)
+      )
+      const tools = [...customActiveTools, ...MANDATORY_TOOLS]
+
       const chatModel = loadChatModel(AiProvider.AzureOpenAI)
       const aiAgentClient = new AiAgentClient(aiAgentArgs, chatModel, tools)
 

--- a/packages/botonic-plugin-ai-agents/src/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/types.ts
@@ -15,6 +15,7 @@ export interface CustomTool {
 export interface AiAgentArgs {
   name: string
   instructions: string
+  activeTools?: { name: string }[]
 }
 
 export interface AgenticBaseMessage {

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.36.0-alpha.4",
+  "version": "0.36.0-alpha.6",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/action/ai-agent.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/ai-agent.ts
@@ -9,7 +9,8 @@ export async function getContentsByAiAgent({
   request,
 }: FlowBuilderContext): Promise<FlowContent[]> {
   const startNodeAiAgentFlow = cmsApi.getStartNodeAiAgentFlow()
-  if (!startNodeAiAgentFlow) {
+  const isAiAgentEnabled = cmsApi.isAiAgentEnabled()
+  if (!startNodeAiAgentFlow || !isAiAgentEnabled) {
     return []
   }
 
@@ -28,6 +29,7 @@ export async function getContentsByAiAgent({
     {
       name: aiAgentContent.name,
       instructions: aiAgentContent.instructions,
+      tools: aiAgentContent.activeTools,
     }
   )
 

--- a/packages/botonic-plugin-flow-builder/src/action/ai-agent.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/ai-agent.ts
@@ -29,7 +29,7 @@ export async function getContentsByAiAgent({
     {
       name: aiAgentContent.name,
       instructions: aiAgentContent.instructions,
-      tools: aiAgentContent.activeTools,
+      activeTools: aiAgentContent.activeTools,
     }
   )
 

--- a/packages/botonic-plugin-flow-builder/src/action/knowledge-bases.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/knowledge-bases.ts
@@ -18,8 +18,9 @@ export async function getContentsByKnowledgeBase({
 }: FlowBuilderContext): Promise<FlowContent[]> {
   if (isKnowledgeBasesAllowed(request)) {
     const startNodeKnowledgeBaseFlow = cmsApi.getStartNodeKnowledgeBaseFlow()
+    const isKnowledgeBaseEnabled = cmsApi.isKnowledgeBaseEnabled()
 
-    if (!startNodeKnowledgeBaseFlow) {
+    if (!startNodeKnowledgeBaseFlow || !isKnowledgeBaseEnabled) {
       return []
     }
 

--- a/packages/botonic-plugin-flow-builder/src/api.ts
+++ b/packages/botonic-plugin-flow-builder/src/api.ts
@@ -223,6 +223,10 @@ export class FlowBuilderApi {
     return this.flow.is_knowledge_base_active || false
   }
 
+  isAiAgentEnabled(): boolean {
+    return this.flow.is_ai_agent_active || false
+  }
+
   getResolvedLocale(): string {
     const systemLocale = this.request.getSystemLocale()
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent.tsx
@@ -7,12 +7,14 @@ export class FlowAiAgent extends ContentFieldsBase {
   public code: string = ''
   public name: string = ''
   public instructions: string = ''
+  public activeTools?: { name: string }[]
   public text: string = ''
 
   static fromHubtypeCMS(component: HtAiAgentNode): FlowAiAgent {
     const newAiAgent = new FlowAiAgent(component.id)
     newAiAgent.name = component.content.name
     newAiAgent.instructions = component.content.instructions
+    newAiAgent.activeTools = component.content.active_tools
 
     return newAiAgent
   }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/ai-agent.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/ai-agent.ts
@@ -6,5 +6,6 @@ export interface HtAiAgentNode extends HtBaseNode {
   content: {
     name: string
     instructions: string
+    active_tools?: { name: string }[]
   }
 }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/common.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/common.ts
@@ -9,6 +9,7 @@ export interface HtFlowBuilderData {
   start_node_id?: string
   ai_model_id?: string
   is_knowledge_base_active?: boolean
+  is_ai_agent_active?: boolean
   nodes: HtNodeComponent[]
   flows: HtFlows[]
 }

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -57,6 +57,7 @@ export type AiAgentFunction<
 export interface AiAgentArgs {
   name: string
   instructions: string
+  tools?: { name: string }[]
 }
 export type ContentFilter<
   TPlugins extends ResolvedPlugins = ResolvedPlugins,

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -57,7 +57,7 @@ export type AiAgentFunction<
 export interface AiAgentArgs {
   name: string
   instructions: string
-  tools?: { name: string }[]
+  activeTools?: { name: string }[]
 }
 export type ContentFilter<
   TPlugins extends ResolvedPlugins = ResolvedPlugins,


### PR DESCRIPTION
## Description

Rename tools to active_tools in ai-agent node(plugin-flow-builder)
Rename tools to activeTools in aiAgentArgs (plugin-ai-agents)

