### PR TITLE
Use disable force when create specialist agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23899,7 +23899,7 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.51.2",
+      "version": "0.51.4",
       "dependencies": {
         "@botonic/core": "^0.51.2",
         "@openai/agents": "^0.10.1",

--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to Botonic will be documented in this file.
 
 </details>
 
+## [0.51.4] - 2026-07-06
+
+### Added
+
+- [PR-3244](https://github.com/hubtype/botonic/pull/3244): Allow to disableForceRetrieveKnowledge and change reasoningEffort in attribute AiAgentArgs from getInference function.
+
 ## [0.50.0] - 2026-06-04
 
 ### Added

--- a/packages/botonic-plugin-ai-agents/README.md
+++ b/packages/botonic-plugin-ai-agents/README.md
@@ -3,10 +3,10 @@
 ## env variables
 
 - It is necessary to add the following variables to an `.env` file:
-  - `AZURE_OPENAI_API_KEY`
-  - `AZURE_OPENAI_API_BASE`
-  - `AZURE_OPENAI_API_DEPLOYMENT_NAME`
-  - `AZURE_OPENAI_API_VERSION`
+  - `LLM_PROVIDER`
+  - `LLM_API_KEY`
+  - `LLM_API_URL`
+  - `LLM_AZURE_API_VERSION`
 - Add these env variables to build using rspack, for target NODE and DEV.
 
 ```ts
@@ -22,17 +22,17 @@ config()
       WEBCHAT_PUSHER_KEY:
         process.env.WEBCHAT_PUSHER_KEY || HUBTYPE_DEFAULTS.WEBCHAT_PUSHER_KEY,
       ENVIRONMENT: process.env.ENVIRONMENT,
-      AZURE_OPENAI_API_KEY: isNodeOrDev
-        ? process.env.AZURE_OPENAI_API_KEY
+      LLM_PROVIDER: isNodeOrDev
+        ? process.env.LLM_PROVIDER
         : undefined,
-      AZURE_OPENAI_API_DEPLOYMENT_NAME: isNodeOrDev
-        ? process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME
+      LLM_API_KEY: isNodeOrDev
+        ? process.env.LLM_API_KEY
         : undefined,
-      AZURE_OPENAI_API_VERSION: isNodeOrDev
-        ? process.env.AZURE_OPENAI_API_VERSION
+      LLM_API_URL: isNodeOrDev
+        ? process.env.LLM_API_URL
         : undefined,
-      AZURE_OPENAI_API_BASE: isNodeOrDev
-        ? process.env.AZURE_OPENAI_API_BASE
+      LLM_AZURE_API_VERSION: isNodeOrDev
+        ? process.env.LLM_AZURE_API_VERSION
         : undefined,
     }),
     new rspack.ProgressPlugin(),

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.51.2",
+  "version": "0.51.4",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",

--- a/packages/botonic-plugin-ai-agents/src/agents/base-agent.ts
+++ b/packages/botonic-plugin-ai-agents/src/agents/base-agent.ts
@@ -44,12 +44,15 @@ export abstract class BaseAgent {
 
   protected getAgentModelSettings(): ModelSettings {
     const modelSettings: ModelSettings = { ...this.llmConfig.modelSettings }
+
     if (this.llmConfig.modelSettings.reasoning) {
       modelSettings.reasoning = { ...this.llmConfig.modelSettings.reasoning }
     }
+
     if (this.llmConfig.modelSettings.text) {
       modelSettings.text = { ...this.llmConfig.modelSettings.text }
     }
+
     return modelSettings
   }
 

--- a/packages/botonic-plugin-ai-agents/src/agents/specialist-agent.ts
+++ b/packages/botonic-plugin-ai-agents/src/agents/specialist-agent.ts
@@ -114,11 +114,12 @@ export class SpecialistAgent<
     hasRetrieveKnowledge: boolean
   ): ModelSettings {
     const modelSettings = this.getAgentModelSettings()
-    if (
+    const forceRetrieveKnowledge =
       hasRetrieveKnowledge &&
       !this.forceToolNameOverride &&
       !this.disableForceRetrieveKnowledge
-    ) {
+
+    if (forceRetrieveKnowledge) {
       modelSettings.toolChoice = RETRIEVE_KNOWLEDGE_TOOL_NAME
     }
 

--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -6,7 +6,6 @@ import {
   type BotContext,
   type HubtypeAssistantMessage,
   type Plugin,
-  type ReasoningEffort,
   type ResolvedPlugins,
 } from '@botonic/core'
 import { handoff, setTracingDisabled, tool } from '@openai/agents'
@@ -87,8 +86,6 @@ export default class BotonicPluginAiAgents<
       throw new Error('Auth token is required')
     }
 
-    const reasoningEffort = aiAgentArgs.reasoningEffort
-
     const inferenceId = uuidv7()
 
     try {
@@ -97,8 +94,7 @@ export default class BotonicPluginAiAgents<
           botContext,
           aiAgentArgs,
           authToken,
-          inferenceId,
-          reasoningEffort
+          inferenceId
         )
       }
 
@@ -107,8 +103,7 @@ export default class BotonicPluginAiAgents<
           botContext,
           aiAgentArgs,
           authToken,
-          inferenceId,
-          reasoningEffort
+          inferenceId
         )
       }
 
@@ -135,8 +130,7 @@ export default class BotonicPluginAiAgents<
     botContext: BotContext<TPlugins, TExtraData>,
     aiAgentArgs: AiAgentSpecialistArgs,
     authToken: string,
-    inferenceId: string,
-    reasoningEffort?: ReasoningEffort
+    inferenceId: string
   ) {
     const llmConfig = new LLMConfig({
       maxRetries: this.maxRetries,
@@ -144,7 +138,7 @@ export default class BotonicPluginAiAgents<
       modelName: aiAgentArgs.model,
       verbosity: aiAgentArgs.verbosity,
       botContext,
-      reasoningEffort,
+      reasoningEffort: aiAgentArgs.reasoningEffort,
     })
 
     // Get LLM config, tools and agent
@@ -197,8 +191,7 @@ export default class BotonicPluginAiAgents<
     botContext: BotContext<TPlugins, TExtraData>,
     aiAgentArgs: AIAgentRouterArgs,
     authToken: string,
-    inferenceId: string,
-    reasoningEffort?: ReasoningEffort
+    inferenceId: string
   ) {
     const { specialists, name, instructions } = aiAgentArgs
 
@@ -208,17 +201,25 @@ export default class BotonicPluginAiAgents<
       modelName: aiAgentArgs.model,
       verbosity: aiAgentArgs.verbosity,
       botContext,
-      reasoningEffort,
+      reasoningEffort: aiAgentArgs.reasoningEffort,
     })
 
     const specialistsAgents = await Promise.all(
       specialists.map(async specialistData => {
         // If the forceToolNameOverride is set, we force this override for all specialists
         const forceToolNameOverride = aiAgentArgs.forceToolNameOverride
-        const aiAgentSpecialistArgs = {
+        const reasoningEffort = aiAgentArgs.reasoningEffort
+        const disableForceRetrieveKnowledge =
+          aiAgentArgs.disableForceRetrieveKnowledge
+
+        // Create AiAgentArgs for the specialist, with values from AIAgentRouterArgs
+        const aiAgentSpecialistArgs: AiAgentArgs = {
           ...specialistData,
           forceToolNameOverride,
+          reasoningEffort,
+          disableForceRetrieveKnowledge,
         }
+
         const { agent } = await this.getSpecialistAgentAndTools(
           botContext,
           aiAgentSpecialistArgs,
@@ -289,6 +290,10 @@ export default class BotonicPluginAiAgents<
     inferenceId: string,
     llmConfig: LLMConfig
   ) {
+    console.log(
+      'getSpecialistAgentAndTools llmConfig.reasoning',
+      llmConfig.modelSettings.reasoning
+    )
     // Build tools
     const tools = this.buildTools(aiAgentArgs)
 
@@ -314,6 +319,7 @@ export default class BotonicPluginAiAgents<
         inferenceId,
       },
       forceToolNameOverride: aiAgentArgs.forceToolNameOverride,
+      disableForceRetrieveKnowledge: aiAgentArgs.disableForceRetrieveKnowledge,
     })
     const specialistAgent = specialist.getAgent()
 

--- a/packages/botonic-plugin-ai-agents/src/llm-config.ts
+++ b/packages/botonic-plugin-ai-agents/src/llm-config.ts
@@ -34,7 +34,6 @@ export class LLMConfig {
   public readonly modelName: string
   public readonly modelSettings: ModelSettings
   public readonly modelProvider: ModelProvider
-  public readonly reasoningEffort?: ReasoningEffort
 
   constructor({
     maxRetries,
@@ -50,8 +49,12 @@ export class LLMConfig {
     this.modelName =
       LLM_PROVIDER === LLM_PROVIDERS.OPENAI ? LLM_OPENAI_MODEL : modelName
     this.modelProvider = this.getModelProvider()
-    this.modelSettings = this.getModelSettings(modelName, verbosity)
-    this.reasoningEffort = reasoningEffort
+    this.modelSettings = this.getModelSettings(
+      modelName,
+      verbosity,
+      reasoningEffort
+    )
+    console.log('new LLMConfig reasoningEffort', reasoningEffort)
   }
 
   async getModel(): Promise<Model> {
@@ -141,12 +144,13 @@ export class LLMConfig {
 
   private getModelSettings(
     model: string,
-    verbosity: VerbosityLevel
+    verbosity: VerbosityLevel,
+    reasoningEffort?: ReasoningEffort
   ): ModelSettings {
     // By default, we use low reasoning effort for chat models because they not accept the reasoning effort set as none.
     if (model.includes('chat')) {
       return {
-        reasoning: { effort: this.reasoningEffort ?? ReasoningEffort.Low },
+        reasoning: { effort: reasoningEffort ?? ReasoningEffort.Low },
         temperature: 1,
         text: { verbosity },
       }
@@ -154,7 +158,7 @@ export class LLMConfig {
 
     if (model.includes('gpt-5')) {
       return {
-        reasoning: { effort: this.reasoningEffort ?? ReasoningEffort.None },
+        reasoning: { effort: reasoningEffort ?? ReasoningEffort.None },
         temperature: 1,
         text: { verbosity },
       }


### PR DESCRIPTION
## Description

This pull request allows AI agent router configuration to be propagated to the specialist agents it creates. Router-level `reasoningEffort` and `disableForceRetrieveKnowledge` values are now applied consistently when building specialist agents and their LLM settings.

## Context

Router agents can dynamically create specialist agents, but some AI agent options were only being applied to the router LLM configuration. This made it impossible to configure specialist reasoning effort from the router and to disable forced knowledge retrieval for specialists created through a router.

## Approach taken / Explain the design

The plugin now reads `reasoningEffort` directly from each `AiAgentArgs` object when creating the corresponding `LLMConfig`, instead of passing it as a separate argument through the inference flow.

When a router creates its specialists, it forwards the router-level `reasoningEffort`, `forceToolNameOverride`, and `disableForceRetrieveKnowledge` values into the generated specialist arguments. `SpecialistAgent` then uses `disableForceRetrieveKnowledge` together with the existing retrieve-knowledge and force-tool checks before forcing the retrieve knowledge tool.

The package version and changelog were updated to `0.51.4`, and the README now documents the current generic LLM environment variables.

## To document / Usage example

A router agent can disable forced knowledge retrieval and set the reasoning effort for the specialists it creates:

```ts
const aiAgentArgs = {
  type: 'router',
  model: 'gpt-5',
  reasoningEffort: ReasoningEffort.Low,
  disableForceRetrieveKnowledge: true,
  ...
}
```