### PR TITLE
style(core): Add missing salesforce attribute inside Input.context type

### DIFF
--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -162,6 +162,9 @@ export interface Input extends Partial<NluResult> {
   type: InputType
   context?: {
     campaign?: Campaign
+    salesforce?: {
+      access_token: string
+    }
   }
   message_id: string
   bot_interaction_id: string


### PR DESCRIPTION
## Description
Add a missing `salesforce` attribute inside the `Input.context` type used when the organisation or the bot are integrated with Salesforce.

## Context
Missing attribute in `Input` type

## Testing

The pull request has no tests.