### PR TITLE
feat(flow-builder): add missing alt prop in CustomRatingMessage

### DIFF
--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-rating.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-rating.tsx
@@ -72,6 +72,7 @@ export class FlowRating extends ContentFieldsBase {
 
       return (
         <CustomRatingMessage
+          alt={this.text}
           payloads={payloads}
           messageText={this.text}
           buttonText={this.sendButtonText}


### PR DESCRIPTION
## Description
Add the `alt` prop when returning the `CustomRatingMessage` to ensure a text will be displayed when rendering this custom message in the Hubtype Chat.
<img width="162" height="78" alt="Screenshot 2025-09-29 at 17 51 08" src="https://github.com/user-attachments/assets/db801ff3-d561-4f34-b083-189c9cfb14a7" />


## Context
In the Hubtype Chat, the rating message was appearing without any text.
<img width="162" height="54" alt="Screenshot 2025-09-29 at 17 51 33" src="https://github.com/user-attachments/assets/d5ab750e-3746-4d6f-9f45-554531d10d5d" />

## Testing

The pull request has no tests.