### PR TITLE
plugin-flow-builder: Replace variables inside instructions and descriptions of AI Agents #BLT-2385

### DIFF
--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -209,15 +209,6 @@ export default class BotonicPluginAiAgents<
         return handoff(agent, {
           toolNameOverride: aiAgentData.name,
           toolDescriptionOverride: aiAgentData.description,
-          // TODO: Review if is possible use onHandoff action to track the handoff
-          // onHandoff: result => {
-          //   console.log('onHandoff', aiAgentData.name, result)
-          // },
-          // TODO: when onHandoff function is defined, we need to provide inputType
-          // inputType: ????,
-          // isEnabled: (context: RunContext<any>) => {
-          //   return true
-          // },
         })
       })
     )

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent-router.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent-router.tsx
@@ -3,7 +3,6 @@ import {
   type BotContext,
   type InferenceResponse,
 } from '@botonic/core'
-import type { FlowBuilderApi } from '../api'
 import {
   type FlowBuilderContentMessage,
   FlowBuilderContentSchema,
@@ -26,17 +25,20 @@ export class FlowAiAgentRouter extends FlowAiAgentBase {
 
   static fromHubtypeCMS(
     component: HtAiAgentRouterNode,
-    cmsApi: FlowBuilderApi
+    botContext: BotContext
   ): FlowAiAgentRouter {
     const newAiAgentRouter = new FlowAiAgentRouter(component.id)
     newAiAgentRouter.code = component.code
     newAiAgentRouter.name = component.content.name
-    newAiAgentRouter.instructions = component.content.instructions
+    newAiAgentRouter.instructions = newAiAgentRouter.replaceVariables(
+      component.content.instructions,
+      botContext
+    )
     newAiAgentRouter.model = component.content.model
     newAiAgentRouter.verbosity = component.content.verbosity
     newAiAgentRouter.agents = FlowAiAgentRouter.getTransferAgentsFromHubtypeCMS(
       component,
-      cmsApi
+      botContext
     )
     newAiAgentRouter.inputGuardrailRules =
       component.content.input_guardrail_rules || []
@@ -45,17 +47,22 @@ export class FlowAiAgentRouter extends FlowAiAgentBase {
 
   private static getTransferAgentsFromHubtypeCMS(
     component: HtAiAgentRouterNode,
-    cmsApi: FlowBuilderApi
+    botContext: BotContext
   ): AiAgentWithNameAndDescription[] {
+    const flowBuilderPlugin = getFlowBuilderPlugin(botContext.plugins)
+    const cmsApi = flowBuilderPlugin.cmsApi
+
     return component.content.agent_slots.map((agentSlot, index) => {
       const agentNode = cmsApi.getNodeById<HtAiAgentNode>(agentSlot.target.id)
-      const aiAgent = FlowAiAgent.fromHubtypeCMS(agentNode)
+      const aiAgent = FlowAiAgent.fromHubtypeCMS(agentNode, botContext)
       const aiAgentName = FlowAiAgentRouter.transferAgentSlotBaseName(
         agentSlot.name,
         index
       )
-      const agentDescription =
-        agentSlot.description || `Transfer to ${aiAgentName}`
+      const agentDescription = aiAgent.replaceVariables(
+        agentSlot.description || `Transfer to ${aiAgentName}`,
+        botContext
+      )
 
       return {
         agent: aiAgent,

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent.tsx
@@ -22,11 +22,17 @@ export class FlowAiAgent extends FlowAiAgentBase {
   public activeTools?: { name: string }[]
   public sources?: { id: string; name: string }[]
 
-  static fromHubtypeCMS(component: HtAiAgentNode): FlowAiAgent {
+  static fromHubtypeCMS(
+    component: HtAiAgentNode,
+    botContext: BotContext
+  ): FlowAiAgent {
     const newAiAgent = new FlowAiAgent(component.id)
     newAiAgent.code = component.code
     newAiAgent.name = component.content.name
-    newAiAgent.instructions = component.content.instructions
+    newAiAgent.instructions = newAiAgent.replaceVariables(
+      component.content.instructions,
+      botContext
+    )
     newAiAgent.model = component.content.model
     newAiAgent.verbosity = component.content.verbosity
     newAiAgent.activeTools = component.content.active_tools

--- a/packages/botonic-plugin-flow-builder/src/flow-factory.ts
+++ b/packages/botonic-plugin-flow-builder/src/flow-factory.ts
@@ -1,4 +1,4 @@
-import type { ActionRequest } from '@botonic/react'
+import type { BotContext } from '@botonic/core'
 
 import type { FlowBuilderApi } from './api'
 import {
@@ -30,12 +30,12 @@ import {
 } from './content-fields/hubtype-fields'
 
 export class FlowFactory {
-  public currentRequest: ActionRequest
+  public botContext: BotContext
   public cmsApi: FlowBuilderApi
   public locale: string
 
-  constructor(request: ActionRequest, cmsApi: FlowBuilderApi, locale: string) {
-    this.currentRequest = request
+  constructor(botContext: BotContext, cmsApi: FlowBuilderApi, locale: string) {
+    this.botContext = botContext
     this.cmsApi = cmsApi
     this.locale = locale
   }
@@ -78,8 +78,11 @@ export class FlowFactory {
       case HtNodeWithContentType.KNOWLEDGE_BASE:
         return FlowKnowledgeBase.fromHubtypeCMS(hubtypeContent)
 
+      case HtNodeWithContentType.AI_AGENT_ROUTER:
+        return FlowAiAgentRouter.fromHubtypeCMS(hubtypeContent, this.botContext)
+
       case HtNodeWithContentType.AI_AGENT:
-        return FlowAiAgent.fromHubtypeCMS(hubtypeContent)
+        return FlowAiAgent.fromHubtypeCMS(hubtypeContent, this.botContext)
 
       case HtNodeWithContentType.RATING:
         return FlowRating.fromHubtypeCMS(hubtypeContent, this.locale)
@@ -99,9 +102,6 @@ export class FlowFactory {
       case HtNodeWithContentType.CAPTURE_USER_INPUT:
         return FlowCaptureUserInput.fromHubtypeCMS(hubtypeContent)
 
-      case HtNodeWithContentType.AI_AGENT_ROUTER:
-        return FlowAiAgentRouter.fromHubtypeCMS(hubtypeContent, this.cmsApi)
-
       default:
         return undefined
     }
@@ -114,12 +114,12 @@ export class FlowFactory {
       case 'check-country':
         return FlowCountryConditional.fromHubtypeCMS(
           hubtypeContent,
-          this.currentRequest
+          this.botContext
         )
       case 'get-channel-type':
         return FlowChannelConditional.fromHubtypeCMS(
           hubtypeContent,
-          this.currentRequest
+          this.botContext
         )
       case 'check-queue-status':
         return FlowQueueStatusConditional.fromHubtypeCMS(
@@ -129,7 +129,7 @@ export class FlowFactory {
       case 'check-bot-variable':
         return FlowCustomConditional.fromHubtypeCMS(
           hubtypeContent,
-          this.currentRequest
+          this.botContext
         )
       default:
         return undefined


### PR DESCRIPTION
## Description

- Replace variables inside instructions and descriptions of AI Agents
- Refactors `FlowFactory`  to use `BotContext` instead of `ActionRequest`.
