### PR TITLE
botonic-react: input panel buttons no need enable attribute set to true to be used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25585,9 +25585,9 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.37.0",
+      "version": "0.37.1-alpha.1",
       "dependencies": {
-        "@botonic/react": "^0.37.0",
+        "@botonic/react": "0.37.1-alpha.1",
         "axios": "^1.10.0",
         "uuid": "^10.0.0"
       },
@@ -25728,7 +25728,7 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.37.0",
+      "version": "0.37.1-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@botonic/core": "^0.37.0",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.37.0",
+  "version": "0.37.1-alpha.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -14,7 +14,7 @@
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"
   },
   "dependencies": {
-    "@botonic/react": "^0.37.0",
+    "@botonic/react": "0.37.1-alpha.1",
     "axios": "^1.10.0",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-react/CHANGELOG.md
+++ b/packages/botonic-react/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to Botonic will be documented in this file.
 
 ### Added
 
--[PR-3074](https://github.com/hubtype/botonic/pull/3074/files): Update Whatsapp CTA URL to accept image, video or document in header.
+- [PR-3074](https://github.com/hubtype/botonic/pull/3074/files): Update Whatsapp CTA URL to accept image, video or document in header.
+- [PR-3077](https://github.com/hubtype/botonic/pull/3077): Input panel buttons no need enable attribute to be used.
 
 ### Changed
 

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.37.0",
+  "version": "0.37.1-alpha.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/webchat/input-panel/send-button.tsx
+++ b/packages/botonic-react/src/webchat/input-panel/send-button.tsx
@@ -13,13 +13,19 @@ interface SendButtonProps {
 export const SendButton = ({ onClick }: SendButtonProps) => {
   const { webchatState } = useContext(WebchatContext)
 
-  const sendButtonEnabled = webchatState.theme.userInput?.sendButton?.enable
-
   const CustomSendButton = webchatState.theme.userInput?.sendButton?.custom
+
+  const isSendButtonEnabled = () => {
+    const hasCustomSendButton = !!CustomSendButton
+    return (
+      webchatState.theme.userInput?.sendButton?.enable ?? hasCustomSendButton
+    )
+  }
+  const sendButtonEnabled = isSendButtonEnabled()
 
   return (
     <>
-      {sendButtonEnabled || CustomSendButton ? (
+      {sendButtonEnabled ? (
         <ConditionalAnimation>
           <div onClick={onClick} role={ROLES.SEND_BUTTON_ICON}>
             {CustomSendButton ? (

--- a/packages/botonic-react/src/webchat/theme/default-theme.ts
+++ b/packages/botonic-react/src/webchat/theme/default-theme.ts
@@ -79,11 +79,11 @@ export const defaultTheme: WebchatTheme = {
   },
   triggerButton: { image: WEBCHAT.DEFAULTS.LOGO },
   userInput: {
-    attachments: { enable: false },
+    attachments: { enable: undefined },
     box: {
       placeholder: 'Ask me something...',
     },
-    emojiPicker: { enable: false },
+    emojiPicker: { enable: undefined },
     sendButton: { enable: true },
     enable: true,
   },


### PR DESCRIPTION
## Description

Change behaviour to use custom buttons in input panel component. If you define a custom component for some button (Attachments, Emojis or SendButton) you don't need to put enable attribute set to true. If you define a custo button but you set enable to false, the custom button is not used.
