### PR TITLE
Feat: Add request to AI Agent context #BLT-1790

### DIFF
--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -52,6 +52,7 @@ export default class BotonicPluginAiAgents implements Plugin {
       const messages = await this.getMessages(request, authToken, 25)
       const context: Context = {
         authToken,
+        request,
       }
 
       const runner = new AIAgentRunner(agent)

--- a/packages/botonic-plugin-ai-agents/src/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/types.ts
@@ -1,22 +1,26 @@
 import {
   Agent,
   AgentInputItem,
-  RunContext,
   Tool as OpenAITool,
+  RunContext as OpenAIRunContext,
 } from '@openai/agents'
 import { ZodSchema } from 'zod'
 
+import { BotContext } from '@botonic/core'
 import { OutputMessage, OutputSchema } from './structured-output'
 
 export interface Context {
   authToken: string
+  request: BotContext
 }
+
+export type RunContext = OpenAIRunContext<Context>
 
 export interface CustomTool {
   name: string
   description: string
   schema: ZodSchema
-  func: (input?: any, runContext?: RunContext<Context>) => Promise<any>
+  func: (input?: any, runContext?: RunContext) => Promise<any>
 }
 
 export type Tool = OpenAITool<Context>


### PR DESCRIPTION
## Description

Now the AI Agent has the request on its context. You can use it on custom tools to access information at the bot session or even update some information.

Example of a custom tool that updates the country of the user:
```typescript
import { RunContext, CustomTool } from '@botonic/plugin-ai-agents'
import { z } from 'zod'


export const tools: CustomTool[] = [
  {
    name: 'update_user_country',
    description: 'Update the user country.',
    schema: z.object({
      country: z
        .string()
        .describe(
          'The country of the user in ISO 3166-1 alfa-2 fomat (e.g: ES, AR, US, MX, etc.)'
        ),
    }),
    func: async (input: { country: string }, runContext?: RunContext) => {
      console.log('Running update_user_country tool with input: ', input)
      if (!runContext) {
        throw new Error('Run context is required')
      }
      const context = runContext.context
      context.request.setUserCountry(input.country)
      return `The user country has been updated to ${input.country}`
    },
  },
]

```

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
