### PR TITLE
botonic-react: Assure urls are always opened via _self on WebView apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23994,7 +23994,7 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "license": "MIT",
       "dependencies": {
         "@botonic/core": "^0.48.0",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/components/button/index.tsx
+++ b/packages/botonic-react/src/components/button/index.tsx
@@ -44,8 +44,8 @@ export const Button = (props: ButtonProps) => {
             payload: props.payload,
           })
     } else if (props.url) {
-      const defaultTarget = isInWebviewApp() ? '_self' : '_blank'
-      window.open(props.url, props.target || defaultTarget)
+      const target = isInWebviewApp() ? '_self' : props.target
+      window.open(props.url, target)
     }
 
     if (props.onClick) {

--- a/packages/botonic-react/src/components/button/index.tsx
+++ b/packages/botonic-react/src/components/button/index.tsx
@@ -44,7 +44,8 @@ export const Button = (props: ButtonProps) => {
             payload: props.payload,
           })
     } else if (props.url) {
-      const target = isInWebviewApp() ? '_self' : props.target
+      const defaultTarget = props.target || '_blank'
+      const target = isInWebviewApp() ? '_self' : defaultTarget
       window.open(props.url, target)
     }
 


### PR DESCRIPTION
Stop defaulting url buttons to _blank when target is omitted; use the explicit target prop so callers control window.open behavior.

<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

We were facing an issue on Alsa that in their app (which is implemented via WebView) the url buttons generated via AI Agents wasn't opening.

With @asastre we found that the issue was that when they generated via AI Agent by default they have `_blank` as default, and was skipping the `isInWebviewApp` check.


<!--
- Must be clear and concise (2-3 lines).
  - Don't make reviewers think. The description should explain what has been implemented or what it's used for. If a pull request is not descriptive, people will be lazy or not willing to spend much time on it.
  - Be explicit with the names (don't abbreviate and don't use acronyms that can lead to misleading understanding).
  - If you consider it appropriate, include the steps to try the new features.
-->

## Approach taken / Explain the design

- Assure that always when a button is rendered on a WebView app it sets the target to `_self` no matters what comes set from upper level. 


<!--
- Explain what the code does.
- If it's a complex solution, try to provide a sketch.
-->


## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
