### PR TITLE
fix: input guardrail handling in BaseRunner and RouterRunner

### DIFF
--- a/packages/botonic-plugin-ai-agents/src/runners/base-runner.ts
+++ b/packages/botonic-plugin-ai-agents/src/runners/base-runner.ts
@@ -86,24 +86,11 @@ export abstract class BaseRunner<
 
       return runResult
     } catch (error) {
-      if (error instanceof InputGuardrailTripwireTriggered) {
-        const runResult: RunResult = {
-          startingAgentName: '',
-          lastAgentName: '',
-          availableSpecialists: [],
-          isTransferredToSpecialist: false,
-          messages: [],
-          memoryLength: 0,
-          toolsExecuted: [],
-          exit: true,
-          error: false,
-          inputGuardrailsTriggered: error.result.output.outputInfo,
-          outputGuardrailsTriggered: [],
-        }
-
-        this.logger.logGuardrailTriggered()
-        this.logger.logRunResult(runResult, startTime)
-
+      const runResult = this.handleInputGuardrailTripwireTriggered(
+        error,
+        startTime
+      )
+      if (runResult) {
         return runResult
       }
 
@@ -286,5 +273,31 @@ export abstract class BaseRunner<
     await client.trackLlmRuns(botId, {
       llm_runs: llmRuns,
     })
+  }
+
+  protected handleInputGuardrailTripwireTriggered(
+    error: unknown,
+    startTime: number
+  ): RunResult | undefined {
+    if (error instanceof InputGuardrailTripwireTriggered) {
+      const runResult: RunResult = {
+        startingAgentName: '',
+        lastAgentName: '',
+        availableSpecialists: [],
+        isTransferredToSpecialist: false,
+        messages: [],
+        memoryLength: 0,
+        toolsExecuted: [],
+        exit: true,
+        error: false,
+        inputGuardrailsTriggered: error.result.output.outputInfo,
+        outputGuardrailsTriggered: [],
+      }
+
+      this.logger.logGuardrailTriggered()
+      this.logger.logRunResult(runResult, startTime)
+
+      return runResult
+    }
   }
 }

--- a/packages/botonic-plugin-ai-agents/src/runners/router-runner.ts
+++ b/packages/botonic-plugin-ai-agents/src/runners/router-runner.ts
@@ -1,4 +1,4 @@
-import type { ResolvedPlugins } from '@botonic/core'
+import type { AvailableSpecialist, ResolvedPlugins } from '@botonic/core'
 import { Handoff } from '@openai/agents'
 import type { Agent } from '@openai/agents-core'
 
@@ -16,17 +16,7 @@ export class RouterRunner<
   ): RunResult {
     const base = super.buildRunResult(result, context, memoryLength)
 
-    const availableSpecialists = (this.agent.handoffs ?? []).map(
-      (entry: Agent<any, any> | Handoff<any, any>) => {
-        const isHandoff = entry instanceof Handoff
-        const agent = isHandoff ? entry.agent : (entry as Agent<any, any>)
-        const description = isHandoff
-          ? entry.toolDescription
-          : agent.handoffDescription
-        return { name: agent.name, description }
-      }
-    )
-
+    const availableSpecialists = this.getAvailableSpecialists()
     const startingAgentName = this.agent.name ?? ''
     const lastAgentName = result.lastAgent?.name ?? ''
 
@@ -37,5 +27,38 @@ export class RouterRunner<
       availableSpecialists,
       isTransferredToSpecialist: startingAgentName !== lastAgentName,
     }
+  }
+
+  protected override handleInputGuardrailTripwireTriggered(
+    error: unknown,
+    startTime: number
+  ): RunResult | undefined {
+    const runResult = super.handleInputGuardrailTripwireTriggered(
+      error,
+      startTime
+    )
+    if (runResult) {
+      // Override attributes to match router agent
+      runResult.startingAgentName = this.agent.name
+      runResult.lastAgentName = this.agent.name
+      runResult.availableSpecialists = this.getAvailableSpecialists()
+      runResult.isTransferredToSpecialist = false
+
+      return runResult
+    }
+    return undefined
+  }
+
+  private getAvailableSpecialists(): AvailableSpecialist[] {
+    return (this.agent.handoffs ?? []).map(
+      (entry: Agent<any, any> | Handoff<any, any>) => {
+        const isHandoff = entry instanceof Handoff
+        const agent = isHandoff ? entry.agent : (entry as Agent<any, any>)
+        const description = isHandoff
+          ? entry.toolDescription
+          : agent.handoffDescription
+        return { name: agent.name, description }
+      }
+    )
   }
 }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent-router.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent-router.tsx
@@ -165,8 +165,8 @@ export class FlowAiAgentRouter extends FlowAiAgentBase {
         this.aiAgentResponse?.inputGuardrailsTriggered ?? [],
       outputGuardrailsTriggered:
         this.aiAgentResponse?.outputGuardrailsTriggered ?? [],
-      startingAgentName: this.aiAgentResponse?.startingAgentName ?? '',
-      lastAgentName: this.aiAgentResponse?.lastAgentName ?? '',
+      startingAgentName: this.aiAgentResponse?.startingAgentName ?? this.name,
+      lastAgentName: this.aiAgentResponse?.lastAgentName ?? this.name,
       availableSpecialists: this.aiAgentResponse?.availableSpecialists ?? [],
       isTransferredToSpecialist,
     }


### PR DESCRIPTION
## Description

This pull request fixes the AI router response when an input guardrail blocks a request.
Router runs now preserve router-specific metadata, including the router agent name and available specialists, even when the OpenAI Agents SDK raises an input guardrail tripwire before a normal run result is built.

## Context

When an input guardrail is triggered, `BaseRunner` builds an early `RunResult` from the exception. Before this change, that fallback result used empty agent names and no specialist list, so router-based AI agent responses could lose important routing context.

This affected consumers such as Flow Builder, where the router response should still identify the router agent as the starting and last agent when no specialist transfer happened.

## Approach taken / Explain the design

The input guardrail tripwire handling has been moved into a protected `BaseRunner` method so specialized runners can reuse and customize the fallback result.

`RouterRunner` now overrides that handler to enrich guardrail-triggered results with router metadata:

- `startingAgentName` and `lastAgentName` are set to the router agent name.
- `availableSpecialists` is derived from the router handoffs.
- `isTransferredToSpecialist` remains `false` because the guardrail stops the run before a handoff.

The existing specialist extraction logic was also centralized in `RouterRunner#getAvailableSpecialists()` so normal router results and guardrail-triggered results stay consistent.

Flow Builder now falls back to the router content field name for `startingAgentName` and `lastAgentName` when an AI agent response does not provide those values.
