### PR TITLE
plugin-ai-agents: add force tool name override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23635,7 +23635,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.50.0",
+      "version": "0.50.1",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -23899,7 +23899,7 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.50.0",
+      "version": "0.50.1",
       "dependencies": {
         "@botonic/core": "^0.50.0",
         "@openai/agents": "^0.10.1",

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-core/src/models/ai-agents.ts
+++ b/packages/botonic-core/src/models/ai-agents.ts
@@ -142,6 +142,7 @@ export type AiAgentBaseArgs = {
   inputGuardrailRules?: GuardrailRule[]
   previousHubtypeMessages?: HubtypeAssistantMessage[]
   outputMessagesSchemas?: z.ZodObject<any>[]
+  forceToolNameOverride?: string
 }
 
 export interface AiAgentSpecialistArgs extends AiAgentBaseArgs {

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",

--- a/packages/botonic-plugin-ai-agents/src/agents/specialist-agent.ts
+++ b/packages/botonic-plugin-ai-agents/src/agents/specialist-agent.ts
@@ -29,6 +29,7 @@ interface SpecialistAgentOptions<
   llmConfig: LLMConfig
   logger: DebugLogger
   guardrailTrackingContext: GuardrailTrackingContext
+  forceToolNameOverride?: string
 }
 
 export class SpecialistAgent<
@@ -38,6 +39,7 @@ export class SpecialistAgent<
   private tools: Tool<TPlugins, TExtraData>[]
   private logger: DebugLogger
   private agent!: AIAgent<TPlugins, TExtraData>
+  private forceToolNameOverride?: string
 
   private constructor(options: SpecialistAgentOptions<TPlugins, TExtraData>) {
     super({
@@ -55,6 +57,7 @@ export class SpecialistAgent<
     )
     this.tools = this.addHubtypeTools(options.tools, options.sourceIds)
     this.logger = options.logger
+    this.forceToolNameOverride = options.forceToolNameOverride
   }
 
   static async create<
@@ -108,8 +111,11 @@ export class SpecialistAgent<
     hasRetrieveKnowledge: boolean
   ): ModelSettings {
     const modelSettings = this.getAgentModelSettings()
-    if (hasRetrieveKnowledge) {
+    if (hasRetrieveKnowledge && !this.forceToolNameOverride) {
       modelSettings.toolChoice = RETRIEVE_KNOWLEDGE_TOOL_NAME
+    }
+    if (this.forceToolNameOverride) {
+      modelSettings.toolChoice = this.forceToolNameOverride
     }
     return modelSettings
   }

--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -204,14 +204,21 @@ export default class BotonicPluginAiAgents<
 
     const specialistsAgents = await Promise.all(
       specialists.map(async specialistData => {
+        // If the forceToolNameOverride is set, we force this override for all specialists
+        const forceToolNameOverride = aiAgentArgs.forceToolNameOverride
+        const aiAgentSpecialistArgs = {
+          ...specialistData,
+          forceToolNameOverride,
+        }
         const { agent } = await this.getSpecialistAgentAndTools(
           botContext,
-          specialistData,
+          aiAgentSpecialistArgs,
           aiAgentArgs.outputMessagesSchemas || [],
           authToken,
           inferenceId,
           llmConfig
         )
+
         return handoff(agent, {
           toolNameOverride: specialistData.name,
           toolDescriptionOverride: specialistData.description,
@@ -297,6 +304,7 @@ export default class BotonicPluginAiAgents<
         authToken,
         inferenceId,
       },
+      forceToolNameOverride: aiAgentArgs.forceToolNameOverride,
     })
     const specialistAgent = specialist.getAgent()
 


### PR DESCRIPTION
## Description

Add forceToolNameOverride in AiAgentBaseArgs to be able to rerun AI Agent Specialist forcing the execution of a tool.

## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
