### PR TITLE
react & plugin-flow-builder: use webview params from flow builder #BLT-2460

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botonic",
-  "version": "0.51.0",
+  "version": "0.52.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botonic",
-      "version": "0.51.0",
+      "version": "0.52.0-alpha.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23665,8 +23665,8 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
-        "@botonic/dx-bundler-rspack": "^0.51.0",
-        "@botonic/eslint-config": "^0.51.0",
+        "@botonic/dx-bundler-rspack": "^0.52.0-alpha.0",
+        "@botonic/eslint-config": "^0.52.0-alpha.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.19.1",
         "babel-loader": "^8.4.1",
@@ -23753,52 +23753,6 @@
       "engines": {
         "node": ">=22.19.0",
         "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-dx/node_modules/@botonic/dx-bundler-rspack": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@botonic/dx-bundler-rspack/-/dx-bundler-rspack-0.51.0.tgz",
-      "integrity": "sha512-MzGHnZCdFogrIgmbVqVAx6vdKRKwStLot7QiO750CUIxB+IEQf2cNS0ww0beT6O7cL3gVhrzWXKu0c7Qa57afA==",
-      "license": "MIT",
-      "dependencies": {
-        "@rspack/cli": "^1.6.1",
-        "@rspack/core": "^1.6.1",
-        "@rspack/plugin-react-refresh": "^1.5.2",
-        "@swc/core": "^1.15.1",
-        "@swc/helpers": "^0.5.17",
-        "css-loader": "^7.1.2",
-        "html-webpack-plugin": "^5.6.4",
-        "node-polyfill-webpack-plugin": "^4.1.0",
-        "null-loader": "^4.0.1",
-        "react-refresh": "^0.16.0",
-        "sass": "^1.93.2",
-        "sass-loader": "^16.0.5",
-        "stream-browserify": "^3.0.0",
-        "style-loader": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=22.19.0",
-        "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-dx/node_modules/@botonic/eslint-config": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@botonic/eslint-config/-/eslint-config-0.51.0.tgz",
-      "integrity": "sha512-4njtLoPc1ig09Kb/ISlaQ6L2OYfRmiUdnNfNkeQgoIPAvAX8d7ymbPgAmeO6jQmpoqh9BdUDJszki4d3EE+EkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
-        "eslint-plugin-filenames": "^1.3.2",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-jest": "^27.9.0",
-        "eslint-plugin-no-null": "^1.0.2",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^5.2.3",
-        "eslint-plugin-promise": "^6.6.0",
-        "eslint-plugin-react": "^7.37.4",
-        "eslint-plugin-react-hooks": "^4.6.2",
-        "eslint-plugin-simple-import-sort": "^10.0.0"
       }
     },
     "packages/botonic-dx/node_modules/@jest/expect-utils": {
@@ -23949,7 +23903,7 @@
       "name": "@botonic/plugin-ai-agents",
       "version": "0.52.0-alpha.0",
       "dependencies": {
-        "@botonic/core": "^0.51.3",
+        "@botonic/core": "^0.52.0-alpha.0",
         "@openai/agents": "^0.10.1",
         "axios": "^1.15.2",
         "openai": "^6.36.0",
@@ -23958,24 +23912,6 @@
       },
       "devDependencies": {
         "@types/uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=22.19.0",
-        "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-plugin-ai-agents/node_modules/@botonic/core": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
-      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-runtime": "^7.25.9",
-        "axios": "^1.15.2",
-        "pako": "^2.1.0",
-        "process": "^0.11.10",
-        "pusher-js": "^5.1.1",
-        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.19.0",
@@ -23999,55 +23935,12 @@
       "name": "@botonic/plugin-flow-builder",
       "version": "0.52.0-alpha.0",
       "dependencies": {
-        "@botonic/react": "^0.51.0",
+        "@botonic/react": "^0.52.0-alpha.0",
         "axios": "^1.15.2",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@types/uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=22.19.0",
-        "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-plugin-flow-builder/node_modules/@botonic/core": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
-      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-runtime": "^7.25.9",
-        "axios": "^1.15.2",
-        "pako": "^2.1.0",
-        "process": "^0.11.10",
-        "pusher-js": "^5.1.1",
-        "zod": "^4.4.3"
-      },
-      "engines": {
-        "node": ">=22.19.0",
-        "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-plugin-flow-builder/node_modules/@botonic/react": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@botonic/react/-/react-0.51.0.tgz",
-      "integrity": "sha512-6N+9TW4Dcprhp+iywZ//jClv3v9jbPQVSIp6LL2fn/Ld2aX4w2pnz4s+bFUcgkUD5YWP+uPwSrCdvA7PqbhJ4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@botonic/core": "^0.51.0",
-        "axios": "^1.15.2",
-        "emoji-picker-react": "^4.12.0",
-        "lodash.merge": "^4.6.2",
-        "markdown-it": "^12.3.2",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-json-tree": "^0.18.0",
-        "react-router-dom": "^5.3.4",
-        "react-textarea-autosize": "^8.5.5",
-        "styled-components": "^5.3.11",
-        "ua-parser-js": "^1.0.39",
-        "uuid": "^10.0.0"
       },
       "engines": {
         "node": ">=22.19.0",
@@ -24073,29 +23966,11 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@botonic/core": "^0.51.0",
+        "@botonic/core": "^0.52.0-alpha.0",
         "axios": "^1.15.2"
       },
       "devDependencies": {
         "@types/node": "^20.11.17"
-      },
-      "engines": {
-        "node": ">=22.19.0",
-        "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-plugin-hubtype-analytics/node_modules/@botonic/core": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
-      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-runtime": "^7.25.9",
-        "axios": "^1.15.2",
-        "pako": "^2.1.0",
-        "process": "^0.11.10",
-        "pusher-js": "^5.1.1",
-        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.19.0",
@@ -24108,29 +23983,11 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@botonic/core": "^0.51.0",
+        "@botonic/core": "^0.52.0-alpha.0",
         "axios": "^1.15.2"
       },
       "devDependencies": {
         "@types/node": "^20.11.16"
-      },
-      "engines": {
-        "node": ">=22.19.0",
-        "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-plugin-knowledge-bases/node_modules/@botonic/core": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
-      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-runtime": "^7.25.9",
-        "axios": "^1.15.2",
-        "pako": "^2.1.0",
-        "process": "^0.11.10",
-        "pusher-js": "^5.1.1",
-        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.19.0",
@@ -24142,7 +23999,7 @@
       "version": "0.52.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@botonic/core": "^0.51.0",
+        "@botonic/core": "^0.52.0-alpha.0",
         "axios": "^1.15.2",
         "emoji-picker-react": "^4.12.0",
         "lodash.merge": "^4.6.2",
@@ -24175,24 +24032,6 @@
         "identity-obj-proxy": "^3.0.0",
         "intersection-observer": "^0.12.2",
         "react-test-renderer": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=22.19.0",
-        "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-react/node_modules/@botonic/core": {
-      "version": "0.51.3",
-      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
-      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-runtime": "^7.25.9",
-        "axios": "^1.15.2",
-        "pako": "^2.1.0",
-        "process": "^0.11.10",
-        "pusher-js": "^5.1.1",
-        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23591,7 +23591,7 @@
     },
     "packages/botonic-cli": {
       "name": "@botonic/cli",
-      "version": "0.51.0",
+      "version": "0.52.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.8.6",
@@ -23636,7 +23636,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.51.3",
+      "version": "0.52.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -23657,7 +23657,7 @@
     },
     "packages/botonic-dx": {
       "name": "@botonic/dx",
-      "version": "0.51.0",
+      "version": "0.52.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-modules-commonjs": "^7.27.1",
@@ -23694,7 +23694,7 @@
     },
     "packages/botonic-dx-bundler-rspack": {
       "name": "@botonic/dx-bundler-rspack",
-      "version": "0.51.0",
+      "version": "0.52.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@rspack/cli": "^1.6.1",
@@ -23753,6 +23753,52 @@
       "engines": {
         "node": ">=22.19.0",
         "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-dx/node_modules/@botonic/dx-bundler-rspack": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@botonic/dx-bundler-rspack/-/dx-bundler-rspack-0.51.0.tgz",
+      "integrity": "sha512-MzGHnZCdFogrIgmbVqVAx6vdKRKwStLot7QiO750CUIxB+IEQf2cNS0ww0beT6O7cL3gVhrzWXKu0c7Qa57afA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rspack/cli": "^1.6.1",
+        "@rspack/core": "^1.6.1",
+        "@rspack/plugin-react-refresh": "^1.5.2",
+        "@swc/core": "^1.15.1",
+        "@swc/helpers": "^0.5.17",
+        "css-loader": "^7.1.2",
+        "html-webpack-plugin": "^5.6.4",
+        "node-polyfill-webpack-plugin": "^4.1.0",
+        "null-loader": "^4.0.1",
+        "react-refresh": "^0.16.0",
+        "sass": "^1.93.2",
+        "sass-loader": "^16.0.5",
+        "stream-browserify": "^3.0.0",
+        "style-loader": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22.19.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-dx/node_modules/@botonic/eslint-config": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@botonic/eslint-config/-/eslint-config-0.51.0.tgz",
+      "integrity": "sha512-4njtLoPc1ig09Kb/ISlaQ6L2OYfRmiUdnNfNkeQgoIPAvAX8d7ymbPgAmeO6jQmpoqh9BdUDJszki4d3EE+EkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "eslint-plugin-filenames": "^1.3.2",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jest": "^27.9.0",
+        "eslint-plugin-no-null": "^1.0.2",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-prettier": "^5.2.3",
+        "eslint-plugin-promise": "^6.6.0",
+        "eslint-plugin-react": "^7.37.4",
+        "eslint-plugin-react-hooks": "^4.6.2",
+        "eslint-plugin-simple-import-sort": "^10.0.0"
       }
     },
     "packages/botonic-dx/node_modules/@jest/expect-utils": {
@@ -23882,7 +23928,7 @@
     },
     "packages/botonic-eslint-config": {
       "name": "@botonic/eslint-config",
-      "version": "0.51.0",
+      "version": "0.52.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -23901,7 +23947,7 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.51.5",
+      "version": "0.52.0-alpha.0",
       "dependencies": {
         "@botonic/core": "^0.51.3",
         "@openai/agents": "^0.10.1",
@@ -23912,6 +23958,24 @@
       },
       "devDependencies": {
         "@types/uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.19.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-plugin-ai-agents/node_modules/@botonic/core": {
+      "version": "0.51.3",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
+      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.15.2",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.19.0",
@@ -23933,7 +23997,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.51.2",
+      "version": "0.52.0-alpha.0",
       "dependencies": {
         "@botonic/react": "^0.51.0",
         "axios": "^1.15.2",
@@ -23941,6 +24005,49 @@
       },
       "devDependencies": {
         "@types/uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.19.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-plugin-flow-builder/node_modules/@botonic/core": {
+      "version": "0.51.3",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
+      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.15.2",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22.19.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-plugin-flow-builder/node_modules/@botonic/react": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@botonic/react/-/react-0.51.0.tgz",
+      "integrity": "sha512-6N+9TW4Dcprhp+iywZ//jClv3v9jbPQVSIp6LL2fn/Ld2aX4w2pnz4s+bFUcgkUD5YWP+uPwSrCdvA7PqbhJ4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@botonic/core": "^0.51.0",
+        "axios": "^1.15.2",
+        "emoji-picker-react": "^4.12.0",
+        "lodash.merge": "^4.6.2",
+        "markdown-it": "^12.3.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-json-tree": "^0.18.0",
+        "react-router-dom": "^5.3.4",
+        "react-textarea-autosize": "^8.5.5",
+        "styled-components": "^5.3.11",
+        "ua-parser-js": "^1.0.39",
+        "uuid": "^10.0.0"
       },
       "engines": {
         "node": ">=22.19.0",
@@ -23962,7 +24069,7 @@
     },
     "packages/botonic-plugin-hubtype-analytics": {
       "name": "@botonic/plugin-hubtype-analytics",
-      "version": "0.51.0",
+      "version": "0.52.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -23977,9 +24084,27 @@
         "npm": ">=10.0.0"
       }
     },
+    "packages/botonic-plugin-hubtype-analytics/node_modules/@botonic/core": {
+      "version": "0.51.3",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
+      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.15.2",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22.19.0",
+        "npm": ">=10.0.0"
+      }
+    },
     "packages/botonic-plugin-knowledge-bases": {
       "name": "@botonic/plugin-knowledge-bases",
-      "version": "0.51.0",
+      "version": "0.52.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -23994,9 +24119,27 @@
         "npm": ">=10.0.0"
       }
     },
+    "packages/botonic-plugin-knowledge-bases/node_modules/@botonic/core": {
+      "version": "0.51.3",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
+      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.15.2",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22.19.0",
+        "npm": ">=10.0.0"
+      }
+    },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.51.0",
+      "version": "0.52.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@botonic/core": "^0.51.0",
@@ -24032,6 +24175,24 @@
         "identity-obj-proxy": "^3.0.0",
         "intersection-observer": "^0.12.2",
         "react-test-renderer": "^18.3.1"
+      },
+      "engines": {
+        "node": ">=22.19.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "packages/botonic-react/node_modules/@botonic/core": {
+      "version": "0.51.3",
+      "resolved": "https://registry.npmjs.org/@botonic/core/-/core-0.51.3.tgz",
+      "integrity": "sha512-Iv9zMh3hJR9XyYz0UFqNhO+zE0XmkDc+VPyYsLAcHG+0hXM3LDmYC5SnTCr6O5PAvIgKo3e6D3MSP7wwyCxiNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "axios": "^1.15.2",
+        "pako": "^2.1.0",
+        "process": "^0.11.10",
+        "pusher-js": "^5.1.1",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.19.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "botonic",
-  "version": "0.51.0",
+  "version": "0.52.0-alpha.0",
   "scripts": {
     "clean": "rimraf packages/**/lib"
   },

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.51.0",
+  "version": "0.52.0-alpha.0",
   "license": "MIT",
   "bin": {
     "botonic": "./bin/run.js"

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.51.3",
+  "version": "0.52.0-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-dx-bundler-rspack/package.json
+++ b/packages/botonic-dx-bundler-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx-bundler-rspack",
-  "version": "0.51.0",
+  "version": "0.52.0-alpha.0",
   "description": "Build Botonic bots with RSPack",
   "scripts": {
     "build": "echo Skipping build...",

--- a/packages/botonic-dx/package.json
+++ b/packages/botonic-dx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx",
-  "version": "0.51.0",
+  "version": "0.52.0-alpha.0",
   "description": "Continuous integration for botonic packages",
   "scripts": {
     "build": "echo Skipping build..."
@@ -18,8 +18,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
-    "@botonic/dx-bundler-rspack": "^0.51.0",
-    "@botonic/eslint-config": "^0.51.0",
+    "@botonic/dx-bundler-rspack": "^0.52.0-alpha.0",
+    "@botonic/eslint-config": "^0.52.0-alpha.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.19.1",
     "babel-loader": "^8.4.1",

--- a/packages/botonic-eslint-config/package.json
+++ b/packages/botonic-eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/eslint-config",
-  "version": "0.51.0",
+  "version": "0.52.0-alpha.0",
   "description": "Eslint config for botonic packages",
   "main": "index.js",
   "scripts": {

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.51.5",
+  "version": "0.52.0-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",
@@ -14,7 +14,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.51.3",
+    "@botonic/core": "^0.52.0-alpha.0",
     "@openai/agents": "^0.10.1",
     "axios": "^1.15.2",
     "openai": "^6.36.0",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.51.2",
+  "version": "0.52.0-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -15,7 +15,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/react": "^0.51.0",
+    "@botonic/react": "^0.52.0-alpha.0",
     "axios": "^1.15.2",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
@@ -59,6 +59,7 @@ export class FlowButton extends ContentFieldsBase {
     const params: Record<string, string> = {
       webviewId: webview.webviewTargetId,
       t: Date.now().toString(),
+      ...webview.webviewParams,
     }
     const exitSuccessContentID = FlowButton.getExitSuccessContentID(
       webview,

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
@@ -8,7 +8,6 @@ import { FlowWebview } from './flow-webview'
 import {
   type HtButton,
   HtButtonStyle,
-  type HtNodeWithContent,
   HtNodeWithContentType,
   type HtUrlNode,
 } from './hubtype-fields'
@@ -26,7 +25,8 @@ export class FlowButton extends ContentFieldsBase {
   static fromHubtypeCMS(
     cmsButton: HtButton,
     locale: string,
-    cmsApi: FlowBuilderApi
+    cmsApi: FlowBuilderApi,
+    botContext: BotContext
   ): FlowButton {
     const urlId = FlowButton.getUrlId(cmsButton, locale)
 
@@ -36,9 +36,8 @@ export class FlowButton extends ContentFieldsBase {
       const webview = FlowButton.getTargetWebview(cmsApi, cmsButton.target.id)
       if (webview) {
         newButton.flowWebview = webview
-        const params = FlowButton.getWebviewParams(webview, cmsApi)
         newButton.webview = { name: webview.webviewComponentName }
-        newButton.params = params
+        newButton.params = webview.getParams(botContext, cmsApi)
       } else {
         newButton.payload = cmsApi.getPayload(cmsButton.target)
       }
@@ -50,43 +49,6 @@ export class FlowButton extends ContentFieldsBase {
     }
 
     return newButton
-  }
-
-  private static getWebviewParams(
-    webview: FlowWebview,
-    cmsApi: FlowBuilderApi
-  ) {
-    const params: Record<string, string> = {
-      webviewId: webview.webviewTargetId,
-      t: Date.now().toString(),
-      ...webview.webviewParams,
-    }
-    const exitSuccessContentID = FlowButton.getExitSuccessContentID(
-      webview,
-      cmsApi
-    )
-
-    if (exitSuccessContentID) {
-      params.exitSuccessContentID = exitSuccessContentID
-    }
-
-    return params
-  }
-
-  private static getExitSuccessContentID(
-    webview: FlowWebview,
-    cmsApi: FlowBuilderApi
-  ) {
-    const webviewSuccessExit = webview.exits?.find(
-      exit => exit.name === 'Success'
-    )
-    const exitSuccessId = webviewSuccessExit?.target?.id
-    if (!exitSuccessId) {
-      return undefined
-    }
-    const exitNode = cmsApi.getNodeById<HtNodeWithContent>(exitSuccessId)
-
-    return exitNode.code
   }
 
   static fromAIAgent(button: {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-carousel.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-carousel.tsx
@@ -30,12 +30,13 @@ export class FlowCarousel extends ContentFieldsBase {
   static fromHubtypeCMS(
     component: HtCarouselNode,
     locale: string,
-    cmsApi: FlowBuilderApi
+    cmsApi: FlowBuilderApi,
+    botContext: BotContext
   ): FlowCarousel {
     const newCarousel = new FlowCarousel(component.id)
     newCarousel.code = component.code
     newCarousel.elements = component.content.elements.map(element =>
-      FlowElement.fromHubtypeCMS(element, locale, cmsApi)
+      FlowElement.fromHubtypeCMS(element, locale, cmsApi, botContext)
     )
     newCarousel.whatsappText = FlowCarousel.getTextByLocale(
       locale,

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-element.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-element.tsx
@@ -16,7 +16,8 @@ export class FlowElement extends ContentFieldsBase {
   static fromHubtypeCMS(
     component: HtCarouselElement,
     locale: string,
-    cmsApi: FlowBuilderApi
+    cmsApi: FlowBuilderApi,
+    botContext: BotContext
   ): FlowElement {
     const newElement = new FlowElement(component.id)
     newElement.title = FlowElement.getTextByLocale(locale, component.title)
@@ -28,7 +29,8 @@ export class FlowElement extends ContentFieldsBase {
     newElement.button = FlowButton.fromHubtypeCMS(
       component.button,
       locale,
-      cmsApi
+      cmsApi,
+      botContext
     )
     return newElement
   }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-text.tsx
@@ -21,14 +21,15 @@ export class FlowText extends ContentFieldsBase {
   static fromHubtypeCMS(
     cmsText: HtTextNode,
     locale: string,
-    cmsApi: FlowBuilderApi
+    cmsApi: FlowBuilderApi,
+    botContext: BotContext
   ): FlowText {
     const newText = new FlowText(cmsText.id)
     newText.code = cmsText.code
     newText.buttonStyle = cmsText.content.buttons_style || HtButtonStyle.BUTTON
     newText.text = FlowText.getTextByLocale(locale, cmsText.content.text)
     newText.buttons = cmsText.content.buttons.map(button =>
-      FlowButton.fromHubtypeCMS(button, locale, cmsApi)
+      FlowButton.fromHubtypeCMS(button, locale, cmsApi, botContext)
     )
     newText.followUp = cmsText.follow_up
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
@@ -4,12 +4,17 @@ import {
   type EventWebviewActionTriggered,
 } from '@botonic/core'
 
+import type { FlowBuilderApi } from '../api'
 import {
   getCommonFlowContentEventArgsForContentId,
   trackEvent,
 } from '../tracking'
 import { ContentFieldsBase } from './content-fields-base'
-import type { HtWebviewExits, HtWebviewNode } from './hubtype-fields'
+import type {
+  HtNodeWithContent,
+  HtWebviewExits,
+  HtWebviewNode,
+} from './hubtype-fields'
 
 export class FlowWebview extends ContentFieldsBase {
   public webviewTargetId: string = ''
@@ -28,6 +33,45 @@ export class FlowWebview extends ContentFieldsBase {
     newWebview.followUp = component.follow_up
 
     return newWebview
+  }
+
+  getParams(
+    botContext: BotContext,
+    cmsApi: FlowBuilderApi
+  ): Record<string, string> {
+    const params: Record<string, string> = {
+      webviewId: this.webviewTargetId,
+      t: Date.now().toString(),
+      ...this.getResolvedWebviewParams(botContext),
+    }
+    const exitSuccessContentID = this.getExitSuccessContentID(cmsApi)
+
+    if (exitSuccessContentID) {
+      params.exitSuccessContentID = exitSuccessContentID
+    }
+    return params
+  }
+
+  private getResolvedWebviewParams(
+    botContext: BotContext
+  ): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(this.webviewParams).map(([key, value]) => [
+        key,
+        this.replaceVariables(value, botContext),
+      ])
+    )
+  }
+
+  private getExitSuccessContentID(cmsApi: FlowBuilderApi): string | undefined {
+    const webviewSuccessExit = this.exits?.find(exit => exit.name === 'Success')
+    const exitSuccessId = webviewSuccessExit?.target?.id
+    if (!exitSuccessId) {
+      return undefined
+    }
+    const exitNode = cmsApi.getNodeById<HtNodeWithContent>(exitSuccessId)
+
+    return exitNode.code
   }
 
   async trackFlow(botContext: BotContext): Promise<void> {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
@@ -28,7 +28,7 @@ export class FlowWebview extends ContentFieldsBase {
     newWebview.webviewTargetId = component.content.webview_target_id
     newWebview.webviewName = component.content.webview_name
     newWebview.webviewComponentName = component.content.webview_component_name
-    newWebview.webviewParams = component.content.webview_params
+    newWebview.webviewParams = component.content.webview_params ?? {}
     newWebview.exits = component.content.exits
     newWebview.followUp = component.follow_up
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
@@ -15,6 +15,7 @@ export class FlowWebview extends ContentFieldsBase {
   public webviewTargetId: string = ''
   public webviewName: string = ''
   public webviewComponentName: string = ''
+  public webviewParams: Record<string, string> = {}
   public exits: HtWebviewExits[] = []
 
   static fromHubtypeCMS(component: HtWebviewNode): FlowWebview {
@@ -22,6 +23,7 @@ export class FlowWebview extends ContentFieldsBase {
     newWebview.webviewTargetId = component.content.webview_target_id
     newWebview.webviewName = component.content.webview_name
     newWebview.webviewComponentName = component.content.webview_component_name
+    newWebview.webviewParams = component.content.webview_params
     newWebview.exits = component.content.exits
     newWebview.followUp = component.follow_up
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-whatsapp-cta-url-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-whatsapp-cta-url-button.tsx
@@ -26,7 +26,8 @@ export class FlowWhatsappCtaUrlButtonNode extends ContentFieldsBase {
   static fromHubtypeCMS(
     component: HtWhatsappCTAUrlButtonNode,
     locale: string,
-    cmsApi: FlowBuilderApi
+    cmsApi: FlowBuilderApi,
+    botContext: BotContext
   ): FlowWhatsappCtaUrlButtonNode {
     const whatsappCtaUrlButton = new FlowWhatsappCtaUrlButtonNode(component.id)
     whatsappCtaUrlButton.code = component.code
@@ -46,7 +47,8 @@ export class FlowWhatsappCtaUrlButtonNode extends ContentFieldsBase {
     const button = FlowButton.fromHubtypeCMS(
       component.content.button,
       locale,
-      cmsApi
+      cmsApi,
+      botContext
     )
     whatsappCtaUrlButton.displayText = button.text
     const urlId = FlowButton.getUrlId(component.content.button, locale)

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/webview.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/webview.ts
@@ -13,6 +13,7 @@ export interface HtWebviewNode extends HtBaseNode {
     webview_target_id: string
     webview_name: string
     webview_component_name: string
+    webview_params: Record<string, string>
     exits: HtWebviewExits[]
   }
 }

--- a/packages/botonic-plugin-flow-builder/src/flow-factory.ts
+++ b/packages/botonic-plugin-flow-builder/src/flow-factory.ts
@@ -46,14 +46,20 @@ export class FlowFactory {
   ): Promise<FlowContent | undefined> {
     switch (hubtypeContent.type) {
       case HtNodeWithContentType.TEXT:
-        return FlowText.fromHubtypeCMS(hubtypeContent, this.locale, this.cmsApi)
+        return FlowText.fromHubtypeCMS(
+          hubtypeContent,
+          this.locale,
+          this.cmsApi,
+          this.botContext
+        )
       case HtNodeWithContentType.IMAGE:
         return FlowImage.fromHubtypeCMS(hubtypeContent, this.locale)
       case HtNodeWithContentType.CAROUSEL:
         return FlowCarousel.fromHubtypeCMS(
           hubtypeContent,
           this.locale,
-          this.cmsApi
+          this.cmsApi,
+          this.botContext
         )
       case HtNodeWithContentType.VIDEO:
         return FlowVideo.fromHubtypeCMS(hubtypeContent, this.locale)
@@ -67,7 +73,8 @@ export class FlowFactory {
         return FlowWhatsappCtaUrlButtonNode.fromHubtypeCMS(
           hubtypeContent,
           this.locale,
-          this.cmsApi
+          this.cmsApi,
+          this.botContext
         )
       case HtNodeWithContentType.HANDOFF:
         return FlowHandoff.fromHubtypeCMS(

--- a/packages/botonic-plugin-flow-builder/tests/helpers/flows/webview.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/flows/webview.ts
@@ -148,6 +148,11 @@ export const webviewFlow = {
         webview_target_id: '0198f614-fafb-71b8-9f4a-e26e9795c8e3',
         webview_name: 'Sdr webview',
         webview_component_name: 'FlowBuilderWebview',
+        webview_params: {
+          customerName: '{customerName}',
+          mixedValue: 'prefix-{customerName}',
+          missingValue: '{missing}',
+        },
         exits: [
           {
             id: '0198f786-6bcc-726d-880f-6aab57bcfe62',

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-text.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-text.test.ts
@@ -57,6 +57,7 @@ describe('Check the contents and logic of a text node', () => {
       flowBuilderOptions: { flow: webviewFlow },
       requestArgs: {
         input: { data: 'hola', type: INPUT.TEXT },
+        extraData: { customerName: 'Alice' },
         isFirstInteraction: true,
       },
     })
@@ -70,7 +71,10 @@ describe('Check the contents and logic of a text node', () => {
       name: 'FlowBuilderWebview',
     })
     expect(firstButton.params).toEqual({
+      customerName: 'Alice',
       exitSuccessContentID: 'webview success',
+      missingValue: '{missing}',
+      mixedValue: 'prefix-Alice',
       t: expect.any(String),
       webviewId: '0198f614-fafb-71b8-9f4a-e26e9795c8e3',
     })

--- a/packages/botonic-plugin-hubtype-analytics/package.json
+++ b/packages/botonic-plugin-hubtype-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-hubtype-analytics",
-  "version": "0.51.0",
+  "version": "0.52.0-alpha.0",
   "description": "Plugin for tracking in the Hubtype backend to see the results in the Hubtype Dashbord",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/core": "^0.51.0",
+    "@botonic/core": "^0.52.0-alpha.0",
     "axios": "^1.15.2"
   },
   "devDependencies": {

--- a/packages/botonic-plugin-knowledge-bases/package.json
+++ b/packages/botonic-plugin-knowledge-bases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-knowledge-bases",
-  "version": "0.51.0",
+  "version": "0.52.0-alpha.0",
   "description": "Use a Hubtype to make the bot respond through a knowledge base.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/core": "^0.51.0",
+    "@botonic/core": "^0.52.0-alpha.0",
     "axios": "^1.15.2"
   },
   "devDependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.51.0",
+  "version": "0.52.0-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",
@@ -20,7 +20,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.51.0",
+    "@botonic/core": "^0.52.0-alpha.0",
     "axios": "^1.15.2",
     "emoji-picker-react": "^4.12.0",
     "lodash.merge": "^4.6.2",

--- a/packages/botonic-react/src/components/index-types.ts
+++ b/packages/botonic-react/src/components/index-types.ts
@@ -43,7 +43,7 @@ export interface Webview {
 }
 
 export interface ButtonProps {
-  params?: any
+  params?: Record<string, string>
   path?: string
   payload?: string
   target?: string

--- a/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
+++ b/packages/botonic-react/src/components/whatsapp-cta-url-button.tsx
@@ -62,7 +62,7 @@ export type WhatsappCTAUrlButtonUrlProps = WhatsappCTAUrlButtonCommonProps & {
 export type WhatsappCTAUrlButtonWebviewProps =
   WhatsappCTAUrlButtonCommonProps & {
     webview: any
-    params?: any
+    params?: Record<string, string>
   }
 
 export type WhatsappCTAUrlButtonProps =

--- a/packages/botonic-react/src/util/webviews.ts
+++ b/packages/botonic-react/src/util/webviews.ts
@@ -1,9 +1,9 @@
-import { params2queryString } from '@botonic/core'
+import type { Webview } from '../components/index-types'
 
 export function generateWebviewUrlWithParams(
-  webview: any,
-  params: any = ''
+  webview: Webview,
+  params?: Record<string, string>
 ): string {
-  const webviewParams = params ? params2queryString(params) : ''
+  const webviewParams = params ? new URLSearchParams(params).toString() : ''
   return `/webviews/${webview.name}?${webviewParams}`
 }

--- a/packages/botonic-react/src/webchat/context/types.ts
+++ b/packages/botonic-react/src/webchat/context/types.ts
@@ -26,7 +26,7 @@ export interface WebchatState {
   typing: boolean
   // In local development webview can be a React.ComponentType or a Webview object
   webview?: Webview | string | React.ComponentType
-  webviewParams: undefined
+  webviewParams: Record<string, string>
   session: Partial<CoreSession>
   lastRoutePath?: string
   handoff: boolean
@@ -67,7 +67,10 @@ export interface WebchatContextProps {
   addMessage: (message: WebchatMessage) => void
   getThemeProperty: (property: string, defaultValue?: any) => any
   closeWebview: (options?: CloseWebviewOptions) => Promise<void>
-  openWebview: (webviewComponent: Webview, params?: any) => void
+  openWebview: (
+    webviewComponent: Webview,
+    params?: Record<string, string>
+  ) => void
   resetUnreadMessages: () => void
   resolveCase: () => void
   sendAttachment: (attachment: File) => Promise<void>

--- a/packages/botonic-react/src/webchat/context/use-webchat.ts
+++ b/packages/botonic-react/src/webchat/context/use-webchat.ts
@@ -23,7 +23,7 @@ function getWebchatInitialState(initialTheme: WebchatTheme): WebchatState {
     latestInput: {},
     typing: false,
     webview: undefined,
-    webviewParams: undefined,
+    webviewParams: {},
     session: { user: undefined },
     lastRoutePath: undefined,
     handoff: false,
@@ -74,7 +74,7 @@ export interface UseWebchat {
   updateSession: (session: Partial<Session>) => void
   updateTheme: (theme: WebchatTheme, themeUpdates?: WebchatTheme) => void
   updateTyping: (typing: boolean) => void
-  updateWebview: (webview: Webview, params: Record<string, string>) => void
+  updateWebview: (webview: Webview, params?: Record<string, string>) => void
   removeReplies: () => void
   removeWebview: () => void
   webchatState: WebchatState
@@ -135,10 +135,10 @@ export function useWebchat(theme?: WebchatTheme): UseWebchat {
   const updateTyping = (typing: boolean) =>
     webchatDispatch({ type: WebchatAction.UPDATE_TYPING, payload: typing })
 
-  const updateWebview = (webview: Webview, params: Record<string, string>) =>
+  const updateWebview = (webview: Webview, params?: Record<string, string>) =>
     webchatDispatch({
       type: WebchatAction.UPDATE_WEBVIEW,
-      payload: { webview, webviewParams: params },
+      payload: { webview, webviewParams: params ?? {} },
     })
 
   const removeWebview = () =>

--- a/packages/botonic-react/src/webchat/context/webchat-reducer.ts
+++ b/packages/botonic-react/src/webchat/context/webchat-reducer.ts
@@ -11,7 +11,7 @@ export function webchatReducer(
     case WebchatAction.UPDATE_WEBVIEW:
       return { ...state, ...action.payload }
     case WebchatAction.REMOVE_WEBVIEW:
-      return { ...state, webview: undefined, webviewParams: undefined }
+      return { ...state, webview: undefined, webviewParams: {} }
     case WebchatAction.UPDATE_SESSION:
       return { ...state, session: { ...action.payload } }
     case WebchatAction.UPDATE_TYPING:

--- a/packages/botonic-react/src/webchat/webchat.tsx
+++ b/packages/botonic-react/src/webchat/webchat.tsx
@@ -20,6 +20,7 @@ import {
   Text,
   Video,
   type WebchatSettingsProps,
+  type Webview,
 } from '../components'
 import {
   COLORS,
@@ -313,7 +314,10 @@ const Webchat = forwardRef<WebchatRef | null, WebchatProps>((props, ref) => {
     updateTheme(merge(props.theme, theme, webchatState.themeUpdates))
   }, [props.theme, webchatState.themeUpdates])
 
-  const openWebview = (webviewComponent, params) => {
+  const openWebview = (
+    webviewComponent: Webview,
+    params?: Record<string, string>
+  ) => {
     updateWebview(webviewComponent, params)
   }
 

--- a/packages/botonic-react/src/webchat/webview/index.tsx
+++ b/packages/botonic-react/src/webchat/webview/index.tsx
@@ -2,6 +2,7 @@ import { type Session as CoreSession, isDev } from '@botonic/core'
 import type React from 'react'
 import { useContext, useEffect } from 'react'
 
+import type { Webview } from '../../components/index-types'
 import { ROLES, WEBCHAT } from '../../constants'
 import {
   type CloseWebviewOptions,
@@ -26,7 +27,7 @@ export const WebviewContainer = ({
     useContext(WebchatContext)
 
   const webviewRequestContext: WebviewRequestContextType = {
-    params: webchatState.webviewParams || ({} as Record<string, string>),
+    params: webchatState.webviewParams,
     session: webchatState.session || ({} as Partial<CoreSession>),
     getUserCountry: () => webchatState.session?.user?.country || '',
     getUserLocale: () => webchatState.session?.user?.locale || '',
@@ -93,16 +94,58 @@ export const WebviewContainer = ({
   )
 }
 
-function getWebviewInDevMode(
+function isReactComponent(value: unknown): value is React.ComponentType {
+  return typeof value === 'function'
+}
+
+function isWebviewDescriptor(value: unknown): value is Webview {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'name' in value &&
+    typeof (value as Webview).name === 'string' &&
+    !isReactComponent(value)
+  )
+}
+
+export function getWebviewInDevMode(
   localWebviews: React.ComponentType[] | undefined,
   webchatState: WebchatState
-) {
-  return (
-    localWebviews?.find(webview => {
-      if (typeof webchatState.webview === 'string') {
-        return false
-      }
-      return webview.name === webchatState.webview?.name
-    }) ?? (webchatState.webview as React.ComponentType)
+): React.ComponentType {
+  const { webview } = webchatState
+
+  if (webview == null) {
+    throw new Error('No webview specified')
+  }
+
+  if (typeof webview === 'string') {
+    return webview as unknown as React.ComponentType
+  }
+
+  if (isReactComponent(webview)) {
+    return webview
+  }
+
+  if (isWebviewDescriptor(webview)) {
+    const localWebview = localWebviews?.find(
+      local => local.name === webview.name
+    )
+
+    if (!localWebview) {
+      const registeredNames =
+        localWebviews
+          ?.map(w => w.name)
+          .filter(Boolean)
+          .join(', ') || 'none'
+      throw new Error(
+        `Local webview "${webview.name}" not found. Registered webviews: ${registeredNames}`
+      )
+    }
+
+    return localWebview
+  }
+
+  throw new Error(
+    'Invalid webview type: expected a React component, a webview descriptor { name }, or a string URL'
   )
 }

--- a/packages/botonic-react/tests/util/webviews.test.js
+++ b/packages/botonic-react/tests/util/webviews.test.js
@@ -1,0 +1,18 @@
+import { generateWebviewUrlWithParams } from '../../src/util/webviews'
+
+describe('generateWebviewUrlWithParams', () => {
+  it('returns webview url without params', () => {
+    expect(generateWebviewUrlWithParams({ name: 'MyWebview' })).toBe(
+      '/webviews/MyWebview?'
+    )
+  })
+
+  it('serializes params with URLSearchParams', () => {
+    expect(
+      generateWebviewUrlWithParams(
+        { name: 'MyWebview' },
+        { numbers: '123', redirectUri: 'www.some-site.com' }
+      )
+    ).toBe('/webviews/MyWebview?numbers=123&redirectUri=www.some-site.com')
+  })
+})

--- a/packages/botonic-react/tests/webchat/get-webview-in-dev-mode.test.js
+++ b/packages/botonic-react/tests/webchat/get-webview-in-dev-mode.test.js
@@ -1,0 +1,54 @@
+import { getWebviewInDevMode } from '../../src/webchat/webview/index'
+
+function TestWebview() {
+  return null
+}
+
+function createWebchatState(webview) {
+  return { webview }
+}
+
+describe('getWebviewInDevMode', () => {
+  it('resolves a webview descriptor by name from localWebviews', () => {
+    const resolved = getWebviewInDevMode(
+      [TestWebview],
+      createWebchatState({ name: 'TestWebview' })
+    )
+
+    expect(resolved).toBe(TestWebview)
+  })
+
+  it('returns a React component directly when passed as webview', () => {
+    const resolved = getWebviewInDevMode([], createWebchatState(TestWebview))
+
+    expect(resolved).toBe(TestWebview)
+  })
+
+  it('preserves string webviews for intrinsic element rendering', () => {
+    const resolved = getWebviewInDevMode([], createWebchatState('webview'))
+
+    expect(resolved).toBe('webview')
+  })
+
+  it('throws a clear error when the local webview name is not registered', () => {
+    expect(() =>
+      getWebviewInDevMode(
+        [TestWebview],
+        createWebchatState({ name: 'MissingWebview' })
+      )
+    ).toThrow(
+      'Local webview "MissingWebview" not found. Registered webviews: TestWebview'
+    )
+  })
+
+  it('throws when no local webviews are registered', () => {
+    expect(() =>
+      getWebviewInDevMode(
+        undefined,
+        createWebchatState({ name: 'FlowBuilderWebview' })
+      )
+    ).toThrow(
+      'Local webview "FlowBuilderWebview" not found. Registered webviews: none'
+    )
+  })
+})

--- a/packages/botonic-react/tests/webchat/usewebchat.test.jsx
+++ b/packages/botonic-react/tests/webchat/usewebchat.test.jsx
@@ -86,12 +86,32 @@ describe('TEST: useWebchat', () => {
     expect(result.current.webchatState.typing).toEqual(true)
   })
 
-  it('updateWebview: assign webview to webchatState.webview', () => {
+  it('updateWebview: assign webview to webchatState.webview and webviewParams', () => {
+    const { result } = renderUseWebchatHook()
+    expect(result.current.webchatState.webviewParams).toEqual({})
+    act(() => {
+      result.current.updateWebview('webview', { foo: 'bar' })
+    })
+    expect(result.current.webchatState.webview).toEqual('webview')
+    expect(result.current.webchatState.webviewParams).toEqual({ foo: 'bar' })
+  })
+
+  it('updateWebview: defaults webviewParams to {} when params are omitted', () => {
     const { result } = renderUseWebchatHook()
     act(() => {
       result.current.updateWebview('webview')
     })
-    expect(result.current.webchatState.webview).toEqual('webview')
+    expect(result.current.webchatState.webviewParams).toEqual({})
+  })
+
+  it('removeWebview: clears webview and resets webviewParams to {}', () => {
+    const { result } = renderUseWebchatHook()
+    act(() => {
+      result.current.updateWebview('webview', { foo: 'bar' })
+      result.current.removeWebview()
+    })
+    expect(result.current.webchatState.webview).toBeUndefined()
+    expect(result.current.webchatState.webviewParams).toEqual({})
   })
 
   it('updateSession: assign initialSession to webchatState.session', () => {

--- a/packages/botonic-react/tests/webchat/webchat.component.test.jsx
+++ b/packages/botonic-react/tests/webchat/webchat.component.test.jsx
@@ -233,4 +233,27 @@ describe('TEST: Webchat Component', () => {
       screen
     )
   })
+
+  function TestWebview() {
+    return <div role='test-webview'>Test Webview Content</div>
+  }
+
+  it('TEST: renders a local webview when webview state is a descriptor with matching name', async () => {
+    const { result } = renderUseWebchatHook()
+    act(() => {
+      result.current.webchatState.session.user = { provider: PROVIDER.DEV }
+      result.current.toggleWebchat(true)
+      result.current.updateWebview({ name: 'TestWebview' }, { foo: 'bar' })
+    })
+    await act(async () => {
+      render(
+        <Webchat webchatHooks={result.current} localWebviews={[TestWebview]} />
+      )
+    })
+    expect(screen.queryByRole('test-webview')).toBeTruthy()
+    expectToHaveRoles(
+      [ROLES.WEBVIEW, ROLES.WEBVIEW_HEADER, ROLES.WEBCHAT],
+      screen
+    )
+  })
 })


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

Flow Builder webviews can now receive the params configured in the Open Webview node, with Botonic variables resolved against the current bot context before the webview opens. Botonic React keeps those params in webchat state and exposes them to local webviews through `WebviewRequestContext.params`.

## Context

Before this change, Flow Builder only sent Botonic-generated webview params such as `webviewId`, timestamp, and the success exit content id. CMS-configured webview params were ignored, so teams could not pass Flow Builder data or resolved bot variables into the webview from the Open Webview node.

Related: BLT-2460

## Approach taken / Explain the design

- Thread `botContext` through the CMS content factories that can contain buttons targeting webviews.
- Store `webview_params` on `FlowWebview` and build the final params from generated Botonic params, resolved CMS params, and the optional `exitSuccessContentID`.
- Let `botonic-react` accept optional params when opening a webview, keep `webviewParams` as an empty object when absent or cleared, and serialize iframe URLs through `URLSearchParams`.
- Resolve local dev-mode webview descriptors by name so Flow Builder descriptors like `{ name: 'MyWebview' }` can render the matching local React component.

## To document / Usage example

Flow Builder can configure params on an Open Webview node, for example `orderId`, `locale`, or any value that includes Botonic variables. When the webview opens, those values are available from `WebviewRequestContext.params` in local webviews and are serialized into the generated iframe URL for hosted webviews.

## Testing

The pull request...

- has unit tests for webview URL param serialization.
- has unit/component coverage for storing, defaulting, and clearing `webviewParams` in webchat state.
- has webchat coverage for resolving a local dev-mode webview descriptor by name.
- currently has a failing `botonic-plugin-flow-builder-tests` CI job: `tests/tracking/track-webview-action-triggered.test.ts` fails in 2 cases because older tracking fixtures do not define `webview_params`.
