### PR TITLE
fix: set as undefined toolChoice only for modelSettings used in guard…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23898,7 +23898,7 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "dependencies": {
         "@botonic/core": "^0.48.0",
         "@openai/agents": "^0.3.9",

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",

--- a/packages/botonic-plugin-ai-agents/src/guardrails/input.ts
+++ b/packages/botonic-plugin-ai-agents/src/guardrails/input.ts
@@ -42,8 +42,10 @@ export function createInputGuardrail(
     execute: async ({ input, context }) => {
       const lastMessage = input[input.length - 1] as UserMessageItem
       const modelProvider = llmConfig.modelProvider
-      const modelSettings = llmConfig.modelSettings
-      modelSettings.toolChoice = undefined
+      const modelSettings = {
+        ...llmConfig.modelSettings,
+        toolChoice: undefined,
+      }
       const runner = new Runner({
         modelSettings,
         modelProvider,

--- a/packages/botonic-plugin-ai-agents/src/guardrails/input.ts
+++ b/packages/botonic-plugin-ai-agents/src/guardrails/input.ts
@@ -1,6 +1,7 @@
 import {
   Agent,
   type InputGuardrail,
+  type ModelSettings,
   Runner,
   type UserMessageItem,
 } from '@openai/agents'
@@ -42,10 +43,7 @@ export function createInputGuardrail(
     execute: async ({ input, context }) => {
       const lastMessage = input[input.length - 1] as UserMessageItem
       const modelProvider = llmConfig.modelProvider
-      const modelSettings = {
-        ...llmConfig.modelSettings,
-        toolChoice: undefined,
-      }
+      const modelSettings = createInputGuardrailModelSettings(llmConfig)
       const runner = new Runner({
         modelSettings,
         modelProvider,
@@ -76,6 +74,15 @@ export function createInputGuardrail(
         tripwireTriggered: triggered,
       }
     },
+  }
+}
+
+function createInputGuardrailModelSettings(
+  llmConfig: LLMConfig
+): ModelSettings {
+  return {
+    ...llmConfig.modelSettings,
+    toolChoice: undefined,
   }
 }
 

--- a/packages/botonic-plugin-ai-agents/tests/runner.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/runner.test.ts
@@ -1,6 +1,11 @@
 import type { DebugLogger } from '../src/debug-logger'
 import type { LLMConfig } from '../src/llm-config'
-import type { AgenticInputMessage, AIAgent, Context } from '../src/types'
+import type {
+  AgenticInputMessage,
+  AIAgent,
+  Context,
+  GuardrailRule,
+} from '../src/types'
 
 const mockTrackLlmRuns = jest.fn().mockResolvedValue(undefined)
 
@@ -22,11 +27,34 @@ const mockLogger: DebugLogger = {
   logToolExecution: jest.fn(),
 }
 
+type RunnerConfig = {
+  modelSettings: LLMConfig['modelSettings']
+  modelProvider: LLMConfig['modelProvider']
+  tracingDisabled: boolean
+}
+
 // Captured runner config for assertions
 let capturedRunnerConfig: any = null
+let capturedRunnerConfigs: RunnerConfig[] = []
 const mockRunnerRunImpl: jest.Mock = jest.fn()
 
 jest.mock('@openai/agents', () => {
+  const MockAgent = jest
+    .fn()
+    .mockImplementation(
+      (config: {
+        name: string
+        instructions?: string
+        tools?: unknown[]
+        outputType?: unknown
+      }) => ({
+        name: config.name,
+        instructions: config.instructions,
+        tools: config.tools ?? [],
+        outputType: config.outputType,
+      })
+    )
+
   class MockRunToolCallItem {
     rawItem: any
     constructor(rawItem: any) {
@@ -51,12 +79,14 @@ jest.mock('@openai/agents', () => {
 
   const MockRunner = jest.fn().mockImplementation((config: any) => {
     capturedRunnerConfig = config
+    capturedRunnerConfigs.push(config)
     return {
       run: mockRunnerRunImpl,
     }
   })
 
   return {
+    Agent: MockAgent,
     Runner: MockRunner,
     RunToolCallItem: MockRunToolCallItem,
     RunToolCallOutputItem: MockRunToolCallOutputItem,
@@ -85,6 +115,7 @@ jest.mock('../src/constants', () => mockConstants)
 
 // Import after mocks
 import { RunToolCallItem } from '@openai/agents'
+import { createInputGuardrail } from '../src/guardrails/input'
 import { AIAgentRunner } from '../src/runner'
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -189,6 +220,7 @@ describe('AIAgentRunner', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     capturedRunnerConfig = null
+    capturedRunnerConfigs = []
     mockConstants.OPENAI_PROVIDER = 'azure'
     mockConstants.isProd = false
   })
@@ -387,6 +419,62 @@ describe('AIAgentRunner', () => {
         buildMockContext()
       )
 
+      expect(llmConfig.modelSettings.toolChoice).toBe('retrieve_knowledge')
+    })
+
+    it('should keep retrieve_knowledge for the main runner but clear toolChoice for input guardrails', async () => {
+      mockConstants.OPENAI_PROVIDER = 'azure'
+      const llmConfig = buildMockLlmConfig('azure')
+      const guardrailRules: GuardrailRule[] = [
+        {
+          name: 'is_offensive',
+          description: 'Whether the user input is offensive.',
+        },
+      ]
+      const inputGuardrail = createInputGuardrail(guardrailRules, llmConfig, {
+        botId: 'test-bot-id',
+        isTest: false,
+        authToken: 'test-token',
+        inferenceId: 'test-inference-id',
+      })
+      const agent = {
+        ...buildMockAgent(true),
+        inputGuardrails: [inputGuardrail],
+      } as AIAgent
+
+      // Simulates the OpenAI runner executing the input guardrails before the
+      // main agent output is produced.
+      mockRunnerRunImpl
+        .mockImplementationOnce(async (agentArg, messages, options) => {
+          await agentArg.inputGuardrails[0].execute({
+            input: messages,
+            context: options.context,
+            agent: agentArg,
+          })
+          return makeTextRunnerResult()
+        })
+        .mockResolvedValueOnce({
+          finalOutput: { is_offensive: false },
+          rawResponses: [],
+        })
+
+      await createRunner(agent, llmConfig).run(sampleMessages, buildMockContext())
+
+      expect(capturedRunnerConfigs).toHaveLength(2)
+      expect(capturedRunnerConfigs[0].modelSettings).toBe(
+        llmConfig.modelSettings
+      )
+      expect(capturedRunnerConfigs[0].modelSettings).toHaveProperty(
+        'toolChoice',
+        'retrieve_knowledge'
+      )
+      expect(capturedRunnerConfigs[1].modelSettings).not.toBe(
+        llmConfig.modelSettings
+      )
+      expect(capturedRunnerConfigs[1].modelSettings).toHaveProperty(
+        'toolChoice',
+        undefined
+      )
       expect(llmConfig.modelSettings.toolChoice).toBe('retrieve_knowledge')
     })
 

--- a/packages/botonic-plugin-ai-agents/tests/runner.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/runner.test.ts
@@ -458,7 +458,10 @@ describe('AIAgentRunner', () => {
           rawResponses: [],
         })
 
-      await createRunner(agent, llmConfig).run(sampleMessages, buildMockContext())
+      await createRunner(agent, llmConfig).run(
+        sampleMessages,
+        buildMockContext()
+      )
 
       expect(capturedRunnerConfigs).toHaveLength(2)
       expect(capturedRunnerConfigs[0].modelSettings).toBe(


### PR DESCRIPTION
## Description

Fixes input guardrail runner setup so clearing `toolChoice` does not mutate the shared `llmConfig.modelSettings` object.
This preserves `retrieve_knowledge` tool selection for the main AI agent runner while still disabling tool choice for guardrail evaluation.

## Context

Azure agent runs that use `retrieve_knowledge` need `modelSettings.toolChoice` to remain available for the main runner. Input guardrails also create a runner from the same LLM config, but they must run without a forced tool choice.

Previously, input guardrail creation cleared `toolChoice` directly on the shared model settings object, which could unintentionally affect the main agent execution.

## Approach taken / Explain the design

`createInputGuardrail` now builds a shallow copy of `llmConfig.modelSettings` with `toolChoice` set to `undefined` before creating the guardrail runner. This keeps the guardrail-specific behavior local to that runner and leaves the original LLM config unchanged.

The runner tests now capture every mocked runner configuration and cover the combined flow where an AI agent with `retrieve_knowledge` executes input guardrails before the main response.

## To document / Usage example

N/A. This is an internal behavior fix for runner configuration and does not change the public API or documented usage.

## Testing

The pull request...

- has unit tests covering that `retrieve_knowledge` remains selected for the main runner while input guardrails receive `toolChoice: undefined`