### PR TITLE
docs(BLT-2353): move 0.50.0 changelog out of Unreleased

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23590,7 +23590,7 @@
     },
     "packages/botonic-cli": {
       "name": "@botonic/cli",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.8.6",
@@ -23635,7 +23635,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -23655,7 +23655,7 @@
     },
     "packages/botonic-dx": {
       "name": "@botonic/dx",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-modules-commonjs": "^7.27.1",
@@ -23663,8 +23663,8 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
-        "@botonic/dx-bundler-rspack": "^0.49.0",
-        "@botonic/eslint-config": "^0.49.0",
+        "@botonic/dx-bundler-rspack": "^0.50.0",
+        "@botonic/eslint-config": "^0.50.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.19.1",
         "babel-loader": "^8.4.1",
@@ -23692,7 +23692,7 @@
     },
     "packages/botonic-dx-bundler-rspack": {
       "name": "@botonic/dx-bundler-rspack",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@rspack/cli": "^1.6.1",
@@ -23880,7 +23880,7 @@
     },
     "packages/botonic-eslint-config": {
       "name": "@botonic/eslint-config",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -23899,9 +23899,9 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "dependencies": {
-        "@botonic/core": "^0.49.0",
+        "@botonic/core": "^0.50.0",
         "@openai/agents": "^0.10.1",
         "axios": "^1.15.2",
         "openai": "^6.36.0",
@@ -23931,9 +23931,9 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "dependencies": {
-        "@botonic/react": "^0.49.0",
+        "@botonic/react": "^0.50.0",
         "axios": "^1.15.2",
         "uuid": "^10.0.0"
       },
@@ -23960,11 +23960,11 @@
     },
     "packages/botonic-plugin-hubtype-analytics": {
       "name": "@botonic/plugin-hubtype-analytics",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@botonic/core": "^0.49.0",
+        "@botonic/core": "^0.50.0",
         "axios": "^1.15.2"
       },
       "devDependencies": {
@@ -23977,11 +23977,11 @@
     },
     "packages/botonic-plugin-knowledge-bases": {
       "name": "@botonic/plugin-knowledge-bases",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@botonic/core": "^0.49.0",
+        "@botonic/core": "^0.50.0",
         "axios": "^1.15.2"
       },
       "devDependencies": {
@@ -23994,10 +23994,10 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
-        "@botonic/core": "^0.49.0",
+        "@botonic/core": "^0.50.0",
         "axios": "^1.15.2",
         "emoji-picker-react": "^4.12.0",
         "lodash.merge": "^4.6.2",

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "license": "MIT",
   "bin": {
     "botonic": "./bin/run.js"

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-dx-bundler-rspack/package.json
+++ b/packages/botonic-dx-bundler-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx-bundler-rspack",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Build Botonic bots with RSPack",
   "scripts": {
     "build": "echo Skipping build...",

--- a/packages/botonic-dx/package.json
+++ b/packages/botonic-dx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Continuous integration for botonic packages",
   "scripts": {
     "build": "echo Skipping build..."
@@ -18,8 +18,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
-    "@botonic/dx-bundler-rspack": "^0.49.0",
-    "@botonic/eslint-config": "^0.49.0",
+    "@botonic/dx-bundler-rspack": "^0.50.0",
+    "@botonic/eslint-config": "^0.50.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.19.1",
     "babel-loader": "^8.4.1",

--- a/packages/botonic-eslint-config/package.json
+++ b/packages/botonic-eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/eslint-config",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Eslint config for botonic packages",
   "main": "index.js",
   "scripts": {

--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.50.0] - 2026-mm-dd
+## [0.50.0] - 2026-06-04
 
 ### Added
 

--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Botonic will be documented in this file.
 
 ### Added
 
+- [PR-3228](https://github.com/hubtype/botonic/pull/3228): Add LiteLLM provider support, allowing AI agents to route LLM calls through a LiteLLM proxy.
+
 ### Changed
 
 ### Fixed

--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -9,19 +9,15 @@ All notable changes to Botonic will be documented in this file.
     Changes that have landed in master but are not yet released.
     Click to see more.
   </summary>
-  
+
+</details>
+
 ## [0.50.0] - 2026-06-04
 
 ### Added
 
 - [PR-3228](https://github.com/hubtype/botonic/pull/3228): Add LiteLLM provider support, allowing AI agents to route LLM calls through a LiteLLM proxy.
 
-### Changed
-
-### Fixed
-
-</details>
-  
 ## [0.49.0] - 2026-05-28
 
 ### Added

--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.49.x] - 2026-mm-dd
+## [0.50.0] - 2026-mm-dd
 
 ### Added
 

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",
@@ -14,7 +14,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.49.0",
+    "@botonic/core": "^0.50.0",
     "@openai/agents": "^0.10.1",
     "axios": "^1.15.2",
     "openai": "^6.36.0",

--- a/packages/botonic-plugin-ai-agents/src/constants.ts
+++ b/packages/botonic-plugin-ai-agents/src/constants.ts
@@ -5,9 +5,16 @@ export const HUBTYPE_API_URL =
 export const LLM_PROVIDERS = {
   AZURE: 'azure',
   OPENAI: 'openai',
+  LITELLM: 'litellm',
 } as const
 
 export type LLMProviderType = (typeof LLM_PROVIDERS)[keyof typeof LLM_PROVIDERS]
+
+export const LITELLM_TAG_KEYS = {
+  BOT_ID: 'bot_id',
+  ORG_ID: 'org_id',
+  SEPARATOR: ',',
+} as const
 
 export const LLM_PROVIDER: LLMProviderType =
   (process.env.LLM_PROVIDER as LLMProviderType) || LLM_PROVIDERS.AZURE

--- a/packages/botonic-plugin-ai-agents/src/guardrails/input.ts
+++ b/packages/botonic-plugin-ai-agents/src/guardrails/input.ts
@@ -6,7 +6,7 @@ import {
   type UserMessageItem,
 } from '@openai/agents'
 import { z } from 'zod'
-import { isProd } from '../constants'
+import { isProd, LLM_PROVIDERS } from '../constants'
 import type { LLMConfig } from '../llm-config'
 import { HubtypeApiClient } from '../services/hubtype-api-client'
 import { TrackFeature, TrackProductName } from '../services/types'
@@ -113,6 +113,9 @@ async function sendGuardrailLlmRunTracking(
   endTime: number
 ): Promise<void> {
   if (!isProd) {
+    return
+  }
+  if (llmConfig.getProviderName() === LLM_PROVIDERS.LITELLM) {
     return
   }
   const rawResponses = result.rawResponses ?? []

--- a/packages/botonic-plugin-ai-agents/src/llm-config.ts
+++ b/packages/botonic-plugin-ai-agents/src/llm-config.ts
@@ -63,15 +63,19 @@ export class LLMConfig {
   }
 
   getProviderName(): LLMProviderType {
-    if (this.botContext.settings.LITELLM_API_URL || LLM_API_URL) {
+    if (
+      this.botContext.settings.LITELLM_API_URL ||
+      LLM_PROVIDER === LLM_PROVIDERS.LITELLM
+    ) {
       return LLM_PROVIDERS.LITELLM
     }
     return LLM_PROVIDER
   }
 
   private getClient(): OpenAI | AzureOpenAI {
-    const litellmUrl = this.botContext.settings.LITELLM_API_URL || LLM_API_URL
-    if (litellmUrl) {
+    if (this.getProviderName() === LLM_PROVIDERS.LITELLM) {
+      const litellmUrl =
+        this.botContext.settings.LITELLM_API_URL || LLM_API_URL || ''
       return this.getLiteLLMClient(litellmUrl)
     }
     if (LLM_PROVIDER === LLM_PROVIDERS.OPENAI) {

--- a/packages/botonic-plugin-ai-agents/src/llm-config.ts
+++ b/packages/botonic-plugin-ai-agents/src/llm-config.ts
@@ -8,12 +8,14 @@ import {
 import OpenAI, { AzureOpenAI } from 'openai'
 import {
   isProd,
+  LITELLM_TAG_KEYS,
   LLM_API_KEY,
   LLM_API_URL,
   LLM_AZURE_API_VERSION,
   LLM_OPENAI_MODEL,
   LLM_PROVIDER,
   LLM_PROVIDERS,
+  type LLMProviderType,
 } from './constants'
 
 export interface LLMConfigParams {
@@ -60,12 +62,48 @@ export class LLMConfig {
     })
   }
 
+  getProviderName(): LLMProviderType {
+    if (this.botContext.settings.LITELLM_API_URL || LLM_API_URL) {
+      return LLM_PROVIDERS.LITELLM
+    }
+    return LLM_PROVIDER
+  }
+
   private getClient(): OpenAI | AzureOpenAI {
+    const litellmUrl = this.botContext.settings.LITELLM_API_URL || LLM_API_URL
+    if (litellmUrl) {
+      return this.getLiteLLMClient(litellmUrl)
+    }
     if (LLM_PROVIDER === LLM_PROVIDERS.OPENAI) {
       return this.getOpenAIClient()
     }
-
     return this.getAzureOpenAiClient()
+  }
+
+  private buildLiteLLMTags(): { 'x-litellm-tags': string } | undefined {
+    const botId = this.botContext.session.bot.id
+    const orgId = this.botContext.session.organization_id
+    const parts: string[] = []
+    if (botId) {
+      parts.push(`${LITELLM_TAG_KEYS.BOT_ID}:${botId}`)
+    }
+    if (orgId) {
+      parts.push(`${LITELLM_TAG_KEYS.ORG_ID}:${orgId}`)
+    }
+    return parts.length > 0
+      ? { 'x-litellm-tags': parts.join(LITELLM_TAG_KEYS.SEPARATOR) }
+      : undefined
+  }
+
+  private getLiteLLMClient(litellmUrl: string): OpenAI {
+    return new OpenAI({
+      apiKey: this.botContext.secrets.LITELLM_API_KEY || LLM_API_KEY,
+      baseURL: litellmUrl,
+      timeout: this.timeout,
+      maxRetries: this.maxRetries,
+      dangerouslyAllowBrowser: !isProd,
+      defaultHeaders: this.buildLiteLLMTags(),
+    })
   }
 
   private getOpenAIClient(): OpenAI {
@@ -112,10 +150,18 @@ export class LLMConfig {
       }
     }
 
-    throw new Error(`Unsupported model: ${model}`)
+    // LiteLLM can proxy any model — fall back to reasoning settings
+    return {
+      reasoning: { effort: 'none' },
+      temperature: 1,
+      text: { verbosity },
+    }
   }
 
-  getApiVersion(): string {
+  getApiVersion(): string | undefined {
+    if (this.getProviderName() === LLM_PROVIDERS.LITELLM) {
+      return undefined
+    }
     if (LLM_PROVIDER !== LLM_PROVIDERS.AZURE) {
       return 'NOT_API_VERSION_FOR_OPENAI_PROVIDER'
     }

--- a/packages/botonic-plugin-ai-agents/src/runners/base-runner.ts
+++ b/packages/botonic-plugin-ai-agents/src/runners/base-runner.ts
@@ -9,7 +9,7 @@ import {
   RunToolCallItem,
   RunToolCallOutputItem,
 } from '@openai/agents'
-import { isProd } from '../constants'
+import { isProd, LLM_PROVIDERS } from '../constants'
 import type { DebugLogger } from '../debug-logger'
 import type { LLMConfig } from '../llm-config'
 import { HubtypeApiClient } from '../services/hubtype-api-client'
@@ -238,6 +238,9 @@ export abstract class BaseRunner<
     endTime: number
   ): Promise<void> {
     if (!isProd) {
+      return
+    }
+    if (this.llmConfig.getProviderName() === LLM_PROVIDERS.LITELLM) {
       return
     }
     const rawResponses = result.rawResponses ?? []

--- a/packages/botonic-plugin-ai-agents/src/services/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/services/types.ts
@@ -17,7 +17,7 @@ export interface LlmRunData {
   deployment_name: string
   model_name: string
   feature: string
-  api_version: string | undefined
+  api_version?: string
   num_prompt_tokens: number
   num_completion_tokens: number
   duration_in_milliseconds: number

--- a/packages/botonic-plugin-ai-agents/src/services/types.ts
+++ b/packages/botonic-plugin-ai-agents/src/services/types.ts
@@ -17,7 +17,7 @@ export interface LlmRunData {
   deployment_name: string
   model_name: string
   feature: string
-  api_version: string
+  api_version: string | undefined
   num_prompt_tokens: number
   num_completion_tokens: number
   duration_in_milliseconds: number

--- a/packages/botonic-plugin-ai-agents/tests/guardrails/input.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/guardrails/input.test.ts
@@ -43,6 +43,7 @@ jest.mock('../../src/constants', () => ({
   isProd: false,
   OPENAI_PROVIDER: 'azure',
   AZURE_OPENAI_API_VERSION: '2025-01-01-preview',
+  LLM_PROVIDERS: { AZURE: 'azure', OPENAI: 'openai', LITELLM: 'litellm' },
 }))
 
 describe('createInputGuardrails', () => {
@@ -94,6 +95,7 @@ describe('createInputGuardrails', () => {
     modelProvider: {},
     getModel: jest.fn().mockResolvedValue({ id: 'guardrail-model' }),
     getApiVersion: jest.fn().mockReturnValue('test-api-version'),
+    getProviderName: jest.fn().mockReturnValue('azure'),
   } as unknown as LLMConfig
 
   const mockTrackingContext: GuardrailTrackingContext = {

--- a/packages/botonic-plugin-ai-agents/tests/llm-config.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/llm-config.test.ts
@@ -36,7 +36,7 @@ jest.mock('@openai/agents', () => ({
 // eslint-disable-next-line no-var
 var mockConstants: {
   LLM_PROVIDERS: { OPENAI: 'openai'; AZURE: 'azure'; LITELLM: 'litellm' }
-  LLM_PROVIDER: 'openai' | 'azure'
+  LLM_PROVIDER: 'openai' | 'azure' | 'litellm'
   LLM_OPENAI_MODEL: string
   LLM_API_KEY: string
   LLM_API_URL: string
@@ -360,9 +360,8 @@ describe('LLMConfig', () => {
       expect(config.getApiVersion()).toBeUndefined()
     })
 
-    it('returns undefined when provider is litellm (via LLM_API_URL constant)', () => {
-      mockConstants.LLM_PROVIDER = 'azure'
-      mockConstants.LLM_API_URL = 'https://litellm.example.com'
+    it('returns undefined when provider is litellm (via LLM_PROVIDER=litellm)', () => {
+      mockConstants.LLM_PROVIDER = 'litellm'
 
       const config = new LLMConfig({
         maxRetries: DEFAULT_MAX_RETRIES,
@@ -373,8 +372,6 @@ describe('LLMConfig', () => {
       })
 
       expect(config.getApiVersion()).toBeUndefined()
-
-      mockConstants.LLM_API_URL = ''
     })
   })
 
@@ -413,9 +410,8 @@ describe('LLMConfig', () => {
       expect(config.getProviderName()).toBe('litellm')
     })
 
-    it('returns litellm when LLM_API_URL constant is set', () => {
-      mockConstants.LLM_PROVIDER = 'azure'
-      mockConstants.LLM_API_URL = 'https://litellm.example.com'
+    it('returns litellm when LLM_PROVIDER=litellm', () => {
+      mockConstants.LLM_PROVIDER = 'litellm'
 
       const config = new LLMConfig({
         maxRetries: DEFAULT_MAX_RETRIES,
@@ -426,13 +422,10 @@ describe('LLMConfig', () => {
       })
 
       expect(config.getProviderName()).toBe('litellm')
-
-      mockConstants.LLM_API_URL = ''
     })
 
-    it('returns azure when neither LITELLM_API_URL nor LLM_API_URL is set', () => {
+    it('returns azure when LITELLM_API_URL is not set and LLM_PROVIDER is azure', () => {
       mockConstants.LLM_PROVIDER = 'azure'
-      mockConstants.LLM_API_URL = ''
 
       const config = new LLMConfig({
         maxRetries: DEFAULT_MAX_RETRIES,
@@ -488,8 +481,9 @@ describe('LLMConfig', () => {
       expect(capturedOpenAIConfig?.apiKey).toBe('fallback-key')
     })
 
-    it('uses LLM_API_URL constant as litellm URL when botContext.settings.LITELLM_API_URL is empty', () => {
-      mockConstants.LLM_API_URL = 'https://litellm-constant.example.com'
+    it('uses LLM_API_URL as litellm URL when LLM_PROVIDER=litellm and no botContext URL', () => {
+      mockConstants.LLM_PROVIDER = 'litellm'
+      mockConstants.LLM_API_URL = 'https://litellm-local.example.com'
 
       new LLMConfig({
         maxRetries: DEFAULT_MAX_RETRIES,
@@ -500,8 +494,11 @@ describe('LLMConfig', () => {
       })
 
       expect(capturedOpenAIConfig?.baseURL).toBe(
-        'https://litellm-constant.example.com'
+        'https://litellm-local.example.com'
       )
+
+      mockConstants.LLM_PROVIDER = 'azure'
+      mockConstants.LLM_API_URL = ''
     })
 
     it('sets x-litellm-tags header with both bot_id and org_id', () => {

--- a/packages/botonic-plugin-ai-agents/tests/llm-config.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/llm-config.test.ts
@@ -35,23 +35,25 @@ jest.mock('@openai/agents', () => ({
 // var so the variable is hoisted and assignable when the mock factory runs (Jest hoists mocks)
 // eslint-disable-next-line no-var
 var mockConstants: {
-  LLM_PROVIDERS: { OPENAI: 'openai'; AZURE: 'azure' }
+  LLM_PROVIDERS: { OPENAI: 'openai'; AZURE: 'azure'; LITELLM: 'litellm' }
   LLM_PROVIDER: 'openai' | 'azure'
   LLM_OPENAI_MODEL: string
   LLM_API_KEY: string
   LLM_API_URL: string
   LLM_AZURE_API_VERSION: string
   isProd: boolean
+  LITELLM_TAG_KEYS: { BOT_ID: 'bot_id'; ORG_ID: 'org_id'; SEPARATOR: ',' }
 }
 jest.mock('../src/constants', () => {
   mockConstants = {
-    LLM_PROVIDERS: { OPENAI: 'openai', AZURE: 'azure' },
+    LLM_PROVIDERS: { OPENAI: 'openai', AZURE: 'azure', LITELLM: 'litellm' },
     LLM_PROVIDER: 'azure',
     LLM_OPENAI_MODEL: 'gpt-4.1-mini',
     LLM_API_KEY: 'fallback-key',
-    LLM_API_URL: 'https://fallback.openai.azure.com/',
+    LLM_API_URL: '',
     LLM_AZURE_API_VERSION: '2025-01-01-preview',
     isProd: false,
+    LITELLM_TAG_KEYS: { BOT_ID: 'bot_id', ORG_ID: 'org_id', SEPARATOR: ',' },
   }
   return mockConstants
 })
@@ -60,12 +62,18 @@ function makeBotContext(
   settings: Partial<{
     AZURE_OPENAI_API_BASE: string
     AZURE_OPENAI_API_VERSION: string
+    LITELLM_API_URL: string
   }> = {},
-  secrets: Partial<{ AZURE_OPENAI_API_KEY: string }> = {}
+  secrets: Partial<{
+    AZURE_OPENAI_API_KEY: string
+    LITELLM_API_KEY: string
+  }> = {},
+  session: Partial<{ botId: string; organizationId: string }> = {}
 ) {
   return createTestBotContext({
-    settings: { ...settings } as any,
+    settings: { LITELLM_API_URL: '', ...settings } as any,
     secrets: { ...secrets } as any,
+    session: { ...session },
   })
 }
 
@@ -148,17 +156,20 @@ describe('LLMConfig', () => {
       })
     })
 
-    it('throws for unsupported model', () => {
-      expect(
-        () =>
-          new LLMConfig({
-            maxRetries: DEFAULT_MAX_RETRIES,
-            timeout: DEFAULT_TIMEOUT,
-            modelName: 'unknown-model',
-            verbosity: VerbosityLevel.Medium,
-            botContext: makeBotContext(),
-          })
-      ).toThrow('Unsupported model: unknown-model')
+    it('returns reasoning settings for unknown model (LiteLLM fallback)', () => {
+      const config = new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.High,
+        botContext: makeBotContext(),
+      })
+
+      expect(config.modelSettings).toEqual({
+        reasoning: { effort: 'none' },
+        temperature: 1,
+        text: { verbosity: 'high' },
+      })
     })
   })
 
@@ -196,7 +207,10 @@ describe('LLMConfig', () => {
         modelName: 'gpt-4.1-mini',
         verbosity: VerbosityLevel.Medium,
         botContext: makeBotContext(
-          { AZURE_OPENAI_API_BASE: '', AZURE_OPENAI_API_VERSION: '' },
+          {
+            AZURE_OPENAI_API_BASE: 'https://fallback.openai.azure.com/',
+            AZURE_OPENAI_API_VERSION: '',
+          },
           { AZURE_OPENAI_API_KEY: '' }
         ),
       })
@@ -329,6 +343,39 @@ describe('LLMConfig', () => {
 
       expect(config.getApiVersion()).toBe('NOT_API_VERSION_FOR_OPENAI_PROVIDER')
     })
+
+    it('returns undefined when provider is litellm (via botContext.settings)', () => {
+      mockConstants.LLM_PROVIDER = 'azure'
+
+      const config = new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext({
+          LITELLM_API_URL: 'https://litellm.example.com',
+        }),
+      })
+
+      expect(config.getApiVersion()).toBeUndefined()
+    })
+
+    it('returns undefined when provider is litellm (via LLM_API_URL constant)', () => {
+      mockConstants.LLM_PROVIDER = 'azure'
+      mockConstants.LLM_API_URL = 'https://litellm.example.com'
+
+      const config = new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(),
+      })
+
+      expect(config.getApiVersion()).toBeUndefined()
+
+      mockConstants.LLM_API_URL = ''
+    })
   })
 
   describe('getModel', () => {
@@ -345,6 +392,203 @@ describe('LLMConfig', () => {
 
       await expect(config.getModel()).resolves.toBe(mockResolvedModel)
       expect(config.modelProvider.getModel).toHaveBeenCalledWith('gpt-4.1-mini')
+    })
+  })
+
+  describe('getProviderName', () => {
+    it('returns litellm when botContext.settings.LITELLM_API_URL is set', () => {
+      mockConstants.LLM_PROVIDER = 'azure'
+      mockConstants.LLM_API_URL = ''
+
+      const config = new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext({
+          LITELLM_API_URL: 'https://litellm.example.com',
+        }),
+      })
+
+      expect(config.getProviderName()).toBe('litellm')
+    })
+
+    it('returns litellm when LLM_API_URL constant is set', () => {
+      mockConstants.LLM_PROVIDER = 'azure'
+      mockConstants.LLM_API_URL = 'https://litellm.example.com'
+
+      const config = new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(),
+      })
+
+      expect(config.getProviderName()).toBe('litellm')
+
+      mockConstants.LLM_API_URL = ''
+    })
+
+    it('returns azure when neither LITELLM_API_URL nor LLM_API_URL is set', () => {
+      mockConstants.LLM_PROVIDER = 'azure'
+      mockConstants.LLM_API_URL = ''
+
+      const config = new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'gpt-4.1-mini',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(),
+      })
+
+      expect(config.getProviderName()).toBe('azure')
+    })
+  })
+
+  describe('LiteLLM client configuration', () => {
+    beforeEach(() => {
+      mockConstants.LLM_PROVIDER = 'azure'
+      mockConstants.LLM_API_URL = ''
+    })
+
+    afterEach(() => {
+      mockConstants.LLM_API_URL = ''
+    })
+
+    it('uses LiteLLM client when LITELLM_API_URL is set in botContext', () => {
+      new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(
+          { LITELLM_API_URL: 'https://litellm.example.com' },
+          { LITELLM_API_KEY: 'platform-litellm-key' }
+        ),
+      })
+
+      expect(capturedOpenAIConfig?.baseURL).toBe('https://litellm.example.com')
+      expect(capturedOpenAIConfig?.apiKey).toBe('platform-litellm-key')
+      expect(capturedAzureConfig).toBeNull()
+    })
+
+    it('falls back to LLM_API_KEY when LITELLM_API_KEY is empty', () => {
+      new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(
+          { LITELLM_API_URL: 'https://litellm.example.com' },
+          { LITELLM_API_KEY: '' }
+        ),
+      })
+
+      expect(capturedOpenAIConfig?.apiKey).toBe('fallback-key')
+    })
+
+    it('uses LLM_API_URL constant as litellm URL when botContext.settings.LITELLM_API_URL is empty', () => {
+      mockConstants.LLM_API_URL = 'https://litellm-constant.example.com'
+
+      new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'gemini-pro',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(),
+      })
+
+      expect(capturedOpenAIConfig?.baseURL).toBe(
+        'https://litellm-constant.example.com'
+      )
+    })
+
+    it('sets x-litellm-tags header with both bot_id and org_id', () => {
+      new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(
+          { LITELLM_API_URL: 'https://litellm.example.com' },
+          {},
+          { botId: 'my-bot', organizationId: 'my-org' }
+        ),
+      })
+
+      expect(capturedOpenAIConfig?.defaultHeaders).toEqual({
+        'x-litellm-tags': 'bot_id:my-bot,org_id:my-org',
+      })
+    })
+
+    it('sets x-litellm-tags header with only bot_id when org_id is missing', () => {
+      new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(
+          { LITELLM_API_URL: 'https://litellm.example.com' },
+          {},
+          { botId: 'my-bot', organizationId: '' }
+        ),
+      })
+
+      expect(capturedOpenAIConfig?.defaultHeaders).toEqual({
+        'x-litellm-tags': 'bot_id:my-bot',
+      })
+    })
+
+    it('sets x-litellm-tags header with only org_id when bot_id is missing', () => {
+      new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(
+          { LITELLM_API_URL: 'https://litellm.example.com' },
+          {},
+          { botId: '', organizationId: 'my-org' }
+        ),
+      })
+
+      expect(capturedOpenAIConfig?.defaultHeaders).toEqual({
+        'x-litellm-tags': 'org_id:my-org',
+      })
+    })
+
+    it('omits x-litellm-tags header when both bot_id and org_id are missing', () => {
+      new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(
+          { LITELLM_API_URL: 'https://litellm.example.com' },
+          {},
+          { botId: '', organizationId: '' }
+        ),
+      })
+
+      expect(capturedOpenAIConfig?.defaultHeaders).toBeUndefined()
+    })
+
+    it('Azure client has no defaultHeaders even when botId and orgId are present', () => {
+      new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'gpt-4.1-mini',
+        verbosity: VerbosityLevel.Medium,
+        botContext: makeBotContext(
+          { AZURE_OPENAI_API_BASE: 'https://platform.openai.azure.com/' },
+          { AZURE_OPENAI_API_KEY: 'platform-key' },
+          { botId: 'my-bot', organizationId: 'my-org' }
+        ),
+      })
+
+      expect(capturedAzureConfig?.defaultHeaders).toBeUndefined()
+      expect(capturedOpenAIConfig).toBeNull()
     })
   })
 })

--- a/packages/botonic-plugin-ai-agents/tests/runner-router.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/runner-router.test.ts
@@ -15,7 +15,7 @@ jest.mock('../src/services/hubtype-api-client', () => ({
 
 jest.mock('../src/constants', () => ({
   LLM_PROVIDER: 'azure',
-  LLM_PROVIDERS: { OPENAI: 'openai', AZURE: 'azure' },
+  LLM_PROVIDERS: { OPENAI: 'openai', AZURE: 'azure', LITELLM: 'litellm' },
   LLM_OPENAI_MODEL: 'gpt-4.1-mini',
   LLM_AZURE_API_VERSION: '2025-01-01-preview',
   get isProd() {
@@ -63,6 +63,7 @@ const mockLlmConfig = {
   modelSettings: { temperature: 0 },
   modelProvider: {},
   getApiVersion: jest.fn().mockReturnValue('test-api-version'),
+  getProviderName: jest.fn().mockReturnValue('azure'),
 } as unknown as LLMConfig
 
 const mockAgent = {

--- a/packages/botonic-plugin-ai-agents/tests/runner.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/runner.test.ts
@@ -117,6 +117,7 @@ const mockConstants = {
   OPENAI_MODEL: 'gpt-4.1-mini',
   AZURE_OPENAI_API_VERSION: '2025-01-01-preview',
   isProd: false,
+  LLM_PROVIDERS: { AZURE: 'azure', OPENAI: 'openai', LITELLM: 'litellm' },
 }
 
 jest.mock('../src/constants', () => mockConstants)
@@ -151,6 +152,7 @@ function buildMockLlmConfig(provider: 'openai' | 'azure' = 'azure'): LLMConfig {
     modelProvider: { provider },
     getModel: jest.fn().mockResolvedValue({ id: 'guardrail-model' }),
     getApiVersion: jest.fn().mockReturnValue('test-api-version'),
+    getProviderName: jest.fn().mockReturnValue(provider),
   } as unknown as LLMConfig
 }
 

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -15,7 +15,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/react": "^0.49.0",
+    "@botonic/react": "^0.50.0",
     "axios": "^1.15.2",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-plugin-hubtype-analytics/package.json
+++ b/packages/botonic-plugin-hubtype-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-hubtype-analytics",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Plugin for tracking in the Hubtype backend to see the results in the Hubtype Dashbord",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/core": "^0.49.0",
+    "@botonic/core": "^0.50.0",
     "axios": "^1.15.2"
   },
   "devDependencies": {

--- a/packages/botonic-plugin-knowledge-bases/package.json
+++ b/packages/botonic-plugin-knowledge-bases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-knowledge-bases",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Use a Hubtype to make the bot respond through a knowledge base.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/core": "^0.49.0",
+    "@botonic/core": "^0.50.0",
     "axios": "^1.15.2"
   },
   "devDependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",
@@ -20,7 +20,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.49.0",
+    "@botonic/core": "^0.50.0",
     "axios": "^1.15.2",
     "emoji-picker-react": "^4.12.0",
     "lodash.merge": "^4.6.2",


### PR DESCRIPTION
Move the `0.50.0` entry in `botonic-plugin-ai-agents` CHANGELOG from the Unreleased section to its own released section.