### PR TITLE
plugin-ai-agents & plugin-flow-builder: create InferenceResponse for ai-agents #BLT-1803

### DIFF
--- a/.github/workflows/botonic-ci-test-all-packages.yml
+++ b/.github/workflows/botonic-ci-test-all-packages.yml
@@ -23,6 +23,15 @@ jobs:
       PACKAGE: botonic-core
       NEEDS_CODECOV_UPLOAD: 'yes'
 
+  botonic-plugin-ai-agents-tests:
+    uses: ./.github/workflows/botonic-common-workflow.yml
+    secrets: inherit #pragma: allowlist secret
+    with:
+      PACKAGE_NAME: Botonic plugin-ai-agents tests
+      PACKAGE: botonic-plugin-ai-agents
+      BUILD_COMMAND: 'cd ../botonic-core && npm run build && cd ../botonic-plugin-ai-agents && npm run build'
+      NEEDS_CODECOV_UPLOAD: 'yes'
+
   botonic-plugin-contentful-tests:
     uses: ./.github/workflows/botonic-common-workflow.yml
     secrets: inherit #pragma: allowlist secret

--- a/.github/workflows/botonic-plugin-ai-agents.yml
+++ b/.github/workflows/botonic-plugin-ai-agents.yml
@@ -1,0 +1,18 @@
+name: Botonic plugin ai agents tests
+
+on:
+  push:
+    paths:
+      - 'packages/botonic-plugin-ai-agents/**'
+      - '.github/workflows/botonic-plugin-ai-agents-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  botonic-plugin-hubtype-analytics-tests:
+    uses: ./.github/workflows/botonic-common-workflow.yml
+    secrets: inherit #pragma: allowlist secret
+    with:
+      PACKAGE_NAME: Botonic plugin ai agents tests
+      PACKAGE: botonic-plugin-ai-agents
+      BUILD_COMMAND: 'cd ../botonic-core && npm run build && cd ../botonic-plugin-ai-agents && npm run build'
+      NEEDS_CODECOV_UPLOAD: 'yes'

--- a/packages/botonic-plugin-ai-agents/babel.config.js
+++ b/packages/botonic-plugin-ai-agents/babel.config.js
@@ -1,0 +1,21 @@
+/*
+ * This babel configuration is used along with Jest for execute tests,
+ * do not modify to avoid conflicts with webpack.config.js.
+ */
+// require("@babel/register");
+
+/*
+ * This babel configuration is used along with Jest for execute tests,
+ * do not modify to avoid conflicts with webpack.config.js.
+ */
+
+module.exports = {
+  sourceType: 'unambiguous',
+  // .map files are not generated unless babel invoked with --source-maps
+  sourceMaps: true,
+  presets: ['@babel/preset-env', '@babel/preset-react'],
+  plugins: [
+    require('@babel/plugin-transform-modules-commonjs'),
+    require('@babel/plugin-transform-runtime'),
+  ],
+}

--- a/packages/botonic-plugin-ai-agents/jest.config.js
+++ b/packages/botonic-plugin-ai-agents/jest.config.js
@@ -1,0 +1,48 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path')
+
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  roots: ['src/', 'tests/'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.tests.json',
+      },
+    ],
+    '^.+\\.jsx?$': [
+      'babel-jest',
+      { configFile: path.resolve(__dirname, 'babel.config.js') },
+    ],
+  },
+  preset: 'ts-jest',
+  testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.([jt]sx?)$',
+  testPathIgnorePatterns: [
+    'dist',
+    'lib',
+    '.*.d.ts',
+    'tests/helpers',
+    'tests/mocks',
+    '.*json.*',
+    '__mocks__',
+  ],
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/'],
+  transformIgnorePatterns: [
+    'node_modules/(?!@botonic|axios|escape-string-regexp).+\\.(js|jsx)$',
+  ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  snapshotSerializers: [],
+  setupFilesAfterEnv: [
+    // 'jest-expect-message', // to display a message when an assert fails
+    // 'jest-extended', // more assertions
+    '<rootDir>/jest.setup.js',
+  ],
+  modulePaths: ['node_modules', 'src'],
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '@botonic/dx/baseline/tests/__mocks__/file-mock.js',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  testEnvironment: 'node',
+}

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "rm -rf lib && ../../node_modules/.bin/tsc -p tsconfig.json && ../../node_modules/.bin/tsc -p tsconfig.esm.json",
     "build:watch": "npm run build -- --watch",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "../../node_modules/.bin/jest --coverage",
     "prepublishOnly": "rm -rf lib && npm i && npm run build",
     "lint": "npm run lint_core -- --fix",
     "lint_core": "../../node_modules/.bin/eslint_d --cache --quiet 'src/**/*.ts*'"

--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -8,10 +8,10 @@ import { setUpOpenAI } from './openai'
 import { AIAgentRunner } from './runner'
 import {
   AgenticInputMessage,
-  AgenticOutputMessage,
   AiAgentArgs,
   Context,
   CustomTool,
+  InferenceResponse,
   PluginAiAgentOptions,
   Tool,
 } from './types'
@@ -33,7 +33,7 @@ export default class BotonicPluginAiAgents implements Plugin {
   async getInference(
     request: BotContext,
     aiAgentArgs: AiAgentArgs
-  ): Promise<AgenticOutputMessage[] | undefined> {
+  ): Promise<InferenceResponse> {
     try {
       const authToken = isProd ? request.session._access_token : this.authToken
       if (!authToken) {
@@ -58,6 +58,8 @@ export default class BotonicPluginAiAgents implements Plugin {
       return await runner.run(messages, context)
     } catch (error) {
       console.error('error plugin returns undefined', error)
+      // Here we can return a InferenceResponse as a exit
+      // but indicate that the inference failed
       return undefined
     }
   }

--- a/packages/botonic-plugin-ai-agents/src/runner.ts
+++ b/packages/botonic-plugin-ai-agents/src/runner.ts
@@ -1,6 +1,12 @@
 import { Runner, RunToolCallItem } from '@openai/agents'
 
-import { AgenticInputMessage, AIAgent, Context, RunResult } from './types'
+import {
+  AgenticInputMessage,
+  AgenticOutputMessage,
+  AIAgent,
+  Context,
+  RunResult,
+} from './types'
 
 export class AIAgentRunner {
   private agent: AIAgent
@@ -38,7 +44,9 @@ export class AIAgentRunner {
       return {
         messages: hasExit
           ? []
-          : outputMessages.filter(message => message.type !== 'exit'),
+          : (outputMessages.filter(
+              message => message.type !== 'exit'
+            ) as AgenticOutputMessage[]),
         toolsExecuted,
         exit: hasExit,
         inputGuardrailTriggered: false,

--- a/packages/botonic-plugin-ai-agents/src/runner.ts
+++ b/packages/botonic-plugin-ai-agents/src/runner.ts
@@ -1,10 +1,11 @@
-import { Runner } from '@openai/agents'
+import { Runner, RunToolCallItem } from '@openai/agents'
 
 import {
   AgenticInputMessage,
   AgenticOutputMessage,
   AIAgent,
   Context,
+  RunResult,
 } from './types'
 
 export class AIAgentRunner {
@@ -18,7 +19,7 @@ export class AIAgentRunner {
     messages: AgenticInputMessage[],
     context: Context,
     maxRetries: number = 1
-  ): Promise<AgenticOutputMessage[]> {
+  ): Promise<RunResult> {
     return this.runWithRetry(messages, context, maxRetries, 1)
   }
 
@@ -27,13 +28,34 @@ export class AIAgentRunner {
     context: Context,
     maxRetries: number,
     attempt: number
-  ): Promise<AgenticOutputMessage[]> {
+  ): Promise<RunResult> {
     try {
       const runner = new Runner({
         modelSettings: { temperature: 0 },
       })
       const result = await runner.run(this.agent, messages, { context })
-      return result.finalOutput?.messages || []
+      console.log('result', result)
+
+      const outputMessages = result.finalOutput?.messages || []
+      const hasExit = outputMessages.some(message => message.type === 'exit')
+      const toolsExecuted =
+        result.newItems
+          ?.filter(item => item instanceof RunToolCallItem)
+          .map(item => {
+            if (item.rawItem.type === 'function_call') {
+              return item.rawItem.name
+            }
+            return ''
+          })
+          .filter(item => item !== '') || []
+
+      return {
+        messages: hasExit ? [] : outputMessages,
+        toolsExecuted,
+        exit: hasExit,
+        inputGuardrailTriggered: false,
+        outputGuardrailTriggered: false,
+      }
     } catch (error) {
       if (attempt > maxRetries) {
         throw error

--- a/packages/botonic-plugin-ai-agents/src/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/types.ts
@@ -1,8 +1,8 @@
 import {
   Agent,
   AgentInputItem,
-  Tool as OpenAITool,
   RunContext as OpenAIRunContext,
+  Tool as OpenAITool,
 } from '@openai/agents'
 import { ZodSchema } from 'zod'
 
@@ -37,3 +37,13 @@ export interface AiAgentArgs {
 
 export type AgenticInputMessage = AgentInputItem
 export type AgenticOutputMessage = OutputMessage
+
+export interface RunResult {
+  messages: AgenticOutputMessage[]
+  toolsExecuted: string[]
+  exit: boolean
+  inputGuardrailTriggered: boolean
+  outputGuardrailTriggered: boolean
+}
+
+export type InferenceResponse = RunResult | undefined

--- a/packages/botonic-plugin-ai-agents/src/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/types.ts
@@ -7,6 +7,7 @@ import {
 import { ZodSchema } from 'zod'
 
 import { OutputMessage, OutputSchema } from './structured-output'
+import { ExitMessage } from './structured-output/exit'
 
 export interface Context {
   authToken: string
@@ -36,7 +37,7 @@ export interface AiAgentArgs {
 }
 
 export type AgenticInputMessage = AgentInputItem
-export type AgenticOutputMessage = OutputMessage
+export type AgenticOutputMessage = Exclude<OutputMessage, ExitMessage>
 
 export interface RunResult {
   messages: AgenticOutputMessage[]

--- a/packages/botonic-plugin-ai-agents/tests/agent-builder.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/agent-builder.test.ts
@@ -1,0 +1,54 @@
+import { AIAgentBuilder } from '../src/agent-builder'
+import { Tool } from '../src/types'
+
+// Mock OpenAI Agent class
+jest.mock('@openai/agents', () => ({
+  Agent: jest.fn().mockImplementation(config => {
+    return {
+      name: config.name,
+      instructions: config.instructions,
+      tools: config.tools,
+    }
+  }),
+}))
+
+jest.mock('../src/tools', () => ({
+  mandatoryTools: [],
+}))
+
+describe('AIAgentBuilder', () => {
+  const agentName = 'Test Agent'
+  const agentInstructions = 'Test instructions for the agent'
+  const agentCustomTools: Tool[] = [
+    {
+      name: 'custom-tool-1',
+      description: 'Description for custom tool 1',
+    } as Tool,
+    {
+      name: 'custom-tool-2',
+      description: 'Description for custom tool 2',
+    } as Tool,
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest
+      .spyOn(Date.prototype, 'toISOString')
+      .mockReturnValue('2024-01-01T00:00:00.000Z')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+  it('should initialize correctly with name, instructions and tools', () => {
+    const aiAgent = new AIAgentBuilder(
+      agentName,
+      agentInstructions,
+      agentCustomTools
+    ).build()
+
+    expect(aiAgent.name).toBe(agentName)
+    expect(aiAgent.instructions).toContain(agentInstructions)
+    expect(aiAgent.tools).toHaveLength(2)
+  })
+})

--- a/packages/botonic-plugin-ai-agents/tests/runner.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/runner.test.ts
@@ -1,0 +1,5 @@
+describe('AIAgentRunner', () => {
+  it('should be defined', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/packages/botonic-plugin-ai-agents/tsconfig.tests.json
+++ b/packages/botonic-plugin-ai-agents/tsconfig.tests.json
@@ -1,0 +1,21 @@
+// Only used for verifying the code (& by jest)
+// It uses noEmit to have faster builds (up to 30%)
+{
+  "extends": "./tsconfig.json",
+  // include: [] makes jest faster,
+  // but it needs to be set for tsc to find the files to verify them. See https://www.notion.so/Typescript-performance-7aa77701970d4d49b8399efcee1b0754
+  "include": [
+    "**/*.[jt]s",
+    "**/*.[jt]sx",
+    "../src/**/*.[jt]s",
+    "../src/**/*.[jt]sx"
+  ],
+  "compilerOptions": {
+    "rootDir": "../",
+    // Options below are for compiling @botonic js/jsx files
+    "declaration": false,
+    "declarationDir": null,
+    "noEmit": true,
+    "types": ["@types/jest", "@types/node"]
+  }
+}

--- a/packages/botonic-plugin-flow-builder/src/action/ai-agent.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/ai-agent.ts
@@ -37,11 +37,11 @@ export async function getContentsByAiAgent({
     return []
   }
 
-  if (aiAgentResponse.length === 1 && aiAgentResponse[0].type === 'exit') {
+  if (aiAgentResponse.exit) {
     return []
   }
 
-  aiAgentContent.responses = aiAgentResponse
+  aiAgentContent.responses = aiAgentResponse.messages
 
   return contents
 }

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -53,7 +53,7 @@ export type AiAgentFunction<
 > = (
   request: BotContext<TPlugins, TExtraData>,
   aiAgentArgs: AiAgentArgs
-) => Promise<AgenticOutputMessage[] | undefined>
+) => Promise<InferenceResponse>
 
 export interface AiAgentArgs {
   name: string
@@ -140,12 +140,15 @@ export interface CarouselMessage extends OutputBaseMessage {
   }
 }
 
-export interface ExitMessage extends OutputBaseMessage {
-  type: 'exit'
-}
-
 export type AgenticOutputMessage =
   | TextMessage
   | TextWithButtonsMessage
   | CarouselMessage
-  | ExitMessage
+
+export interface InferenceResponse {
+  messages: AgenticOutputMessage[]
+  toolsExecuted: string[]
+  exit: boolean
+  inputGuardrailTriggered: boolean
+  outputGuardrailTriggered: boolean
+}

--- a/packages/botonic-plugin-flow-builder/tests/__mocks__/ai-agent.ts
+++ b/packages/botonic-plugin-flow-builder/tests/__mocks__/ai-agent.ts
@@ -1,7 +1,14 @@
-import { AgenticOutputMessage } from '../../src/types'
+import { AgenticOutputMessage, InferenceResponse } from '../../src/types'
 
 export function mockAiAgentResponse(messages: AgenticOutputMessage[]) {
   return jest.fn(() => {
-    return Promise.resolve(messages)
+    const response: InferenceResponse = {
+      messages,
+      toolsExecuted: [],
+      exit: false,
+      inputGuardrailTriggered: false,
+      outputGuardrailTriggered: false,
+    }
+    return Promise.resolve(response)
   })
 }


### PR DESCRIPTION
## Description

plugin-ai-agents return an object with interface InferenceResponse. With this object we can know the tools executed or if ai agents not respond (exit is true). In the future we include in this response the guardrails info.

```typescript
export type InferenceResponse = {
  messages: AgenticOutputMessage[]
  toolsExecuted: string[]
  exit: boolean
  inputGuardrailTriggered: boolean
  outputGuardrailTriggered: boolean
} | undefined
```

plugin -flow-builder use this object to generate response, in the future PR use this info to track ai-agents responses

## Test

Update mockAiAgentResponse to pass tests
