### PR TITLE
fix(react): Fix type of user argument in updateUser function

### DIFF
--- a/packages/botonic-react/src/webchat/context/types.ts
+++ b/packages/botonic-react/src/webchat/context/types.ts
@@ -78,7 +78,7 @@ export interface WebchatContextProps {
   updateLatestInput: (input: ClientInput) => void
   updateMessage: (message: WebchatMessage) => void
   updateReplies: (replies: (typeof Reply)[]) => void
-  updateUser: (user: ClientUser) => void
+  updateUser: (user: Partial<ClientUser>) => void
   updateWebchatDevSettings: (settings: WebchatSettingsProps) => void
   trackEvent?: TrackEventFunction
   webchatState: WebchatState


### PR DESCRIPTION
## Description
Set the type of the `user` argument of the `updateUser` function as `Partial<ClientUser>` because you may want to update just part of the user attributes, not all of them.

## Context
If you wanted to update just some user attributes, you would get a Typescript error.

## Testing

The pull request has no tests.
