### PR TITLE
Reasoning effort none as default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23635,7 +23635,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.51.1",
+      "version": "0.51.2",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -23899,9 +23899,9 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.51.1",
+      "version": "0.51.2",
       "dependencies": {
-        "@botonic/core": "^0.51.1",
+        "@botonic/core": "^0.51.2",
         "@openai/agents": "^0.10.1",
         "axios": "^1.15.2",
         "openai": "^6.36.0",

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-core/src/models/ai-agents.ts
+++ b/packages/botonic-core/src/models/ai-agents.ts
@@ -147,6 +147,7 @@ export type AiAgentBaseArgs = {
   model: string
   verbosity: VerbosityLevel
   reasoningEffort?: ReasoningEffort
+  disableForceRetrieveKnowledge?: boolean // If true, the agent will not force the retrieve knowledge tool to be used.
   inputGuardrailRules?: GuardrailRule[]
   previousHubtypeMessages?: HubtypeAssistantMessage[]
   outputMessagesSchemas?: z.ZodObject<any>[]

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",
@@ -14,7 +14,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.51.1",
+    "@botonic/core": "^0.51.2",
     "@openai/agents": "^0.10.1",
     "axios": "^1.15.2",
     "openai": "^6.36.0",

--- a/packages/botonic-plugin-ai-agents/src/agents/specialist-agent.ts
+++ b/packages/botonic-plugin-ai-agents/src/agents/specialist-agent.ts
@@ -30,6 +30,7 @@ interface SpecialistAgentOptions<
   logger: DebugLogger
   guardrailTrackingContext: GuardrailTrackingContext
   forceToolNameOverride?: string
+  disableForceRetrieveKnowledge?: boolean
 }
 
 export class SpecialistAgent<
@@ -40,6 +41,7 @@ export class SpecialistAgent<
   private logger: DebugLogger
   private agent!: AIAgent<TPlugins, TExtraData>
   private forceToolNameOverride?: string
+  private disableForceRetrieveKnowledge?: boolean
 
   private constructor(options: SpecialistAgentOptions<TPlugins, TExtraData>) {
     super({
@@ -58,6 +60,7 @@ export class SpecialistAgent<
     this.tools = this.addHubtypeTools(options.tools, options.sourceIds)
     this.logger = options.logger
     this.forceToolNameOverride = options.forceToolNameOverride
+    this.disableForceRetrieveKnowledge = options.disableForceRetrieveKnowledge
   }
 
   static async create<
@@ -111,12 +114,18 @@ export class SpecialistAgent<
     hasRetrieveKnowledge: boolean
   ): ModelSettings {
     const modelSettings = this.getAgentModelSettings()
-    if (hasRetrieveKnowledge && !this.forceToolNameOverride) {
+    if (
+      hasRetrieveKnowledge &&
+      !this.forceToolNameOverride &&
+      !this.disableForceRetrieveKnowledge
+    ) {
       modelSettings.toolChoice = RETRIEVE_KNOWLEDGE_TOOL_NAME
     }
+
     if (this.forceToolNameOverride) {
       modelSettings.toolChoice = this.forceToolNameOverride
     }
+
     return modelSettings
   }
 

--- a/packages/botonic-plugin-ai-agents/src/llm-config.ts
+++ b/packages/botonic-plugin-ai-agents/src/llm-config.ts
@@ -143,9 +143,18 @@ export class LLMConfig {
     model: string,
     verbosity: VerbosityLevel
   ): ModelSettings {
+    // By default, we use low reasoning effort for chat models because they not accept the reasoning effort set as none.
+    if (model.includes('chat')) {
+      return {
+        reasoning: { effort: this.reasoningEffort ?? ReasoningEffort.Low },
+        temperature: 1,
+        text: { verbosity },
+      }
+    }
+
     if (model.includes('gpt-5')) {
       return {
-        reasoning: { effort: this.reasoningEffort ?? ReasoningEffort.Medium },
+        reasoning: { effort: this.reasoningEffort ?? ReasoningEffort.None },
         temperature: 1,
         text: { verbosity },
       }

--- a/packages/botonic-plugin-ai-agents/tests/agent-builder.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/agent-builder.test.ts
@@ -670,6 +670,34 @@ describe('WorkerAgent', () => {
       )
     })
 
+    it('should NOT set toolChoice to retrieve_knowledge when disableForceRetrieveKnowledge is true', async () => {
+      await SpecialistAgent.create({
+        name: agentName,
+        instructions: agentInstructions,
+        llmConfig: mockLlmConfig,
+        tools: agentCustomTools,
+        contactInfo,
+        inputGuardrailRules: [],
+        sourceIds: ['source-1'],
+        disableForceRetrieveKnowledge: true,
+        campaignsContext: undefined,
+        logger: mockLogger,
+        guardrailTrackingContext: mockGuardrailTrackingContext,
+      }).then(agent => agent.getAgent())
+
+      expect(mockLogger.logModelSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hasRetrieveKnowledge: true,
+        })
+      )
+      expect(mockLogger.logModelSettings).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          toolChoice: 'retrieve_knowledge',
+        })
+      )
+      expect(capturedAgentConfig.modelSettings.toolChoice).toBeUndefined()
+    })
+
     it('should set resolved model for azure provider', async () => {
       // Default OPENAI_PROVIDER is 'azure'
       await SpecialistAgent.create({

--- a/packages/botonic-plugin-ai-agents/tests/llm-config.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/llm-config.test.ts
@@ -150,7 +150,23 @@ describe('LLMConfig', () => {
       })
 
       expect(config.modelSettings).toEqual({
-        reasoning: { effort: 'medium' },
+        reasoning: { effort: 'none' },
+        temperature: 1,
+        text: { verbosity: 'high' },
+      })
+    })
+
+    it('returns gpt-chat style settings for gpt-chat model', () => {
+      const config = new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'gpt-chat-latest',
+        verbosity: VerbosityLevel.High,
+        botContext: makeBotContext(),
+      })
+
+      expect(config.modelSettings).toEqual({
+        reasoning: { effort: 'low' },
         temperature: 1,
         text: { verbosity: 'high' },
       })


### PR DESCRIPTION
## Description

This pull request adjusts default LLM model settings for GPT-5 and chat-style models, and introduces an opt-out flag to stop forcing the `retrieve_knowledge` tool on specialist agents. Both `@botonic/core` and `@botonic/plugin-ai-agents` are bumped to `0.51.2`.

## Context

- **Reasoning effort defaults:** GPT-5 models were defaulting to `medium` reasoning effort, which increases latency and cost without a clear benefit for all use cases. The new default is `none`, while still allowing an explicit override via `reasoningEffort`.
- **Chat model compatibility:** Chat-style models (e.g. `gpt-chat-latest`) do not accept `reasoning.effort: none`. Sending that value can cause API errors. These models now receive `low` as the default reasoning effort instead.
- **Retrieve knowledge tool forcing:** Specialist agents with knowledge sources automatically set `toolChoice` to `retrieve_knowledge`, forcing the model to call that tool on every turn. Some bots need the retrieve knowledge tool available but not mandatory — for example, when the agent should decide whether retrieval is needed based on the user message.

## Approach taken / Explain the design

### 1. LLM model settings (`LLMConfig.getModelSettings`)

Model-specific defaults are resolved in this order:

1. **Chat models** (`model.includes('chat')`): use `reasoning.effort: low` (or the configured `reasoningEffort` override), since `none` is not supported.
2. **GPT-5 models** (`model.includes('gpt-5')`): use `reasoning.effort: none` (or the configured `reasoningEffort` override), changed from the previous default of `medium`.
3. **GPT-4 and other models:** unchanged behavior.

### 2. `disableForceRetrieveKnowledge` flag

- Added to `AiAgentBaseArgs` in `@botonic/core` so it can be configured at the agent definition level.
- Wired into `SpecialistAgent.resolveModelSettings()`: when `true`, the agent no longer sets `toolChoice` to `retrieve_knowledge`, even if knowledge sources are configured.
- `forceToolNameOverride` still takes precedence when set.

```
hasRetrieveKnowledge && !forceToolNameOverride && !disableForceRetrieveKnowledge
  → toolChoice = 'retrieve_knowledge'
```

## To document / Usage example

### Disable forced retrieve knowledge

```typescript
import { AiAgentType, VerbosityLevel } from '@botonic/core'

const specialistAgent: AiAgentSpecialistArgs = {
  type: AiAgentType.Specialist,
  name: 'support-agent',
  instructions: 'You are a helpful support agent.',
  model: 'gpt-5',
  verbosity: VerbosityLevel.Medium,
  disableForceRetrieveKnowledge: true, // Agent can choose whether to retrieve knowledge
  activeTools: [{ name: 'retrieve_knowledge' }],
  sourceIds: ['source-1'],
}
```

Or when creating a `SpecialistAgent` directly:

```typescript
await SpecialistAgent.create({
  name: 'support-agent',
  instructions: '...',
  sourceIds: ['source-1'],
  disableForceRetrieveKnowledge: true,
  // ...other options
})
```

### Reasoning effort behavior

```typescript
// GPT-5: defaults to reasoning.effort = 'none'
const gpt5Config = new LLMConfig({
  modelName: 'gpt-5',
  verbosity: VerbosityLevel.High,
  botContext,
})

// Chat models: defaults to reasoning.effort = 'low'
const chatConfig = new LLMConfig({
  modelName: 'gpt-chat-latest',
  verbosity: VerbosityLevel.High,
  botContext,
})

// Explicit override still works for both
const customConfig = new LLMConfig({
  modelName: 'gpt-5',
  verbosity: VerbosityLevel.High,
  botContext,
  reasoningEffort: ReasoningEffort.High,
})
```

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because...