### PR TITLE
refactor: create hubtype-analytics interfaces and enums in @botonic/core #BLT-1806

### DIFF
--- a/packages/botonic-core/src/models/hubtype-analytics.ts
+++ b/packages/botonic-core/src/models/hubtype-analytics.ts
@@ -1,0 +1,157 @@
+export enum EventAction {
+  FeedbackCase = 'feedback_case',
+  FeedbackMessage = 'feedback_message',
+  FeedbackConversation = 'feedback_conversation',
+  FeedbackKnowledgebase = 'feedback_knowledgebase',
+  FeedbackWebview = 'feedback_webview',
+  FlowNode = 'flow_node',
+  HandoffOption = 'handoff_option',
+  HandoffSuccess = 'handoff_success',
+  HandoffFail = 'handoff_fail',
+  Keyword = 'nlu_keyword',
+  IntentSmart = 'nlu_intent_smart',
+  Knowledgebase = 'knowledgebase',
+  Fallback = 'fallback',
+  WebviewStep = 'webview_step',
+  WebviewEnd = 'webview_end',
+  Custom = 'custom',
+}
+
+export interface HtBaseEventProps {
+  action: EventAction
+}
+
+export interface EventFeedback extends HtBaseEventProps {
+  action:
+    | EventAction.FeedbackCase
+    | EventAction.FeedbackConversation
+    | EventAction.FeedbackMessage
+    | EventAction.FeedbackWebview
+  feedbackTargetId: string
+  feedbackGroupId: string
+  possibleOptions: string[]
+  possibleValues?: number[]
+  option: string
+  value?: number
+  comment?: string
+}
+
+export interface EventFeedbackKnowledgebase extends HtBaseEventProps {
+  action: EventAction.FeedbackKnowledgebase
+  knowledgebaseInferenceId: string
+  feedbackBotInteractionId: string
+  feedbackTargetId: string
+  feedbackGroupId: string
+  possibleOptions: string[]
+  possibleValues?: number[]
+  option: string
+  value?: number
+  comment?: string
+}
+
+export interface EventFlow extends HtBaseEventProps {
+  action: EventAction.FlowNode
+  flowThreadId: string
+  flowId: string
+  flowName: string
+  flowNodeId: string
+  flowNodeContentId: string
+  flowNodeIsMeaningful?: boolean
+}
+
+export interface EventHandoff extends HtBaseEventProps {
+  action: EventAction.HandoffSuccess | EventAction.HandoffFail
+  flowThreadId?: string
+  queueId: string
+  queueName: string
+  caseId?: string
+  isQueueOpen?: boolean
+  isAvailableAgent?: boolean
+  isThresholdReached?: boolean
+}
+
+export interface EventHandoffOption extends HtBaseEventProps {
+  action: EventAction.HandoffOption
+  flowThreadId?: string
+  queueId?: string
+  queueName?: string
+}
+
+export interface EventKeyword extends HtBaseEventProps {
+  action: EventAction.Keyword
+  flowThreadId: string
+  flowId: string
+  flowNodeId: string
+  nluKeywordName: string
+  nluKeywordIsRegex?: boolean
+  nluKeywordMessageId: string
+  userInput: string
+}
+
+export interface EventIntentSmart extends HtBaseEventProps {
+  action: EventAction.IntentSmart
+  flowThreadId: string
+  flowId: string
+  flowNodeId: string
+  nluIntentSmartTitle: string
+  nluIntentSmartNumUsed: number
+  nluIntentSmartMessageId: string
+  userInput: string
+}
+
+export interface EventKnowledgeBase extends HtBaseEventProps {
+  action: EventAction.Knowledgebase
+  flowThreadId: string
+  flowId: string
+  flowNodeId: string
+  knowledgebaseInferenceId: string
+  knowledgebaseFailReason?: KnowledgebaseFailReason
+  knowledgebaseSourcesIds: string[]
+  knowledgebaseChunksIds: string[]
+  knowledgebaseMessageId: string
+  userInput: string
+}
+
+export enum KnowledgebaseFailReason {
+  NoKnowledge = 'no_knowledge',
+  Hallucination = 'hallucination',
+}
+
+export interface EventFallback extends HtBaseEventProps {
+  action: EventAction.Fallback
+  userInput: string
+  fallbackOut: number
+  fallbackMessageId: string
+}
+
+export interface EventWebviewStep extends HtBaseEventProps {
+  action: EventAction.WebviewStep
+  flowThreadId?: string
+  webviewThreadId: string
+  webviewName: string
+  webviewStepName: string
+  webviewStepNumber: number
+}
+
+export interface EventWebviewEnd extends HtBaseEventProps {
+  action: EventAction.WebviewEnd
+  flowThreadId?: string
+  webviewThreadId: string
+  webviewName: string
+  webviewStepName?: string
+  webviewStepNumber?: number
+  webviewEndFailType?: WebviewEndFailType
+  webviewEndFailMessage?: string
+}
+
+export enum WebviewEndFailType {
+  CanceledByUser = 'canceled_by_user',
+  ApiError = 'api_error',
+  NeedsEscalation = 'needs_escalation',
+}
+
+export interface EventCustom extends HtBaseEventProps {
+  action: EventAction.Custom
+  customFields?: Record<string, any>
+  customSensitiveFields?: Record<string, any>
+}

--- a/packages/botonic-core/src/models/index.ts
+++ b/packages/botonic-core/src/models/index.ts
@@ -1,3 +1,4 @@
 export * from './events'
+export * from './hubtype-analytics'
 export * from './legacy-types'
 export * from './user'

--- a/packages/botonic-plugin-flow-builder/src/action/fallback.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/fallback.ts
@@ -1,8 +1,9 @@
+import { EventAction, EventFallback } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
 import { FlowBuilderApi } from '../api'
 import { FlowContent } from '../content-fields'
-import { EventAction, trackEvent } from '../tracking'
+import { trackEvent } from '../tracking'
 import { FlowBuilderContext } from './index'
 
 export async function getContentsByFallback({
@@ -30,11 +31,15 @@ async function getFallbackNode(cmsApi: FlowBuilderApi, request: ActionRequest) {
   const fallbackNode = cmsApi.getFallbackNode(isFirstFallbackOption)
   request.session.user.extra_data.isFirstFallbackOption = !isFirstFallbackOption
 
-  await trackEvent(request, EventAction.Fallback, {
-    userInput: request.input.data,
+  const event: EventFallback = {
+    action: EventAction.Fallback,
+    userInput: request.input.data as string,
     fallbackOut: isFirstFallbackOption ? 1 : 2,
     fallbackMessageId: request.input.message_id,
-  })
+  }
+  const { action, ...eventArgs } = event
+
+  await trackEvent(request, action, eventArgs)
 
   return fallbackNode
 }

--- a/packages/botonic-plugin-flow-builder/src/action/payload.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/payload.ts
@@ -1,10 +1,10 @@
-import { storeCaseRating } from '@botonic/core'
+import { EventAction, EventFeedback, storeCaseRating } from '@botonic/core'
 import { v7 as uuid } from 'uuid'
 
 import { AGENT_RATING_PAYLOAD, SEPARATOR } from '../constants'
 import { FlowContent } from '../content-fields'
 import { HtNodeWithContent } from '../content-fields/hubtype-fields'
-import { EventAction, trackEvent } from '../tracking'
+import { trackEvent } from '../tracking'
 import { FlowBuilderContext } from './index'
 
 export async function getContentsByPayload(
@@ -45,7 +45,7 @@ async function resolveRatingPayload(
   const possibleValues = ratingNode.content.buttons.map(button => button.value)
 
   if (request.session._hubtype_case_id) {
-    const event = {
+    const event: EventFeedback = {
       action: EventAction.FeedbackCase,
       feedbackTargetId: request.session._hubtype_case_id,
       feedbackGroupId: uuid().toString(),

--- a/packages/botonic-plugin-flow-builder/src/tracking.ts
+++ b/packages/botonic-plugin-flow-builder/src/tracking.ts
@@ -1,3 +1,4 @@
+import { EventAction, EventFlow } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 import { v7 as uuidv7 } from 'uuid'
 
@@ -7,20 +8,6 @@ import {
   HtNodeWithContentType,
 } from './content-fields/hubtype-fields'
 import { getFlowBuilderPlugin } from './helpers'
-
-export enum EventAction {
-  FlowNode = 'flow_node',
-  Keyword = 'nlu_keyword',
-  IntentSmart = 'nlu_intent_smart',
-  Knowledgebase = 'knowledgebase',
-  Fallback = 'fallback',
-  FeedbackCase = 'feedback_case',
-}
-
-export enum KnowledgebaseFailReason {
-  NoKnowledge = 'no_knowledge',
-  Hallucination = 'hallucination',
-}
 
 export async function trackEvent(
   request: ActionRequest,
@@ -43,37 +30,29 @@ export async function trackFlowContent(
   for (const content of contents) {
     const nodeContent = cmsApi.getNodeById<HtNodeWithContent>(content.id)
     if (nodeContent.type !== HtNodeWithContentType.KNOWLEDGE_BASE) {
-      const eventArgs = getContentEventArgs(request, {
-        code: nodeContent.code,
-        flowId: nodeContent.flow_id,
-        flowName: flowBuilderPlugin.getFlowName(nodeContent.flow_id),
-        id: nodeContent.id,
-        isMeaningful: nodeContent.is_meaningful ?? false,
-      })
-      await trackEvent(request, EventAction.FlowNode, eventArgs)
+      const event = getContentEventArgs(request, nodeContent)
+      const { action, ...eventArgs } = event
+      await trackEvent(request, action, eventArgs)
     }
   }
 }
 
 function getContentEventArgs(
   request: ActionRequest,
-  contentInfo: {
-    code: string
-    flowId: string
-    flowName: string
-    id: string
-    isMeaningful: boolean
-  }
-) {
+  nodeContent: HtNodeWithContent
+): EventFlow {
+  const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)
+  const flowName = flowBuilderPlugin.getFlowName(nodeContent.flow_id)
   const flowThreadId = request.session.flow_thread_id ?? uuidv7()
   request.session.flow_thread_id = flowThreadId
 
   return {
+    action: EventAction.FlowNode,
     flowThreadId,
-    flowId: contentInfo.flowId,
-    flowName: contentInfo.flowName,
-    flowNodeId: contentInfo.id,
-    flowNodeContentId: contentInfo.code,
-    flowNodeIsMeaningful: contentInfo.isMeaningful,
+    flowId: nodeContent.flow_id,
+    flowName: flowName,
+    flowNodeId: nodeContent.id,
+    flowNodeContentId: nodeContent.code,
+    flowNodeIsMeaningful: nodeContent.is_meaningful ?? false,
   }
 }

--- a/packages/botonic-plugin-flow-builder/src/user-input/keyword.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/keyword.ts
@@ -1,4 +1,4 @@
-import { NluType } from '@botonic/core'
+import { EventAction, EventKeyword, NluType } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 
 import { FlowBuilderApi } from '../api'
@@ -7,7 +7,7 @@ import {
   HtKeywordNode,
   HtNodeWithContent,
 } from '../content-fields/hubtype-fields'
-import { EventAction, trackEvent } from '../tracking'
+import { trackEvent } from '../tracking'
 
 interface KeywordProps {
   cmsApi: FlowBuilderApi
@@ -101,15 +101,17 @@ export class KeywordMatcher {
   }
 
   private async trackKeywordEvent() {
-    const eventArgs = {
-      nluKeywordName: this.matchedKeyword,
+    const event: EventKeyword = {
+      action: EventAction.Keyword,
+      flowThreadId: this.request.session.flow_thread_id as string,
+      flowNodeId: this.keywordNodeId as string,
+      flowId: this.flowId as string,
+      nluKeywordName: this.matchedKeyword as string,
       nluKeywordIsRegex: this.isRegExp,
       nluKeywordMessageId: this.request.input.message_id,
-      userInput: this.request.input.data,
-      flowThreadId: this.request.session.flow_thread_id,
-      flowId: this.flowId,
-      flowNodeId: this.keywordNodeId,
+      userInput: this.request.input.data as string,
     }
-    await trackEvent(this.request, EventAction.Keyword, eventArgs)
+    const { action, ...eventArgs } = event
+    await trackEvent(this.request, action, eventArgs)
   }
 }

--- a/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
@@ -1,11 +1,11 @@
-import { NluType } from '@botonic/core'
+import { EventAction, EventIntentSmart, NluType } from '@botonic/core'
 import { ActionRequest } from '@botonic/react'
 import axios from 'axios'
 
 import { FlowBuilderApi } from '../api'
 import { HtSmartIntentNode } from '../content-fields/hubtype-fields/smart-intent'
 import { getFlowBuilderPlugin } from '../helpers'
-import { EventAction, trackEvent } from '../tracking'
+import { trackEvent } from '../tracking'
 import { SmartIntentResponse } from '../types'
 
 export interface SmartIntentsInferenceParams {
@@ -55,15 +55,19 @@ export class SmartIntentsApi {
           payload: targetPayload,
         }
 
-        await trackEvent(this.currentRequest, EventAction.IntentSmart, {
+        const event: EventIntentSmart = {
+          action: EventAction.IntentSmart,
           nluIntentSmartTitle: response.data.smart_intent_title,
           nluIntentSmartNumUsed: response.data.smart_intents_used.length,
           nluIntentSmartMessageId: this.currentRequest.input.message_id,
           userInput: this.currentRequest.input.data,
-          flowThreadId: this.currentRequest.session.flow_thread_id,
+          flowThreadId: this.currentRequest.session.flow_thread_id as string,
           flowId: smartIntentNode.flow_id,
           flowNodeId: smartIntentNode.id,
-        })
+        }
+        const { action, ...eventArgs } = event
+
+        await trackEvent(this.currentRequest, action, eventArgs)
 
         return smartIntentNode
       }

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-rating.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-rating.test.ts
@@ -1,10 +1,9 @@
-import { INPUT, InputType, Session, storeCaseRating } from '@botonic/core'
+import { EventAction, INPUT, InputType, storeCaseRating } from '@botonic/core'
 import { describe, test } from '@jest/globals'
 
 import { AGENT_RATING_PAYLOAD } from '../../src/constants'
 import { RatingType } from '../../src/content-fields/hubtype-fields/index'
 import { FlowRating, FlowText } from '../../src/content-fields/index'
-import { EventAction } from '../../src/tracking'
 import { ProcessEnvNodeEnvs } from '../../src/types'
 // eslint-disable-next-line jest/no-mocks-import
 import { trackEventMock } from '../__mocks__/track-event'

--- a/packages/botonic-plugin-hubtype-analytics/src/types.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/types.ts
@@ -1,164 +1,22 @@
+import {
+  EventAction,
+  EventCustom,
+  EventFallback,
+  EventFeedback,
+  EventFeedbackKnowledgebase,
+  EventFlow,
+  EventHandoff,
+  EventHandoffOption,
+  EventIntentSmart,
+  EventKeyword,
+  EventKnowledgeBase,
+  EventWebviewEnd,
+  EventWebviewStep,
+} from '@botonic/core'
+
 export enum EventType {
   BotEvent = 'botevent',
   WebEvent = 'webevent',
-}
-
-export enum EventAction {
-  FeedbackCase = 'feedback_case',
-  FeedbackMessage = 'feedback_message',
-  FeedbackConversation = 'feedback_conversation',
-  FeedbackKnowledgebase = 'feedback_knowledgebase',
-  FeedbackWebview = 'feedback_webview',
-  FlowNode = 'flow_node',
-  HandoffOption = 'handoff_option',
-  HandoffSuccess = 'handoff_success',
-  HandoffFail = 'handoff_fail',
-  Keyword = 'nlu_keyword',
-  IntentSmart = 'nlu_intent_smart',
-  Knowledgebase = 'knowledgebase',
-  Fallback = 'fallback',
-  WebviewStep = 'webview_step',
-  WebviewEnd = 'webview_end',
-  Custom = 'custom',
-}
-
-export interface HtBaseEventProps {
-  action: EventAction
-}
-
-export interface EventFeedback extends HtBaseEventProps {
-  action:
-    | EventAction.FeedbackCase
-    | EventAction.FeedbackConversation
-    | EventAction.FeedbackMessage
-    | EventAction.FeedbackWebview
-  feedbackTargetId: string
-  feedbackGroupId: string
-  possibleOptions: string[]
-  possibleValues?: number[]
-  option: string
-  value?: number
-  comment?: string
-}
-
-export interface EventFeedbackKnowledgebase extends HtBaseEventProps {
-  action: EventAction.FeedbackKnowledgebase
-  knowledgebaseInferenceId: string
-  feedbackBotInteractionId: string
-  feedbackTargetId: string
-  feedbackGroupId: string
-  possibleOptions: string[]
-  possibleValues?: number[]
-  option: string
-  value?: number
-  comment?: string
-}
-
-export interface EventFlow extends HtBaseEventProps {
-  action: EventAction.FlowNode
-  flowThreadId: string
-  flowId: string
-  flowName: string
-  flowNodeId: string
-  flowNodeContentId: string
-  flowNodeIsMeaningful?: boolean
-}
-
-export interface EventHandoff extends HtBaseEventProps {
-  action: EventAction.HandoffSuccess | EventAction.HandoffFail
-  flowThreadId?: string
-  queueId: string
-  queueName: string
-  caseId?: string
-  isQueueOpen?: boolean
-  isAvailableAgent?: boolean
-  isThresholdReached?: boolean
-}
-
-export interface EventHandoffOption extends HtBaseEventProps {
-  action: EventAction.HandoffOption
-  flowThreadId?: string
-  queueId?: string
-  queueName?: string
-}
-
-export interface EventKeyword extends HtBaseEventProps {
-  action: EventAction.Keyword
-  flowThreadId: string
-  flowId: string
-  flowNodeId: string
-  nluKeywordName: string
-  nluKeywordIsRegex?: boolean
-  nluKeywordMessageId: string
-  userInput: string
-}
-
-export interface EventIntentSmart extends HtBaseEventProps {
-  action: EventAction.IntentSmart
-  flowThreadId: string
-  flowId: string
-  flowNodeId: string
-  nluIntentSmartTitle: string
-  nluIntentSmartNumUsed: number
-  nluIntentSmartMessageId: string
-  userInput: string
-}
-
-export interface EventKnowledgeBase extends HtBaseEventProps {
-  action: EventAction.Knowledgebase
-  flowThreadId: string
-  flowId: string
-  flowNodeId: string
-  knowledgebaseInferenceId: string
-  knowledgebaseFailReason?: KnowledgebaseFailReason
-  knowledgebaseSourcesIds: string[]
-  knowledgebaseChunksIds: string[]
-  knowledgebaseMessageId: string
-  userInput: string
-}
-
-export enum KnowledgebaseFailReason {
-  NoKnowledge = 'no_knowledge',
-  Hallucination = 'hallucination',
-}
-
-export interface EventFallback extends HtBaseEventProps {
-  action: EventAction.Fallback
-  userInput: string
-  fallbackOut: number
-  fallbackMessageId: string
-}
-
-export interface EventWebviewStep extends HtBaseEventProps {
-  action: EventAction.WebviewStep
-  flowThreadId?: string
-  webviewThreadId: string
-  webviewName: string
-  webviewStepName: string
-  webviewStepNumber: number
-}
-
-export interface EventWebviewEnd extends HtBaseEventProps {
-  action: EventAction.WebviewEnd
-  flowThreadId?: string
-  webviewThreadId: string
-  webviewName: string
-  webviewStepName?: string
-  webviewStepNumber?: number
-  webviewEndFailType?: WebviewEndFailType
-  webviewEndFailMessage?: string
-}
-
-export enum WebviewEndFailType {
-  CanceledByUser = 'canceled_by_user',
-  ApiError = 'api_error',
-  NeedsEscalation = 'needs_escalation',
-}
-
-export interface EventCustom extends HtBaseEventProps {
-  action: EventAction.Custom
-  customFields?: Record<string, any>
-  customSensitiveFields?: Record<string, any>
 }
 
 export type HtEventProps =
@@ -181,4 +39,20 @@ export interface RequestData {
   userLocale: string
   userCountry: string
   systemLocale: string
+}
+
+export {
+  EventAction,
+  EventCustom,
+  EventFallback,
+  EventFeedback,
+  EventFeedbackKnowledgebase,
+  EventFlow,
+  EventHandoff,
+  EventHandoffOption,
+  EventIntentSmart,
+  EventKeyword,
+  EventKnowledgeBase,
+  EventWebviewEnd,
+  EventWebviewStep,
 }

--- a/packages/botonic-react/src/webchat/tracking.ts
+++ b/packages/botonic-react/src/webchat/tracking.ts
@@ -1,3 +1,4 @@
+import { EventFeedbackKnowledgebase } from '@botonic/core'
 import { useContext } from 'react'
 import { v7 as uuidv7 } from 'uuid'
 
@@ -14,7 +15,7 @@ interface TrackKnowledgebaseFeedbackArgs {
   inferenceId?: string
 }
 
-export enum FeedbackOption {
+enum FeedbackOption {
   ThumbsUp = 'thumbsUp',
   ThumbsDown = 'thumbsDown',
 }
@@ -46,10 +47,13 @@ export function useTracking() {
     if (!trackEvent) {
       return
     }
+    const request = getRequest()
 
-    const args = {
-      knowledgebaseInferenceId: inferenceId,
-      feedbackBotInteractionId: botInteractionId,
+    // inferenceId and botInteractionId are strings, but in local development they are undefined
+    const event: EventFeedbackKnowledgebase = {
+      action: EventAction.FeedbackKnowledgebase,
+      knowledgebaseInferenceId: inferenceId as string,
+      feedbackBotInteractionId: botInteractionId as string,
       feedbackTargetId: messageId,
       feedbackGroupId: uuidv7(),
       possibleOptions: [FeedbackOption.ThumbsDown, FeedbackOption.ThumbsUp],
@@ -57,6 +61,10 @@ export function useTracking() {
       option: isUseful ? FeedbackOption.ThumbsUp : FeedbackOption.ThumbsDown,
       value: isUseful ? 1 : 0,
     }
+    const { action, ...eventArgs } = event
+
+    await trackEvent(request, action, eventArgs)
+  }
 
     const request = getRequest()
 

--- a/packages/botonic-react/src/webchat/tracking.ts
+++ b/packages/botonic-react/src/webchat/tracking.ts
@@ -1,4 +1,8 @@
-import { EventFeedbackKnowledgebase } from '@botonic/core'
+import {
+  EventCustom,
+  EventFeedback,
+  EventFeedbackKnowledgebase,
+} from '@botonic/core'
 import { useContext } from 'react'
 import { v7 as uuidv7 } from 'uuid'
 
@@ -20,7 +24,18 @@ enum FeedbackOption {
   ThumbsDown = 'thumbsDown',
 }
 
-export function useTracking() {
+interface UseTracking {
+  trackKnowledgebaseFeedback: ({
+    messageId,
+    isUseful,
+    botInteractionId,
+    inferenceId,
+  }: TrackKnowledgebaseFeedbackArgs) => Promise<void>
+  trackCustomEvent: (event: EventCustom) => Promise<void>
+  trackFeedbackEvent: (event: EventFeedback) => Promise<void>
+}
+
+export function useTracking(): UseTracking {
   const { webchatState, trackEvent } = useContext(WebchatContext)
 
   const getRequest = () => {
@@ -66,10 +81,25 @@ export function useTracking() {
     await trackEvent(request, action, eventArgs)
   }
 
-    const request = getRequest()
+  const trackCustomEvent = async (event: EventCustom) => {
+    if (!trackEvent) {
+      return
+    }
 
-    await trackEvent(request, EventAction.FeedbackKnowledgebase, args)
+    const request = getRequest()
+    const { action, ...eventArgs } = event
+    await trackEvent(request, action, eventArgs)
   }
 
-  return { trackKnowledgebaseFeedback }
+  const trackFeedbackEvent = async (event: EventFeedback) => {
+    if (!trackEvent) {
+      return
+    }
+
+    const request = getRequest()
+    const { action, ...eventArgs } = event
+    await trackEvent(request, action, eventArgs)
+  }
+
+  return { trackKnowledgebaseFeedback, trackCustomEvent, trackFeedbackEvent }
 }


### PR DESCRIPTION
## Description

Refactor hubtype-analytics, pass all interfaces and enums to @botonic/core to be able to import them in @botonic/plugin-flow-builder and @botonic/react to type events

Import from @botonic/core interfaces and enums and export from @botnic/plugin-hubtype-analytics, this way it is not necessary to change the imports in the bots.

In the last commit I create a functions to track custom events a feedback events from webchat.