### PR TITLE
chore(botonic-core): remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10558,13 +10558,6 @@
       "version": "10.4.3",
       "license": "MIT"
     },
-    "node_modules/decode": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "kung-fu": "^0.2.0"
-      }
-    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "license": "MIT",
@@ -17550,10 +17543,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/kung-fu": {
-      "version": "0.2.1",
-      "license": "MIT"
     },
     "node_modules/launch-editor": {
       "version": "2.9.1",
@@ -25871,13 +25860,11 @@
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
         "axios": "^1.10.0",
-        "decode": "^0.3.0",
         "pako": "^2.1.0",
         "process": "^0.11.10",
         "pusher-js": "^5.1.1"
       },
       "devDependencies": {
-        "@types/minipass": "^3.3.5",
         "@types/pako": "^1.0.2",
         "babel-plugin-add-module-exports": "^1.0.2"
       },

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -31,13 +31,11 @@
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.25.9",
     "axios": "^1.10.0",
-    "decode": "^0.3.0",
     "pako": "^2.1.0",
     "process": "^0.11.10",
     "pusher-js": "^5.1.1"
   },
   "devDependencies": {
-    "@types/minipass": "^3.3.5",
     "@types/pako": "^1.0.2",
     "babel-plugin-add-module-exports": "^1.0.2"
   },


### PR DESCRIPTION
## Summary
- remove the unused `decode` runtime dependency from `@botonic/core`
- drop the unused `@types/minipass` dev dependency and clean the lockfile entries

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dcd4376170832f8d8b8319e69fc7db