### PR TITLE
feat: change do-nothing payload #BLT-1830

### DIFF
--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to Botonic will be documented in this file.
 
 ### Changed
 
+- [PR-3092](https://github.com/hubtype/botonic/pull/3092): Change do-nothing payload.
+
 ### Fixed
 
 </details>

--- a/packages/botonic-plugin-flow-builder/src/action/index.tsx
+++ b/packages/botonic-plugin-flow-builder/src/action/index.tsx
@@ -9,6 +9,7 @@ import {
 import React from 'react'
 
 import { FlowBuilderApi } from '../api'
+import { DO_NOTHING_PAYLOAD } from '../constants'
 import { FlowContent, FlowHandoff } from '../content-fields'
 import { FlowBotAction } from '../content-fields/flow-bot-action'
 import { ContentFilterExecutor } from '../filters'
@@ -125,7 +126,7 @@ async function getContents(
     return []
   }
 
-  if (request.input.payload?.startsWith('do-nothing')) {
+  if (request.input.payload?.startsWith(DO_NOTHING_PAYLOAD)) {
     request.input.payload = undefined
   }
 

--- a/packages/botonic-plugin-flow-builder/src/constants.ts
+++ b/packages/botonic-plugin-flow-builder/src/constants.ts
@@ -2,6 +2,7 @@ export const FLOW_BUILDER_API_URL_PROD =
   process.env.HUBTYPE_API_URL || 'https://api.hubtype.com'
 export const SEPARATOR = '|'
 export const SOURCE_INFO_SEPARATOR = `${SEPARATOR}source_`
+export const DO_NOTHING_PAYLOAD = 'fb-do-nothing'
 export const VARIABLE_PATTERN = /{([^}]+)}/g
 export const ACCESS_TOKEN_VARIABLE_KEY = '_access_token'
 export const REG_EXP_PATTERN = /^\/(.*)\/([gimyus]*)$/

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent.tsx
@@ -1,7 +1,7 @@
 import { AgenticOutputMessage } from '@botonic/core'
 import { Button, Carousel, Text } from '@botonic/react'
 
-import { SOURCE_INFO_SEPARATOR } from '../constants'
+import { DO_NOTHING_PAYLOAD, SOURCE_INFO_SEPARATOR } from '../constants'
 import { ContentFieldsBase } from './content-fields-base'
 import { FlowElement } from './flow-element'
 import { HtAiAgentNode, HtInputGuardrailRule } from './hubtype-fields/ai-agent'
@@ -40,7 +40,7 @@ export class FlowAiAgent extends ContentFieldsBase {
                 {response.content.buttons.map((button, buttonIndex) => (
                   <Button
                     key={buttonIndex}
-                    payload={`do-nothing${SOURCE_INFO_SEPARATOR}${buttonIndex}`}
+                    payload={`${DO_NOTHING_PAYLOAD}${SOURCE_INFO_SEPARATOR}${buttonIndex}`}
                   >
                     {button}
                   </Button>


### PR DESCRIPTION
## Description

Change the payload used in the buttons created by the AI Agent, currently `do-nothing`  to `fb-do-nothing`
The current one is already used by the delivery team.

