### PR TITLE
plugin-ai-agents: only ensure the call to knowledge for gpt-4 models

### DIFF
--- a/packages/botonic-plugin-ai-agents/src/runner.ts
+++ b/packages/botonic-plugin-ai-agents/src/runner.ts
@@ -9,7 +9,7 @@ import {
   RunToolCallItem,
   RunToolCallOutputItem,
 } from '@openai/agents'
-import { isProd, OPENAI_PROVIDER } from './constants'
+import { isProd } from './constants'
 import type { DebugLogger } from './debug-logger'
 import { getApiVersion, type LLMConfig } from './llm-config'
 import { HubtypeApiClient } from './services/hubtype-api-client'
@@ -73,7 +73,7 @@ export class AIAgentRunner<
       const modelSettings = this.llmConfig.modelSettings
 
       const hasRetrieveKnowledge = this.agent.tools.includes(retrieveKnowledge)
-      if (hasRetrieveKnowledge && OPENAI_PROVIDER === 'azure') {
+      if (hasRetrieveKnowledge && this.llmConfig.modelName.includes('gpt-4')) {
         modelSettings.toolChoice = retrieveKnowledge.name
       }
 

--- a/packages/botonic-plugin-ai-agents/tests/runner.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/runner.test.ts
@@ -100,9 +100,12 @@ function makeToolCallItem(
   ) as any
 }
 
-function buildMockLlmConfig(provider: 'openai' | 'azure' = 'azure'): LLMConfig {
+function buildMockLlmConfig(
+  provider: 'openai' | 'azure' = 'azure',
+  modelName: string = 'gpt-4.1-mini'
+): LLMConfig {
   return {
-    modelName: 'gpt-4.1-mini',
+    modelName,
     modelSettings: {
       temperature: 0,
       toolChoice: undefined as string | undefined,
@@ -390,11 +393,9 @@ describe('AIAgentRunner', () => {
       expect(llmConfig.modelSettings.toolChoice).toBe('retrieve_knowledge')
     })
 
-    it('should NOT set toolChoice for openai provider even with retrieve_knowledge tool', async () => {
-      mockConstants.OPENAI_PROVIDER = 'openai'
+    it('should NOT set toolChoice for other models than gpt-4', async () => {
+      const llmConfig = buildMockLlmConfig('openai', 'gpt-5-mini')
       mockRunnerRunImpl.mockResolvedValueOnce(makeTextRunnerResult())
-
-      const llmConfig = buildMockLlmConfig('openai')
       await createRunner(buildMockAgent(true), llmConfig).run(
         sampleMessages,
         buildMockContext()


### PR DESCRIPTION
## Description

Update AI agent tool choice logic. Only ensure the call to `knowledge` for GPT-4 models

- Removed dependency on OPENAI_PROVIDER and replaced it with a check for 'gpt-4' in the model name for tool choice selection.
- Cleaned up imports by removing unused OPENAI_PROVIDER constant.

## Testing

- update tests to check that not call knowledge with gpt-5-mini
