### PR TITLE
react: Detect automatically if the webchat is running in iOS/Android webview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25568,6 +25568,31 @@
         "npm": ">=10.0.0"
       }
     },
+    "packages/botonic-plugin-flow-builder/node_modules/@botonic/react": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@botonic/react/-/react-0.36.2.tgz",
+      "integrity": "sha512-yRobfr3GzkATUfask6erEXINT4Ll6LnLSZ7yoUKAbWEjpn0Fpn8foO72Sx//PCbGn4F5je9+wQ1p51GD3g3phg==",
+      "license": "MIT",
+      "dependencies": {
+        "@botonic/core": "^0.36.0",
+        "axios": "^1.10.0",
+        "emoji-picker-react": "^4.12.0",
+        "lodash.merge": "^4.6.2",
+        "markdown-it": "^12.3.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-json-tree": "^0.18.0",
+        "react-router-dom": "^5.3.4",
+        "react-textarea-autosize": "^8.5.5",
+        "styled-components": "^5.3.11",
+        "ua-parser-js": "^1.0.39",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
     "packages/botonic-plugin-google-analytics": {
       "name": "@botonic/plugin-google-analytics",
       "version": "0.36.0",
@@ -25697,7 +25722,7 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.36.2",
+      "version": "0.36.3",
       "license": "MIT",
       "dependencies": {
         "@botonic/core": "^0.36.0",

--- a/packages/botonic-react/CHANGELOG.md
+++ b/packages/botonic-react/CHANGELOG.md
@@ -9,16 +9,13 @@ All notable changes to Botonic will be documented in this file.
     Changes that have landed in master-lts but are not yet released.
     Click to see more.
   </summary>
-  
-## [0.36.x] - 2025-mm-dd
+</details>
+
+## [0.36.3] - 2025-06-30
 
 ### Added
 
-### Changed
-
-### Fixed
-
-</details>
+- [PR-3050](https://github.com/hubtype/botonic/pull/3050): Set the default target in bot links to `_self` in iOS/Android webviews.
 
 ## [0.36.0] - 2025-06-18
 

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.36.2",
+  "version": "0.36.3-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/components/button/index.tsx
+++ b/packages/botonic-react/src/components/button/index.tsx
@@ -1,7 +1,7 @@
 import { INPUT } from '@botonic/core'
 import React, { useContext } from 'react'
 
-import { resolveImage } from '../../util/environment'
+import { isInWebView, resolveImage } from '../../util/environment'
 import { renderComponent } from '../../util/react'
 import { generateWebviewUrlWithParams } from '../../util/webviews'
 import { WebchatContext } from '../../webchat/context'
@@ -41,7 +41,8 @@ export const Button = (props: ButtonProps) => {
             payload: props.payload,
           })
     } else if (props.url) {
-      window.open(props.url, props.target || '_blank')
+      const defaultTarget = isInWebView() ? '_self' : '_blank'
+      window.open(props.url, props.target || defaultTarget)
     }
 
     if (props.onClick) {

--- a/packages/botonic-react/src/components/button/index.tsx
+++ b/packages/botonic-react/src/components/button/index.tsx
@@ -1,7 +1,7 @@
 import { INPUT } from '@botonic/core'
 import React, { useContext } from 'react'
 
-import { isInWebViewApp, resolveImage } from '../../util/environment'
+import { isInWebviewApp, resolveImage } from '../../util/environment'
 import { renderComponent } from '../../util/react'
 import { generateWebviewUrlWithParams } from '../../util/webviews'
 import { WebchatContext } from '../../webchat/context'
@@ -41,7 +41,7 @@ export const Button = (props: ButtonProps) => {
             payload: props.payload,
           })
     } else if (props.url) {
-      const defaultTarget = isInWebViewApp() ? '_self' : '_blank'
+      const defaultTarget = isInWebviewApp() ? '_self' : '_blank'
       window.open(props.url, props.target || defaultTarget)
     }
 

--- a/packages/botonic-react/src/components/button/index.tsx
+++ b/packages/botonic-react/src/components/button/index.tsx
@@ -1,7 +1,7 @@
 import { INPUT } from '@botonic/core'
 import React, { useContext } from 'react'
 
-import { isInWebView, resolveImage } from '../../util/environment'
+import { isInWebViewApp, resolveImage } from '../../util/environment'
 import { renderComponent } from '../../util/react'
 import { generateWebviewUrlWithParams } from '../../util/webviews'
 import { WebchatContext } from '../../webchat/context'
@@ -41,7 +41,7 @@ export const Button = (props: ButtonProps) => {
             payload: props.payload,
           })
     } else if (props.url) {
-      const defaultTarget = isInWebView() ? '_self' : '_blank'
+      const defaultTarget = isInWebViewApp() ? '_self' : '_blank'
       window.open(props.url, props.target || defaultTarget)
     }
 

--- a/packages/botonic-react/src/components/markdown.js
+++ b/packages/botonic-react/src/components/markdown.js
@@ -1,6 +1,6 @@
 import MarkdownIt from 'markdown-it'
 
-import { isInWebViewApp } from '../util/environment'
+import { isInWebviewApp } from '../util/environment'
 
 const BR_STRING_TAG = '<br/>'
 const BR_STRING_TAG_REGEX = new RegExp('<br\\s*/?>', 'g')
@@ -49,7 +49,7 @@ const configureMarkdownRenderer = target => {
 }
 
 export const renderMarkdown = text => {
-  const target = isInWebViewApp() ? '_self' : '_blank'
+  const target = isInWebviewApp() ? '_self' : '_blank'
   const markdownRenderer = configureMarkdownRenderer(target)
   // markdown-it renderer expects '<br/>' strings to render correctly line breaks
   // Supporting multiline: https://stackoverflow.com/a/20543835

--- a/packages/botonic-react/src/components/markdown.js
+++ b/packages/botonic-react/src/components/markdown.js
@@ -1,6 +1,6 @@
 import MarkdownIt from 'markdown-it'
 
-import { isInWebView } from '../util/environment'
+import { isInWebViewApp } from '../util/environment'
 
 const BR_STRING_TAG = '<br/>'
 const BR_STRING_TAG_REGEX = new RegExp('<br\\s*/?>', 'g')
@@ -49,7 +49,7 @@ const configureMarkdownRenderer = target => {
 }
 
 export const renderMarkdown = text => {
-  const target = isInWebView() ? '_self' : '_blank'
+  const target = isInWebViewApp() ? '_self' : '_blank'
   const markdownRenderer = configureMarkdownRenderer(target)
   // markdown-it renderer expects '<br/>' strings to render correctly line breaks
   // Supporting multiline: https://stackoverflow.com/a/20543835

--- a/packages/botonic-react/src/components/markdown.js
+++ b/packages/botonic-react/src/components/markdown.js
@@ -1,5 +1,7 @@
 import MarkdownIt from 'markdown-it'
 
+import { isInWebView } from '../util/environment'
+
 const BR_STRING_TAG = '<br/>'
 const BR_STRING_TAG_REGEX = new RegExp('<br\\s*/?>', 'g')
 export const ESCAPED_LINE_BREAK = '&lt;br&gt;'
@@ -36,18 +38,19 @@ const configureLinksRenderer = () => {
   return linksRenderer
 }
 
-const configureMarkdownRenderer = () => {
+const configureMarkdownRenderer = target => {
   const markdownRenderer = new MarkdownIt({
     html: true,
     linkify: true,
     typographer: true,
   })
-  withLinksTarget(markdownRenderer)
+  withLinksTarget(markdownRenderer, target)
   return markdownRenderer
 }
 
-const markdownRenderer = configureMarkdownRenderer()
 export const renderMarkdown = text => {
+  const target = isInWebView() ? '_self' : '_blank'
+  const markdownRenderer = configureMarkdownRenderer(target)
   // markdown-it renderer expects '<br/>' strings to render correctly line breaks
   // Supporting multiline: https://stackoverflow.com/a/20543835
   text = text

--- a/packages/botonic-react/src/components/message/index.jsx
+++ b/packages/botonic-react/src/components/message/index.jsx
@@ -41,12 +41,12 @@ export const Message = props => {
     feedbackEnabled,
     inferenceId,
     botInteractionId,
+    markdown,
     ...otherProps
   } = props
 
   const isSentByUser = sentBy === SENDERS.user
   const isSentByBot = sentBy === SENDERS.bot
-  const markdown = props.markdown
   const { webchatState, addMessage, updateReplies, getThemeProperty } =
     useContext(WebchatContext)
   const [state] = useState({

--- a/packages/botonic-react/src/util/environment.js
+++ b/packages/botonic-react/src/util/environment.js
@@ -55,3 +55,19 @@ function normalizeArray(parts, allowAboveRoot) {
   }
   return res
 }
+
+export function isInWebView() {
+  const userAgent = window.navigator.userAgent || ''
+  const standalone = window.navigator.standalone
+
+  const isIOS = /iPad|iPhone|iPod/.test(userAgent)
+  const isAndroid = /Android/.test(userAgent)
+
+  // Detects iOS WebView
+  const isIOSWebView = isIOS && !userAgent.includes('Safari') && !standalone
+
+  // Detects Android WebView
+  const isAndroidWebView = isAndroid && userAgent.includes('wv')
+
+  return isIOSWebView || isAndroidWebView
+}

--- a/packages/botonic-react/src/util/environment.js
+++ b/packages/botonic-react/src/util/environment.js
@@ -56,7 +56,7 @@ function normalizeArray(parts, allowAboveRoot) {
   return res
 }
 
-export function isInWebView() {
+export function isInWebViewApp() {
   const userAgent = window.navigator.userAgent || ''
   const standalone = window.navigator.standalone
 

--- a/packages/botonic-react/src/util/environment.js
+++ b/packages/botonic-react/src/util/environment.js
@@ -56,7 +56,7 @@ function normalizeArray(parts, allowAboveRoot) {
   return res
 }
 
-export function isInWebViewApp() {
+export function isInWebviewApp() {
   const userAgent = window.navigator.userAgent || ''
   const standalone = window.navigator.standalone
 

--- a/packages/botonic-react/src/webchat/webchat.tsx
+++ b/packages/botonic-react/src/webchat/webchat.tsx
@@ -452,7 +452,6 @@ const Webchat = forwardRef<WebchatRef | null, WebchatProps>((props, ref) => {
   */
 
   const updateSessionWithUser = (userToUpdate: any) => {
-    console.log('userToUpdate', userToUpdate)
     updateSession(merge(webchatState.session, { user: userToUpdate }))
   }
 


### PR DESCRIPTION
## Description
Set the default target parameter in links depending if the webchat is opened within a iOS/Android webview (`_self`) or not (`_blank`)

## Context
If the webchat is displayed within an iOS webview (inside an iOS App), the links weren't working because the default target was `_blank` and on iOS webviews the links only work if the target is `_self`.

## Approach taken / Explain the design
Create a new `isInWebView` function to detect if the environment is a webview in iOS/Android.

## Testing

The pull request has no tests.