### PR TITLE
fix(plugin-flow-builder): Fix payload in toBotonic method of FlowWhatsappButtonList

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botonic",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botonic",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -25585,7 +25585,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "dependencies": {
         "@botonic/react": "^0.38.0",
         "axios": "^1.10.0",

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to Botonic will be documented in this file.
 
 </details>
 
+## [0.38.1] - 2025-08-26
+
+### Fixed
+
+- [PR-3093](https://github.com/hubtype/botonic/pull/3093): Fix payload in toBotonic method of FlowWhatsappButtonList component.
+
 ## [0.38.0] - 2025-08-20
 
 ### Added

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/content-fields/whatsapp-button-list/flow-whatsapp-button-list.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/whatsapp-button-list/flow-whatsapp-button-list.tsx
@@ -38,7 +38,7 @@ export class FlowWhatsappButtonList extends ContentFieldsBase {
     if (!isWhatsapp(request.session)) {
       const rows = this.sections.flatMap(section => section.rows)
       const buttons = rows.map(row => (
-        <Button key={row.id} payload={row.id}>
+        <Button key={row.id} payload={row.targetId}>
           {row.title}
         </Button>
       ))


### PR DESCRIPTION
## Description
Fix the value set in the `payload` prop when returning the value in the `toBotonic` method of `FlowWhatsappButtonList` for non WhatsApp channels.

## Context
Clicking a button of a `FlowWhatsappButtonList` component rendered in a webchat was not redirecting to the expected content.

## Approach taken / Explain the design

## To document / Usage example

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
