### PR TITLE
Disable gloabl tracing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24148,7 +24148,7 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.47.0",
+      "version": "0.47.1",
       "dependencies": {
         "@botonic/core": "^0.47.0",
         "@openai/agents": "^0.3.9",

--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.46.x] - 2026-mm-dd
+## [0.47.x] - 2026-mm-dd
 
 ### Added
 
@@ -19,6 +19,19 @@ All notable changes to Botonic will be documented in this file.
 ### Fixed
 
 </details>
+
+## [0.47.1] - 2026-03-31
+
+- [PR-3196](https://github.com/hubtype/botonic/pull/3196): Disable global sdk tracing.  
+
+### Added
+
+## [0.47.0] - 2026-03-30
+
+- [PR-3190](https://github.com/hubtype/botonic/pull/3190): getInference accept a new parm with previousMessages that backend has not yet received.
+
+### Added
+
 
 ## [0.46.2] - 2026-03-26
 

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",

--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -39,6 +39,7 @@ export default class BotonicPluginAiAgents<
   private readonly timeout: number
   private readonly maxRetries: number
   public toolDefinitions: CustomTool<TPlugins, TExtraData>[] = []
+  private readonly localStorageKey: string
 
   constructor(options?: PluginAiAgentOptions<TPlugins, TExtraData>) {
     this.authToken = options?.authToken
@@ -47,10 +48,11 @@ export default class BotonicPluginAiAgents<
     this.timeout = options?.timeout ?? DEFAULT_TIMEOUT_16_SECONDS
     this.maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES
     this.logger = createDebugLogger(options?.enableDebug ?? false)
+    this.localStorageKey = options?.localStorageKey ?? 'botonicState'
     setTracingDisabled(true)
 
     this.logger.logInitialConfig({
-      messageHistoryApiVersion: this.messageHistoryApiVersion,
+      messageHistoryApiVersion: 'v2',
       maxRetries: options?.maxRetries ?? DEFAULT_MAX_RETRIES,
       timeout: options?.timeout ?? DEFAULT_TIMEOUT_16_SECONDS,
       customToolNames: this.toolDefinitions.map(t => t.name),
@@ -176,7 +178,8 @@ export default class BotonicPluginAiAgents<
     if (!isProd) {
       return await hubtypeClient.getLocalMessages(
         MAX_MEMORY_LENGTH,
-        previousHubtypeMessages
+        previousHubtypeMessages,
+        this.localStorageKey
       )
     }
 

--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -24,7 +24,6 @@ import type {
   CustomTool,
   InferenceResponse,
   MemoryOptions,
-  MessageHistoryApiVersion,
   PluginAiAgentOptions,
   Tool,
 } from './types'
@@ -35,7 +34,6 @@ export default class BotonicPluginAiAgents<
 > implements Plugin
 {
   private readonly authToken?: string
-  private readonly messageHistoryApiVersion: MessageHistoryApiVersion
   private readonly memory: MemoryOptions
   private readonly logger: DebugLogger
   private readonly timeout: number
@@ -43,16 +41,8 @@ export default class BotonicPluginAiAgents<
   public toolDefinitions: CustomTool<TPlugins, TExtraData>[] = []
 
   constructor(options?: PluginAiAgentOptions<TPlugins, TExtraData>) {
-    if (options?.messageHistoryApiVersion === 'v1' && options?.memory) {
-      throw new Error(
-        'Cannot use memory when messageHistoryApiVersion is "v1". ' +
-          'Either set messageHistoryApiVersion to "v2" or remove memory.'
-      )
-    }
-
     this.authToken = options?.authToken
     this.toolDefinitions = options?.customTools || []
-    this.messageHistoryApiVersion = options?.messageHistoryApiVersion ?? 'v2'
     this.memory = this.getMemoryOptions(options?.memory)
     this.timeout = options?.timeout ?? DEFAULT_TIMEOUT_16_SECONDS
     this.maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES

--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -5,7 +5,7 @@ import type {
   Plugin,
   ResolvedPlugins,
 } from '@botonic/core'
-import { tool } from '@openai/agents'
+import { setTracingDisabled, tool } from '@openai/agents'
 import { v7 as uuidv7 } from 'uuid'
 import { AIAgentBuilder } from './agent-builder'
 import {
@@ -57,6 +57,7 @@ export default class BotonicPluginAiAgents<
     this.timeout = options?.timeout ?? DEFAULT_TIMEOUT_16_SECONDS
     this.maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES
     this.logger = createDebugLogger(options?.enableDebug ?? false)
+    setTracingDisabled(true)
 
     this.logger.logInitialConfig({
       messageHistoryApiVersion: this.messageHistoryApiVersion,

--- a/packages/botonic-plugin-ai-agents/src/services/hubtype-api-client.ts
+++ b/packages/botonic-plugin-ai-agents/src/services/hubtype-api-client.ts
@@ -46,11 +46,12 @@ export class HubtypeApiClient {
 
   async getLocalMessages(
     maxMemoryLength: number,
-    previousHubtypeMessages: HubtypeAssistantMessage[]
+    previousHubtypeMessages: HubtypeAssistantMessage[],
+    localStorageKey: string
   ): Promise<AgenticInputMessage[]> {
     const localBotonicState =
       typeof globalThis !== 'undefined' && globalThis.localStorage
-        ? globalThis.localStorage.getItem('botonicState')
+        ? globalThis.localStorage.getItem(localStorageKey)
         : null
     const botonicState = JSON.parse(localBotonicState || '{}')
     const messages = botonicState.messages

--- a/packages/botonic-plugin-ai-agents/src/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/types.ts
@@ -84,6 +84,8 @@ export interface PluginAiAgentOptions<
   memory?: Partial<MemoryOptions>
   /** Enable debug logging for AI agent configuration and execution details. */
   enableDebug?: boolean
+  /** Key for the local storage to to get messages in local development mode */
+  localStorageKey?: string
 }
 
 export interface ResultRawResponse {

--- a/packages/botonic-plugin-ai-agents/src/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/types.ts
@@ -66,8 +66,6 @@ export type AIAgent<
   TExtraData = any,
 > = Agent<Context<TPlugins, TExtraData>, AgentOutputType<typeof OutputSchema>>
 
-export type MessageHistoryApiVersion = 'v1' | 'v2'
-
 export interface MemoryOptions {
   maxMessages: number
   includeToolCalls: boolean
@@ -83,9 +81,6 @@ export interface PluginAiAgentOptions<
   customTools?: CustomTool<TPlugins, TExtraData>[]
   maxRetries?: number
   timeout?: number
-  /** API version for message history endpoint. Defaults to 'v2'. */
-  messageHistoryApiVersion?: MessageHistoryApiVersion
-  /** Options for V2 message history API. Only used when messageHistoryApiVersion is 'v2'. */
   memory?: Partial<MemoryOptions>
   /** Enable debug logging for AI agent configuration and execution details. */
   enableDebug?: boolean

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.46.x] - 2026-mm-dd
+## [0.47.x] - 2026-mm-dd
 
 ### Added
 
@@ -19,6 +19,12 @@ All notable changes to Botonic will be documented in this file.
 ### Fixed
 
 </details>
+
+## [0.47.0] - 2026-03-30
+
+### Added
+
+- [PR-3190](https://github.com/hubtype/botonic/pull/3190): Allow as follow up a GoToFlow with Ai Agents flow.
 
 ## [0.46.2] - 2026-03-20
 


### PR DESCRIPTION
## Description

- Disable global tracing.
- Remove reference to message history v1.
- Add localStorage key to use a different localstroage to get messages in local development.
