### PR TITLE
feat: create core helpers to create botContext and reuse logic in all…

### DIFF
--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -41,7 +41,9 @@
   ],
   "typesVersions": {
     "*": {
-      "testing": ["./lib/cjs/testing/index.d.ts"]
+      "testing": [
+        "./lib/cjs/testing/index.d.ts"
+      ]
     }
   },
   "dependencies": {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -5,6 +5,16 @@
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
+  "exports": {
+    ".": {
+      "require": "./lib/cjs/index.js",
+      "import": "./lib/esm/index.js"
+    },
+    "./testing": {
+      "require": "./lib/cjs/testing/index.js",
+      "import": "./lib/esm/testing/index.js"
+    }
+  },
   "scripts": {
     "test": "../../node_modules/.bin/jest --coverage",
     "prepublishOnly": "rm -rf lib && npm i && npm run build",
@@ -29,6 +39,11 @@
     "index.d.ts",
     "README.md"
   ],
+  "typesVersions": {
+    "*": {
+      "testing": ["./lib/cjs/testing/index.d.ts"]
+    }
+  },
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.25.9",
     "axios": "^1.13.6",

--- a/packages/botonic-core/src/testing/index.ts
+++ b/packages/botonic-core/src/testing/index.ts
@@ -1,0 +1,315 @@
+import {
+  type BotContext,
+  type BotRequest,
+  type BotSecrets,
+  type BotSettings,
+  type ContactInfo,
+  INPUT,
+  type Input,
+  PROVIDER,
+  type ProviderType,
+  type ResolvedPlugins,
+  type Session,
+  type SessionUser,
+} from '../models'
+
+// ---------------------------------------------------------------------------
+// Default values
+// ---------------------------------------------------------------------------
+
+export const TEST_DEFAULTS = {
+  HUBTYPE_API_URL: 'https://api.hubtype.com',
+  STATIC_URL: 'https://static.hubtype.com',
+  LITELLM_API_URL: 'https://api.litellm.com',
+  AZURE_OPENAI_API_BASE: 'https://api.openai.com',
+  AZURE_OPENAI_API_VERSION: '2026-02-01',
+  LANGUAGE_DETECTION_ENABLED: 'true',
+  HUBTYPE_ACCESS_TOKEN: 'testAccessToken',
+  LITELLM_API_KEY: 'testLiteLLMAPIKey',
+  AZURE_OPENAI_API_KEY: 'testAzureOpenAIAPIKey',
+  ACCESS_TOKEN: 'fake_access_token',
+  HUBTYPE_API_HOST: 'https://api.hubtype.com',
+  FLOW_THREAD_ID: 'testFlowThreadId',
+  BOT_ID: 'testBotId',
+  USER_ID: 'testUserId',
+  ORG_ID: 'testOrgId',
+  ORG_NAME: 'testOrg',
+  PROVIDER: PROVIDER.WEBCHAT as ProviderType,
+  LOCALE: 'en',
+  COUNTRY: 'US',
+  BOT_INTERACTION_ID: 'testInteractionId',
+  MESSAGE_ID: 'testMessageId',
+  LAST_ROUTE_PATH: '',
+}
+
+// ---------------------------------------------------------------------------
+// Leaf factories
+// ---------------------------------------------------------------------------
+
+export function createTestSettings(
+  overrides?: Partial<BotSettings>
+): BotSettings {
+  return {
+    HUBTYPE_API_URL: TEST_DEFAULTS.HUBTYPE_API_URL,
+    STATIC_URL: TEST_DEFAULTS.STATIC_URL,
+    LITELLM_API_URL: TEST_DEFAULTS.LITELLM_API_URL,
+    AZURE_OPENAI_API_BASE: TEST_DEFAULTS.AZURE_OPENAI_API_BASE,
+    AZURE_OPENAI_API_VERSION: TEST_DEFAULTS.AZURE_OPENAI_API_VERSION,
+    LANGUAGE_DETECTION_ENABLED: TEST_DEFAULTS.LANGUAGE_DETECTION_ENABLED,
+    CUSTOM_SHORT_URL_HOST: null,
+    custom: {},
+    ...overrides,
+  }
+}
+
+export function createTestSecrets(overrides?: Partial<BotSecrets>): BotSecrets {
+  return {
+    HUBTYPE_ACCESS_TOKEN: TEST_DEFAULTS.HUBTYPE_ACCESS_TOKEN,
+    LITELLM_API_KEY: TEST_DEFAULTS.LITELLM_API_KEY,
+    AZURE_OPENAI_API_KEY: TEST_DEFAULTS.AZURE_OPENAI_API_KEY,
+    custom: {},
+    ...overrides,
+  }
+}
+
+export interface TestUserOptions {
+  id?: string
+  provider?: ProviderType
+  locale?: string
+  country?: string
+  systemLocale?: string
+  contactInfo?: ContactInfo[]
+  extraData?: Record<string, any>
+}
+
+export function createTestSessionUser(
+  options?: TestUserOptions
+): SessionUser<Record<string, any>> {
+  const locale = options?.locale ?? TEST_DEFAULTS.LOCALE
+  const country = options?.country ?? TEST_DEFAULTS.COUNTRY
+  return {
+    id: options?.id ?? TEST_DEFAULTS.USER_ID,
+    provider: options?.provider ?? TEST_DEFAULTS.PROVIDER,
+    locale,
+    country,
+    system_locale: options?.systemLocale ?? locale,
+    contact_info: options?.contactInfo ?? [],
+    extra_data: options?.extraData ?? {},
+  }
+}
+
+export interface TestSessionOptions {
+  user?: TestUserOptions
+  botId?: string
+  organization?: string
+  organizationId?: string
+  isFirstInteraction?: boolean
+  isTestIntegration?: boolean
+  accessToken?: string
+  hubtypeApi?: string
+  flowThreadId?: string
+  retries?: number
+  shadowing?: boolean
+  hubtypeCaseId?: string
+  captureUserInputNodeId?: string
+}
+
+export function createTestSession(
+  options?: TestSessionOptions
+): Session<Record<string, any>> {
+  return {
+    bot: { id: options?.botId ?? TEST_DEFAULTS.BOT_ID },
+    user: createTestSessionUser(options?.user),
+    organization: options?.organization ?? TEST_DEFAULTS.ORG_NAME,
+    organization_id: options?.organizationId ?? TEST_DEFAULTS.ORG_ID,
+    is_first_interaction: options?.isFirstInteraction ?? false,
+    is_test_integration: options?.isTestIntegration ?? false,
+    _access_token: options?.accessToken ?? TEST_DEFAULTS.ACCESS_TOKEN,
+    _hubtype_api: options?.hubtypeApi ?? TEST_DEFAULTS.HUBTYPE_API_HOST,
+    flow_thread_id: options?.flowThreadId ?? TEST_DEFAULTS.FLOW_THREAD_ID,
+    __retries: options?.retries ?? 0,
+    _shadowing: options?.shadowing,
+    _hubtype_case_id: options?.hubtypeCaseId,
+    capture_user_input: options?.captureUserInputNodeId
+      ? { node_id: options.captureUserInputNodeId }
+      : undefined,
+  }
+}
+
+export interface TestInputOptions {
+  type?: Input['type']
+  data?: string
+  text?: string
+  payload?: string
+  src?: string
+  botInteractionId?: string
+  messageId?: string
+  context?: Input['context']
+  transcript?: string
+}
+
+export function createTestInput(options?: TestInputOptions): Input {
+  return {
+    type: options?.type ?? INPUT.TEXT,
+    data: options?.data,
+    text: options?.text,
+    payload: options?.payload,
+    src: options?.src,
+    transcript: options?.transcript,
+    context: options?.context,
+    bot_interaction_id:
+      options?.botInteractionId ?? TEST_DEFAULTS.BOT_INTERACTION_ID,
+    message_id: options?.messageId ?? TEST_DEFAULTS.MESSAGE_ID,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Composite factories
+// ---------------------------------------------------------------------------
+
+export interface TestBotRequestOptions {
+  input?: TestInputOptions | Input
+  session?: TestSessionOptions | Session
+  lastRoutePath?: string
+  settings?: Partial<BotSettings> | BotSettings
+  secrets?: Partial<BotSecrets> | BotSecrets
+}
+
+function isFullInput(v: TestInputOptions | Input): v is Input {
+  return 'bot_interaction_id' in v && 'message_id' in v
+}
+
+function isFullSession(v: TestSessionOptions | Session): v is Session {
+  return 'bot' in v && '__retries' in v
+}
+
+function isFullSettings(
+  v: Partial<BotSettings> | BotSettings
+): v is BotSettings {
+  return (
+    'HUBTYPE_API_URL' in v &&
+    'STATIC_URL' in v &&
+    'LITELLM_API_URL' in v &&
+    'AZURE_OPENAI_API_BASE' in v &&
+    'AZURE_OPENAI_API_VERSION' in v &&
+    'LANGUAGE_DETECTION_ENABLED' in v &&
+    'CUSTOM_SHORT_URL_HOST' in v &&
+    'custom' in v
+  )
+}
+
+function isFullSecrets(
+  v: Partial<BotSecrets> | BotSecrets
+): v is BotSecrets {
+  return (
+    'HUBTYPE_ACCESS_TOKEN' in v &&
+    'LITELLM_API_KEY' in v &&
+    'AZURE_OPENAI_API_KEY' in v &&
+    'custom' in v
+  )
+}
+
+export function createTestBotRequest(
+  options?: TestBotRequestOptions
+): BotRequest {
+  const input =
+    options?.input == null
+      ? createTestInput()
+      : isFullInput(options.input)
+        ? options.input
+        : createTestInput(options.input)
+
+  const session =
+    options?.session == null
+      ? createTestSession()
+      : isFullSession(options.session)
+        ? options.session
+        : createTestSession(options.session)
+
+  const settings =
+    options?.settings == null
+      ? createTestSettings()
+      : isFullSettings(options.settings)
+        ? options.settings
+        : createTestSettings(options.settings)
+
+  const secrets =
+    options?.secrets == null
+      ? createTestSecrets()
+      : isFullSecrets(options.secrets)
+        ? options.secrets
+        : createTestSecrets(options.secrets)
+
+  return {
+    input,
+    session,
+    lastRoutePath: options?.lastRoutePath ?? TEST_DEFAULTS.LAST_ROUTE_PATH,
+    settings,
+    secrets,
+  }
+}
+
+export interface TestBotContextOptions<
+  TPlugins extends ResolvedPlugins = ResolvedPlugins,
+> extends TestBotRequestOptions {
+  plugins?: TPlugins
+  params?: Record<string, string>
+  defaultDelay?: number
+  defaultTyping?: number
+}
+
+export function createTestBotContext<
+  TPlugins extends ResolvedPlugins = ResolvedPlugins,
+>(
+  options?: TestBotContextOptions<TPlugins>
+): BotContext<TPlugins> {
+  const request = createTestBotRequest(options)
+
+  const sessionForLocale =
+    options?.session == null
+      ? createTestSession()
+      : isFullSession(options.session)
+        ? options.session
+        : createTestSession(options.session)
+
+  const locale = sessionForLocale.user.locale
+  const country = sessionForLocale.user.country
+  const systemLocale = sessionForLocale.user.system_locale
+
+  return {
+    ...request,
+    plugins: options?.plugins ?? ({} as TPlugins),
+    params: options?.params ?? {},
+    defaultDelay: options?.defaultDelay ?? 0,
+    defaultTyping: options?.defaultTyping ?? 0,
+    getUserLocale: () => locale,
+    getUserCountry: () => country,
+    getSystemLocale: () => systemLocale,
+    setUserLocale: () => undefined,
+    setUserCountry: () => undefined,
+    setSystemLocale: () => undefined,
+  }
+}
+
+/**
+ * Alias for `createTestBotContext` typed as `PluginPreRequest`.
+ * PluginPreRequest === BotContext in @botonic/core.
+ */
+export const createTestPluginPreRequest = createTestBotContext
+
+export interface TestPluginPostRequestOptions<
+  TPlugins extends ResolvedPlugins = ResolvedPlugins,
+> extends TestBotContextOptions<TPlugins> {
+  response?: string | null
+}
+
+export function createTestPluginPostRequest<
+  TPlugins extends ResolvedPlugins = ResolvedPlugins,
+>(
+  options?: TestPluginPostRequestOptions<TPlugins>
+): BotContext<TPlugins> & { response: string | null } {
+  return {
+    ...createTestBotContext(options),
+    response: options?.response ?? null,
+  }
+}

--- a/packages/botonic-core/src/testing/index.ts
+++ b/packages/botonic-core/src/testing/index.ts
@@ -198,9 +198,7 @@ function isFullSettings(
   )
 }
 
-function isFullSecrets(
-  v: Partial<BotSecrets> | BotSecrets
-): v is BotSecrets {
+function isFullSecrets(v: Partial<BotSecrets> | BotSecrets): v is BotSecrets {
   return (
     'HUBTYPE_ACCESS_TOKEN' in v &&
     'LITELLM_API_KEY' in v &&
@@ -260,9 +258,7 @@ export interface TestBotContextOptions<
 
 export function createTestBotContext<
   TPlugins extends ResolvedPlugins = ResolvedPlugins,
->(
-  options?: TestBotContextOptions<TPlugins>
-): BotContext<TPlugins> {
+>(options?: TestBotContextOptions<TPlugins>): BotContext<TPlugins> {
   const request = createTestBotRequest(options)
 
   const sessionForLocale =

--- a/packages/botonic-core/src/testing/index.ts
+++ b/packages/botonic-core/src/testing/index.ts
@@ -24,9 +24,9 @@ export const TEST_DEFAULTS = {
   AZURE_OPENAI_API_BASE: 'https://api.openai.com',
   AZURE_OPENAI_API_VERSION: '2026-02-01',
   LANGUAGE_DETECTION_ENABLED: 'true',
-  HUBTYPE_ACCESS_TOKEN: 'testAccessToken',
-  LITELLM_API_KEY: 'testLiteLLMAPIKey',
-  AZURE_OPENAI_API_KEY: 'testAzureOpenAIAPIKey',
+  HUBTYPE_ACCESS_TOKEN: 'testAccessToken', // pragma: allowlist secret
+  LITELLM_API_KEY: 'testLiteLLMAPIKey', // pragma: allowlist secret
+  AZURE_OPENAI_API_KEY: 'testAzureOpenAIAPIKey', // pragma: allowlist secret
   ACCESS_TOKEN: 'fake_access_token',
   HUBTYPE_API_HOST: 'https://api.hubtype.com',
   FLOW_THREAD_ID: 'testFlowThreadId',

--- a/packages/botonic-core/tests/routing/router.match-route.test.ts
+++ b/packages/botonic-core/tests/routing/router.match-route.test.ts
@@ -1,85 +1,51 @@
 import { type BotRequest, INPUT, type Input } from '../../src'
 import { Router } from '../../src/routing'
+import { createTestBotRequest, createTestInput } from '../../src/testing'
 import { testRoute, testSession } from '../helpers/routing'
 
-const textInput: Input = {
-  type: INPUT.TEXT,
-  text: 'hi',
-  bot_interaction_id: 'testInteractionId',
-  message_id: 'testMessageId',
-}
+const textInput: Input = createTestInput({ type: INPUT.TEXT, text: 'hi' })
 
-const textInputComplex: Input = {
+const textInputComplex: Input = createTestInput({
   type: INPUT.TEXT,
   text: 'Cömplêx input &% 🚀',
-  bot_interaction_id: 'testInteractionId',
-  message_id: 'testMessageId',
-}
+})
 
-const textPayloadInput: Input = {
+const textPayloadInput: Input = createTestInput({
   type: INPUT.TEXT,
   text: 'hi',
   payload: 'foo',
-  bot_interaction_id: 'testInteractionId',
-  message_id: 'testMessageId',
-}
+})
 
-const postbackInput: Input = {
+const postbackInput: Input = createTestInput({
   type: INPUT.POSTBACK,
   payload: 'foo',
-  bot_interaction_id: 'testInteractionId',
-  message_id: 'testMessageId',
-}
+})
 
-const audioInput: Input = {
+const audioInput: Input = createTestInput({
   type: INPUT.AUDIO,
   src: 'data:audio/mpeg;base64,iVBORw0KG',
-  bot_interaction_id: 'testInteractionId',
-  message_id: 'testMessageId',
-}
+})
 
-const documentInput: Input = {
+const documentInput: Input = createTestInput({
   type: INPUT.DOCUMENT,
   src: 'data:application/pdf;base64,iVBORw0KG',
-  bot_interaction_id: 'testInteractionId',
-  message_id: 'testMessageId',
-}
+})
 
-const imageInput: Input = {
+const imageInput: Input = createTestInput({
   type: INPUT.IMAGE,
   src: 'data:image/png;base64,iVBORw0KG',
-  bot_interaction_id: 'testInteractionId',
-  message_id: 'testMessageId',
-}
+})
 
-const videoInput: Input = {
+const videoInput: Input = createTestInput({
   type: INPUT.VIDEO,
   src: 'data:video/mp4;base64,iVBORw0KG',
-  bot_interaction_id: 'testInteractionId',
-  message_id: 'testMessageId',
-}
+})
 
-const requestInput: BotRequest = {
+const requestInput: BotRequest = createTestBotRequest({
   input: textInput,
   session: { ...testSession(), organization: 'myOrg' },
   lastRoutePath: 'initial',
-  settings: {
-    HUBTYPE_API_URL: 'https://api.hubtype.com',
-    STATIC_URL: 'https://static.hubtype.com',
-    LITELLM_API_URL: 'https://api.litellm.com',
-    AZURE_OPENAI_API_BASE: 'https://api.openai.com',
-    AZURE_OPENAI_API_VERSION: '2026-02-01',
-    LANGUAGE_DETECTION_ENABLED: 'true',
-    CUSTOM_SHORT_URL_HOST: null,
-    custom: {},
-  },
-  secrets: {
-    HUBTYPE_ACCESS_TOKEN: 'testAccessToken',
-    LITELLM_API_KEY: 'testLiteLLMAPIKey',
-    AZURE_OPENAI_API_KEY: 'testAzureOpenAIAPIKey',
-    custom: {},
-  },
-}
+})
 
 describe('TEST: Match route by MATCHER <> INPUT', () => {
   const router = new Router([])

--- a/packages/botonic-plugin-ai-agents/tests/index.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/index.test.ts
@@ -5,6 +5,7 @@ import {
   PROVIDER,
   VerbosityLevel,
 } from '@botonic/core'
+import { createTestBotContext } from '@botonic/core/testing'
 import {
   afterEach,
   beforeEach,
@@ -74,72 +75,37 @@ describe('BotonicPluginAiAgents - Campaign Context Integration', () => {
       name: string
       agent_context?: string
     }[]
-  ): BotContext => ({
-    session: {
-      is_first_interaction: false,
-      organization: 'test-org',
-      organization_id: 'org-123',
-      bot: { id: 'bot-123' },
-      user: {
-        id: 'user-123',
-        provider: PROVIDER.WEBCHAT,
-        locale: 'en',
-        country: 'US',
-        system_locale: 'en',
-        contact_info: [
-          {
-            name: 'email',
-            value: 'test@test.com',
-            type: 'string',
-            description: 'User email',
-          },
-        ],
-        extra_data: {},
+  ): BotContext =>
+    createTestBotContext({
+      session: {
+        organization: 'test-org',
+        organizationId: 'org-123',
+        botId: 'bot-123',
+        user: {
+          id: 'user-123',
+          provider: PROVIDER.WEBCHAT,
+          locale: 'en',
+          country: 'US',
+          contactInfo: [
+            {
+              name: 'email',
+              value: 'test@test.com',
+              type: 'string',
+              description: 'User email',
+            },
+          ],
+        },
+        accessToken: 'test-token',
+        flowThreadId: 'flow-123',
       },
-      _access_token: 'test-token',
-      _hubtype_api: 'https://api.hubtype.com',
-      is_test_integration: false,
-      flow_thread_id: 'flow-123',
-      __retries: 0,
-    },
-    input: {
-      type: INPUT.TEXT,
-      data: 'Hello',
-      bot_interaction_id: 'interaction-123',
-      message_id: 'msg-123',
-      context: campaigns_v2 ? { campaigns_v2 } : undefined,
-    },
-    lastRoutePath: '',
-    settings: {
-      HUBTYPE_API_URL: 'https://api.hubtype.com',
-      STATIC_URL: 'https://static.hubtype.com',
-      LITELLM_API_URL: 'https://api.litellm.com',
-      AZURE_OPENAI_API_BASE: 'https://api.openai.com',
-      AZURE_OPENAI_API_VERSION: '2026-02-01',
-      LANGUAGE_DETECTION_ENABLED: 'true',
-      CUSTOM_SHORT_URL_HOST: null,
-      custom: {},
-    },
-    secrets: {
-      HUBTYPE_ACCESS_TOKEN: 'testAccessToken',
-      LITELLM_API_KEY: 'testLiteLLMAPIKey',
-      AZURE_OPENAI_API_KEY: 'testAzureOpenAIAPIKey',
-      custom: {},
-    },
-    params: {},
-    defaultDelay: 0,
-    defaultTyping: 0,
-    plugins: {},
-    getUserCountry: () => 'US',
-    getUserLocale: () => 'en',
-    getSystemLocale: () => 'en',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setUserCountry: jest.fn() as any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setUserLocale: jest.fn() as any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setSystemLocale: jest.fn() as any,
-  })
+      input: {
+        type: INPUT.TEXT,
+        data: 'Hello',
+        botInteractionId: 'interaction-123',
+        messageId: 'msg-123',
+        context: campaigns_v2 ? { campaigns_v2 } : undefined,
+      },
+    })
 
   const mockAiAgentArgs: AiAgentArgs = {
     name: 'Test Agent',

--- a/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/utils.ts
@@ -8,6 +8,7 @@ import {
   type ProviderType,
   type ResolvedPlugins,
 } from '@botonic/core'
+import { createTestPluginPreRequest } from '@botonic/core/testing'
 import type { ActionRequest } from '@botonic/react'
 
 import BotonicPluginFlowBuilder, {
@@ -89,74 +90,32 @@ export function createRequest({
   captureUserInputId,
   contactInfo = [],
 }: RequestArgs): PluginPreRequest {
-  return {
+  return createTestPluginPreRequest({
     session: {
-      is_first_interaction: isFirstInteraction,
+      isFirstInteraction,
       organization: 'orgTest',
-      organization_id: 'orgIdTest',
-      bot: { id: 'bid1' },
+      organizationId: 'orgIdTest',
+      botId: 'bid1',
       user: {
-        provider,
         id: 'uid1',
+        provider,
         locale: user.locale,
         country: user.country,
-        system_locale: user.systemLocale,
-        contact_info: contactInfo,
-        extra_data: extraData,
+        systemLocale: user.systemLocale,
+        contactInfo,
+        extraData,
       },
-      _shadowing: shadowing,
-      _hubtype_case_id: hubtypeCaseId,
-      __retries: 0,
-      _access_token: 'fake_access_token',
-      _hubtype_api: 'https://api.hubtype.com',
-      is_test_integration: false,
-      flow_thread_id: 'testFlowThreadId',
-      capture_user_input: captureUserInputId
-        ? {
-            node_id: captureUserInputId,
-          }
-        : undefined,
+      shadowing,
+      hubtypeCaseId,
+      captureUserInputNodeId: captureUserInputId,
     },
     input: {
       bot_interaction_id: 'testInteractionId',
       message_id: 'testMessageId',
       ...input,
-    },
-    lastRoutePath: '',
-    settings: {
-      HUBTYPE_API_URL: 'https://api.hubtype.com',
-      STATIC_URL: 'https://static.hubtype.com',
-      LITELLM_API_URL: 'https://api.litellm.com',
-      AZURE_OPENAI_API_BASE: 'https://api.openai.com',
-      AZURE_OPENAI_API_VERSION: '2026-02-01',
-      LANGUAGE_DETECTION_ENABLED: 'true',
-      CUSTOM_SHORT_URL_HOST: null,
-      custom: {},
-    },
-    secrets: {
-      HUBTYPE_ACCESS_TOKEN: 'testAccessToken',
-      LITELLM_API_KEY: 'testLiteLLMAPIKey',
-      AZURE_OPENAI_API_KEY: 'testAzureOpenAIAPIKey',
-      custom: {},
-    },
+    } as Input,
     plugins,
-    getUserCountry: () => user.country,
-    getUserLocale: () => user.locale,
-    getSystemLocale: () => user.systemLocale,
-    setUserCountry: (_country: string) => {
-      user.country = _country
-      return
-    },
-    setUserLocale: (_locale: string) => {
-      return
-    },
-    setSystemLocale: (_locale: string) => {
-      return
-    },
-    params: {},
-    defaultDelay: 0,
-    defaultTyping: 0,
-  }
+  })
 }
 
 export async function getContentsAfterPreAndBotonicInit(

--- a/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
@@ -1,8 +1,4 @@
-import {
-  type BotContext,
-  type ProviderType,
-  type ResolvedPlugins,
-} from '@botonic/core'
+import type { BotContext, ProviderType, ResolvedPlugins } from '@botonic/core'
 import { createTestBotContext } from '@botonic/core/testing'
 
 import BotonicPluginHubtypeAnalytics from '../../src/index'

--- a/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/helpers/index.ts
@@ -1,10 +1,9 @@
 import {
   type BotContext,
-  INPUT,
-  PROVIDER,
   type ProviderType,
   type ResolvedPlugins,
 } from '@botonic/core'
+import { createTestBotContext } from '@botonic/core/testing'
 
 import BotonicPluginHubtypeAnalytics from '../../src/index'
 
@@ -23,64 +22,22 @@ export function getRequestData(args?: RequestArgs) {
 }
 
 export function createRequest(args?: RequestArgs): BotContext<ResolvedPlugins> {
-  return {
+  return createTestBotContext({
     session: {
-      is_first_interaction: args?.isFirstInteraction || false,
+      isFirstInteraction: args?.isFirstInteraction ?? false,
       organization: 'orgTest',
-      organization_id: 'orgIdTest',
-      bot: { id: 'bid1' },
+      organizationId: 'orgIdTest',
+      botId: 'bid1',
       user: {
-        locale: args?.language || 'es',
-        country: args?.country || 'ES',
-        system_locale: args?.language || 'es',
-        provider: args?.provider || PROVIDER.WEBCHAT,
-        id: args?.chatId || 'chatIdTest',
-        extra_data: {},
+        id: args?.chatId ?? 'chatIdTest',
+        provider: args?.provider,
+        locale: args?.language ?? 'es',
+        country: args?.country ?? 'ES',
+        systemLocale: args?.language ?? 'es',
       },
-      __retries: 0,
-      _access_token: 'fake_access_token',
-      _hubtype_api: 'https://api.hubtype.com',
-      is_test_integration: false,
-      flow_thread_id: 'testFlowThreadId',
     },
     input: {
       data: 'Hola',
-      type: INPUT.TEXT,
-      bot_interaction_id: 'testInteractionId',
-      message_id: 'testMessageId',
     },
-    lastRoutePath: '',
-    settings: {
-      HUBTYPE_API_URL: 'https://api.hubtype.com',
-      STATIC_URL: 'https://static.hubtype.com',
-      LITELLM_API_URL: 'https://api.litellm.com',
-      AZURE_OPENAI_API_BASE: 'https://api.openai.com',
-      AZURE_OPENAI_API_VERSION: '2026-02-01',
-      LANGUAGE_DETECTION_ENABLED: 'true',
-      CUSTOM_SHORT_URL_HOST: null,
-      custom: {},
-    },
-    secrets: {
-      HUBTYPE_ACCESS_TOKEN: 'testAccessToken',
-      LITELLM_API_KEY: 'testLiteLLMAPIKey',
-      AZURE_OPENAI_API_KEY: 'testAzureOpenAIAPIKey',
-      custom: {},
-    },
-    getUserCountry: () => args?.country || 'ES',
-    getUserLocale: () => args?.language || 'es',
-    getSystemLocale: () => args?.language || 'es',
-    setUserCountry: () => {
-      return
-    },
-    setUserLocale: () => {
-      return
-    },
-    setSystemLocale: () => {
-      return
-    },
-    defaultDelay: 0,
-    defaultTyping: 0,
-    params: {},
-    plugins: {},
-  }
+  })
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,6 +20,7 @@
     "noImplicitAny": false,
     "paths": {
       "@botonic/core": ["./packages/botonic-core/src"],
+      "@botonic/core/testing": ["./packages/botonic-core/src/testing"],
       "@botonic/react": ["./packages/botonic-react/src"]
     },
     "preserveSymlinks": false


### PR DESCRIPTION
## Description

Create a testing helpers to create BotContext, Input, Session etc
export it from @botonic/core/testing

### Writing tests with the shared helpers

```typescript
import { createTestBotContext, createTestInput, INPUT } from '@botonic/core/testing'

const ctx = createTestBotContext({
  input: { type: INPUT.TEXT, text: 'hello' },
  session: { organization: 'acme', isFirstInteraction: true },
  settings: { CUSTOM_SHORT_URL_HOST: 'https://short.acme.com' }, // only override what matters
})
```

### Extending the helper in a plugin

```typescript
// packages/botonic-plugin-x/tests/helpers/index.ts
import { createTestBotContext } from '@botonic/core/testing'

export function createPluginXRequest(args?: { locale?: string }) {
  return createTestBotContext({
    session: { user: { locale: args?.locale ?? 'en' } },
    plugins: { pluginX: new BotonicPluginX() },
  })
}
```
