### PR TITLE
docs(BLT-2353): move 0.50.0 changelog out of Unreleased

### DIFF
--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -9,19 +9,15 @@ All notable changes to Botonic will be documented in this file.
     Changes that have landed in master but are not yet released.
     Click to see more.
   </summary>
-  
+
+</details>
+
 ## [0.50.0] - 2026-06-04
 
 ### Added
 
 - [PR-3228](https://github.com/hubtype/botonic/pull/3228): Add LiteLLM provider support, allowing AI agents to route LLM calls through a LiteLLM proxy.
 
-### Changed
-
-### Fixed
-
-</details>
-  
 ## [0.49.0] - 2026-05-28
 
 ### Added


### PR DESCRIPTION
Move the `0.50.0` entry in `botonic-plugin-ai-agents` CHANGELOG from the Unreleased section to its own released section.