### PR TITLE
Fix: Use only last message on guardrail

### DIFF
--- a/packages/botonic-plugin-ai-agents/src/guardrails/input.ts
+++ b/packages/botonic-plugin-ai-agents/src/guardrails/input.ts
@@ -1,4 +1,4 @@
-import { Agent, InputGuardrail, run } from '@openai/agents'
+import { Agent, InputGuardrail, run, UserMessageItem } from '@openai/agents'
 import { z } from 'zod'
 
 import { GuardrailRule } from '../types'
@@ -20,7 +20,8 @@ export function createInputGuardrail(rules: GuardrailRule[]): InputGuardrail {
   return {
     name: 'InputGuardrail',
     execute: async ({ input, context }) => {
-      const result = await run(agent, input, { context })
+      const lastMessage = input[input.length - 1] as UserMessageItem
+      const result = await run(agent, [lastMessage], { context })
       const finalOutput = result.finalOutput
       if (finalOutput === undefined) {
         throw new Error('Guardrail agent failed to produce output')

--- a/packages/botonic-plugin-ai-agents/tests/guardrails/input.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/guardrails/input.test.ts
@@ -77,7 +77,12 @@ describe('createInputGuardrail', () => {
 
     const guardrail = createInputGuardrail(mockRules)
     const result = await guardrail.execute({
-      input: 'some offensive text',
+      input: [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: 'some offensive text' }],
+        },
+      ],
       context: mockRunContext,
       agent: mockAgent,
     })
@@ -88,7 +93,12 @@ describe('createInputGuardrail', () => {
     })
     expect(run).toHaveBeenCalledWith(
       expect.any(Object),
-      'some offensive text',
+      [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: 'some offensive text' }],
+        },
+      ],
       { context: mockRunContext }
     )
   })
@@ -104,7 +114,12 @@ describe('createInputGuardrail', () => {
 
     const guardrail = createInputGuardrail(mockRules)
     const result = await guardrail.execute({
-      input: 'normal text',
+      input: [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: 'normal text' }],
+        },
+      ],
       context: mockRunContext,
       agent: mockAgent,
     })
@@ -124,7 +139,12 @@ describe('createInputGuardrail', () => {
     const guardrail = createInputGuardrail(mockRules)
     await expect(
       guardrail.execute({
-        input: 'some text',
+        input: [
+          {
+            role: 'user',
+            content: [{ type: 'input_text', text: 'some text' }],
+          },
+        ],
         context: mockRunContext,
         agent: mockAgent,
       })


### PR DESCRIPTION
## Description

Use only last message when running input Guardrail.
