### PR TITLE
FlowBuilder: Export function to obtain the rating value selected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25585,7 +25585,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.38.1",
+      "version": "0.38.2",
       "dependencies": {
         "@botonic/react": "^0.38.0",
         "axios": "^1.10.0",

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to Botonic will be documented in this file.
 
 </details>
 
+## [0.38.2] - 2025-08-28
+
+### Added
+
+- [PR-3094](https://github.com/hubtype/botonic/pull/3094): Extract the logic that obtains the submitted rating information into a function so it can be exported and used in the bots.
+
 ## [0.38.1] - 2025-08-26
 
 ### Fixed

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/action/payload.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/payload.ts
@@ -1,9 +1,14 @@
 import { EventAction, EventFeedback, storeCaseRating } from '@botonic/core'
+import { ActionRequest } from '@botonic/react'
 import { v7 as uuid } from 'uuid'
 
 import { AGENT_RATING_PAYLOAD, SEPARATOR } from '../constants'
 import { FlowContent } from '../content-fields'
-import { HtNodeWithContent } from '../content-fields/hubtype-fields'
+import {
+  HtNodeWithContent,
+  HtRatingButton,
+} from '../content-fields/hubtype-fields'
+import { getFlowBuilderPlugin } from '../helpers'
 import { trackEvent } from '../tracking'
 import { FlowBuilderContext } from './index'
 
@@ -36,11 +41,12 @@ async function resolveRatingPayload(
     return []
   }
 
-  const id = request.input.payload
-  const buttonId = id?.split(SEPARATOR)[1]
-  const ratingNode = cmsApi.getRatingNodeByButtonId(buttonId)
-  const ratingButton = cmsApi.getRatingButtonById(ratingNode, buttonId)
-  const { target, text, value } = ratingButton
+  const { id, target, text, value } = getRatingButtonClicked(
+    request,
+    request.input.payload
+  )
+  const ratingNode = cmsApi.getRatingNodeByButtonId(id)
+
   const possibleOptions = ratingNode.content.buttons.map(button => button.text)
   const possibleValues = ratingNode.content.buttons.map(button => button.value)
 
@@ -68,4 +74,16 @@ async function resolveRatingPayload(
   }
 
   return []
+}
+
+export function getRatingButtonClicked(
+  request: ActionRequest,
+  payload: string
+): HtRatingButton {
+  const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)
+  const cmsApi = flowBuilderPlugin.cmsApi
+  const buttonId = payload?.split(SEPARATOR)[1]
+  const ratingNode = cmsApi.getRatingNodeByButtonId(buttonId)
+
+  return cmsApi.getRatingButtonById(ratingNode, buttonId)
 }

--- a/packages/botonic-plugin-flow-builder/src/action/payload.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/payload.ts
@@ -1,14 +1,9 @@
 import { EventAction, EventFeedback, storeCaseRating } from '@botonic/core'
-import { ActionRequest } from '@botonic/react'
 import { v7 as uuid } from 'uuid'
 
-import { AGENT_RATING_PAYLOAD, SEPARATOR } from '../constants'
+import { AGENT_RATING_PAYLOAD } from '../constants'
 import { FlowContent } from '../content-fields'
-import {
-  HtNodeWithContent,
-  HtRatingButton,
-} from '../content-fields/hubtype-fields'
-import { getFlowBuilderPlugin } from '../helpers'
+import { HtNodeWithContent } from '../content-fields/hubtype-fields'
 import { trackEvent } from '../tracking'
 import { FlowBuilderContext } from './index'
 
@@ -41,14 +36,8 @@ async function resolveRatingPayload(
     return []
   }
 
-  const { id, target, text, value } = getRatingButtonClicked(
-    request,
-    request.input.payload
-  )
-  const ratingNode = cmsApi.getRatingNodeByButtonId(id)
-
-  const possibleOptions = ratingNode.content.buttons.map(button => button.text)
-  const possibleValues = ratingNode.content.buttons.map(button => button.value)
+  const { target, text, value, possibleOptions, possibleValues } =
+    flowBuilderPlugin.getRatingSubmittedInfo(request.input.payload)
 
   if (request.session._hubtype_case_id) {
     const event: EventFeedback = {
@@ -74,16 +63,4 @@ async function resolveRatingPayload(
   }
 
   return []
-}
-
-export function getRatingButtonClicked(
-  request: ActionRequest,
-  payload: string
-): HtRatingButton {
-  const flowBuilderPlugin = getFlowBuilderPlugin(request.plugins)
-  const cmsApi = flowBuilderPlugin.cmsApi
-  const buttonId = payload?.split(SEPARATOR)[1]
-  const ratingNode = cmsApi.getRatingNodeByButtonId(buttonId)
-
-  return cmsApi.getRatingButtonById(ratingNode, buttonId)
 }

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -317,6 +317,8 @@ export default class BotonicPluginFlowBuilder implements Plugin {
 }
 
 export * from './action'
+export { getRatingButtonClicked } from './action/payload'
+export { AGENT_RATING_PAYLOAD } from './constants'
 export * from './content-fields'
 export { HtBotActionNode } from './content-fields/hubtype-fields'
 export { trackFlowContent } from './tracking'

--- a/packages/botonic-plugin-flow-builder/src/index.ts
+++ b/packages/botonic-plugin-flow-builder/src/index.ts
@@ -36,6 +36,7 @@ import {
   HtNodeComponent,
   HtNodeWithContent,
   HtNodeWithContentType,
+  HtRatingButton,
 } from './content-fields/hubtype-fields'
 import { DEFAULT_FUNCTIONS } from './functions'
 import {
@@ -46,6 +47,7 @@ import {
   InShadowingConfig,
   KnowledgeBaseFunction,
   PayloadParamsBase,
+  RatingSubmittedInfo,
   TrackEventFunction,
 } from './types'
 import { getNodeByUserInput } from './user-input'
@@ -314,10 +316,28 @@ export default class BotonicPluginFlowBuilder implements Plugin {
   getFlowName(flowId: string): string {
     return this.cmsApi.getFlowName(flowId)
   }
+
+  getRatingSubmittedInfo(payload: string): RatingSubmittedInfo {
+    const buttonId = payload?.split(SEPARATOR)[1]
+    const ratingNode = this.cmsApi.getRatingNodeByButtonId(buttonId)
+
+    const ratingButton = this.cmsApi.getRatingButtonById(ratingNode, buttonId)
+    const possibleOptions = ratingNode.content.buttons.map(
+      button => button.text
+    )
+    const possibleValues = ratingNode.content.buttons.map(
+      button => button.value
+    )
+
+    return {
+      ...ratingButton,
+      possibleOptions,
+      possibleValues,
+    }
+  }
 }
 
 export * from './action'
-export { getRatingButtonClicked } from './action/payload'
 export { AGENT_RATING_PAYLOAD } from './constants'
 export * from './content-fields'
 export { HtBotActionNode } from './content-fields/hubtype-fields'
@@ -327,5 +347,6 @@ export {
   ContentFilter,
   FlowBuilderJSONVersion,
   PayloadParamsBase,
+  RatingSubmittedInfo,
 } from './types'
 export * from './webview'

--- a/packages/botonic-plugin-flow-builder/src/types.ts
+++ b/packages/botonic-plugin-flow-builder/src/types.ts
@@ -1,17 +1,16 @@
 import {
-  AgenticOutputMessage,
   BotContext,
-  CarouselMessage,
   InferenceResponse,
   KnowledgeBasesResponse,
   PluginPreRequest,
   ResolvedPlugins,
-  TextMessage,
-  TextWithButtonsMessage,
 } from '@botonic/core'
 
 import { FlowContent } from './content-fields'
-import { HtFlowBuilderData } from './content-fields/hubtype-fields'
+import {
+  HtFlowBuilderData,
+  HtRatingButton,
+} from './content-fields/hubtype-fields'
 
 export interface InShadowingConfig {
   allowKeywords: boolean
@@ -115,4 +114,9 @@ export interface SmartIntentResponse {
 
 export interface PayloadParamsBase {
   followUpContentID?: string
+}
+
+export interface RatingSubmittedInfo extends HtRatingButton {
+  possibleOptions: string[]
+  possibleValues: number[]
 }


### PR DESCRIPTION
## Description
Extract the logic that obtains the submitted rating information into a function so it can be exported and used in the bots.

## Context
If the bot needs to do some extra logic with the rating selected, it needs to have a way to obtain the rating value selected by the user.

## Approach taken / Explain the design

## To document / Usage example
After exporting this new `getRatingButtonClicked` function, we could add a Plugin in the bot to do some extra logic in the `pre` method when a rating is submitted:
```ts
import { AGENT_RATING_PAYLOAD, getRatingSubmittedInfo } from '@botonic/plugin-flow-builder'
...
async pre(request: PluginPreRequest<BotPlugins>) {
    const { payload, cmsPlugin } = getRequestData(request)
    const agentRatingPayloadRegex = new RegExp(`^${AGENT_RATING_PAYLOAD}.*`)

    if (agentRatingPayloadRegex.test(payload)) {
      const { value } = cmsPlugin.getRatingSubmittedInfo(payload)
      // Do some logic with this rating value
    }
  }
```

## Testing

The pull request has no tests