### PR TITLE
feat(hubtype-analytics): add webview params to event WebviewActionTriggered #BLT-2466

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23591,7 +23591,7 @@
     },
     "packages/botonic-cli": {
       "name": "@botonic/cli",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.8.6",
@@ -23636,7 +23636,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -23657,7 +23657,7 @@
     },
     "packages/botonic-dx": {
       "name": "@botonic/dx",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-modules-commonjs": "^7.27.1",
@@ -23665,8 +23665,8 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
-        "@botonic/dx-bundler-rspack": "^0.52.0-alpha.0",
-        "@botonic/eslint-config": "^0.52.0-alpha.0",
+        "@botonic/dx-bundler-rspack": "^0.52.0-alpha.1",
+        "@botonic/eslint-config": "^0.52.0-alpha.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.19.1",
         "babel-loader": "^8.4.1",
@@ -23694,7 +23694,7 @@
     },
     "packages/botonic-dx-bundler-rspack": {
       "name": "@botonic/dx-bundler-rspack",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@rspack/cli": "^1.6.1",
@@ -23882,7 +23882,7 @@
     },
     "packages/botonic-eslint-config": {
       "name": "@botonic/eslint-config",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -23901,9 +23901,9 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "dependencies": {
-        "@botonic/core": "^0.52.0-alpha.0",
+        "@botonic/core": "^0.52.0-alpha.1",
         "@openai/agents": "^0.10.1",
         "axios": "^1.15.2",
         "openai": "^6.36.0",
@@ -23933,9 +23933,9 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "dependencies": {
-        "@botonic/react": "^0.52.0-alpha.0",
+        "@botonic/react": "^0.52.0-alpha.1",
         "axios": "^1.15.2",
         "uuid": "^10.0.0"
       },
@@ -23962,11 +23962,11 @@
     },
     "packages/botonic-plugin-hubtype-analytics": {
       "name": "@botonic/plugin-hubtype-analytics",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@botonic/core": "^0.52.0-alpha.0",
+        "@botonic/core": "^0.52.0-alpha.1",
         "axios": "^1.15.2"
       },
       "devDependencies": {
@@ -23979,11 +23979,11 @@
     },
     "packages/botonic-plugin-knowledge-bases": {
       "name": "@botonic/plugin-knowledge-bases",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@botonic/core": "^0.52.0-alpha.0",
+        "@botonic/core": "^0.52.0-alpha.1",
         "axios": "^1.15.2"
       },
       "devDependencies": {
@@ -23996,10 +23996,10 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.52.0-alpha.0",
+      "version": "0.52.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@botonic/core": "^0.52.0-alpha.0",
+        "@botonic/core": "^0.52.0-alpha.1",
         "axios": "^1.15.2",
         "emoji-picker-react": "^4.12.0",
         "lodash.merge": "^4.6.2",

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "license": "MIT",
   "bin": {
     "botonic": "./bin/run.js"

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-core/src/models/hubtype-analytics.ts
+++ b/packages/botonic-core/src/models/hubtype-analytics.ts
@@ -187,6 +187,7 @@ export interface EventWebviewActionTriggered extends HtBaseEventAllFlowProps {
   action: EventAction.WebviewActionTriggered
   webviewTargetId: string
   webviewName: string
+  webviewParams?: Record<string, string>
 }
 
 export interface EventAiAgent extends HtBaseEventAllFlowProps {

--- a/packages/botonic-dx-bundler-rspack/package.json
+++ b/packages/botonic-dx-bundler-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx-bundler-rspack",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "description": "Build Botonic bots with RSPack",
   "scripts": {
     "build": "echo Skipping build...",

--- a/packages/botonic-dx/package.json
+++ b/packages/botonic-dx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "description": "Continuous integration for botonic packages",
   "scripts": {
     "build": "echo Skipping build..."
@@ -18,8 +18,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
-    "@botonic/dx-bundler-rspack": "^0.52.0-alpha.0",
-    "@botonic/eslint-config": "^0.52.0-alpha.0",
+    "@botonic/dx-bundler-rspack": "^0.52.0-alpha.1",
+    "@botonic/eslint-config": "^0.52.0-alpha.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.19.1",
     "babel-loader": "^8.4.1",

--- a/packages/botonic-eslint-config/package.json
+++ b/packages/botonic-eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/eslint-config",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "description": "Eslint config for botonic packages",
   "main": "index.js",
   "scripts": {

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",
@@ -14,7 +14,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.52.0-alpha.0",
+    "@botonic/core": "^0.52.0-alpha.1",
     "@openai/agents": "^0.10.1",
     "axios": "^1.15.2",
     "openai": "^6.36.0",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -15,7 +15,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/react": "^0.52.0-alpha.0",
+    "@botonic/react": "^0.52.0-alpha.1",
     "axios": "^1.15.2",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-button.tsx
@@ -37,7 +37,7 @@ export class FlowButton extends ContentFieldsBase {
       if (webview) {
         newButton.flowWebview = webview
         newButton.webview = { name: webview.webviewComponentName }
-        newButton.params = webview.getParams(botContext, cmsApi)
+        newButton.params = webview.getParams(botContext)
       } else {
         newButton.payload = cmsApi.getPayload(cmsButton.target)
       }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
@@ -88,6 +88,7 @@ export class FlowWebview extends ContentFieldsBase {
       flowNodeIsMeaningful: false,
       webviewTargetId: this.webviewTargetId,
       webviewName: this.webviewName,
+      webviewParams: this.webviewParams,
     }
     const { action, ...eventArgs } = eventWebviewActionTriggered
     await trackEvent(botContext, action, eventArgs)

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-webview.tsx
@@ -9,6 +9,7 @@ import {
   getCommonFlowContentEventArgsForContentId,
   trackEvent,
 } from '../tracking'
+import { getFlowBuilderPlugin } from '../utils/get-flow-builder-plugin'
 import { ContentFieldsBase } from './content-fields-base'
 import type {
   HtNodeWithContent,
@@ -35,10 +36,10 @@ export class FlowWebview extends ContentFieldsBase {
     return newWebview
   }
 
-  getParams(
-    botContext: BotContext,
-    cmsApi: FlowBuilderApi
-  ): Record<string, string> {
+  getParams(botContext: BotContext): Record<string, string> {
+    const flowBuilderPlugin = getFlowBuilderPlugin(botContext.plugins)
+    const cmsApi = flowBuilderPlugin.cmsApi
+
     const params: Record<string, string> = {
       webviewId: this.webviewTargetId,
       t: Date.now().toString(),
@@ -88,7 +89,7 @@ export class FlowWebview extends ContentFieldsBase {
       flowNodeIsMeaningful: false,
       webviewTargetId: this.webviewTargetId,
       webviewName: this.webviewName,
-      webviewParams: this.webviewParams,
+      webviewParams: this.getParams(botContext),
     }
     const { action, ...eventArgs } = eventWebviewActionTriggered
     await trackEvent(botContext, action, eventArgs)

--- a/packages/botonic-plugin-flow-builder/tests/helpers/flows/open-webview.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/flows/open-webview.ts
@@ -163,6 +163,10 @@ export const openWebviewFlow = {
         webview_target_id: '0199102d-90b9-771d-a927-7329bd348a5e',
         webview_name: 'TestWebview',
         webview_component_name: 'Testwebview',
+        webview_params: {
+          bookingId: '12345',
+          source: 'confirmation',
+        },
         exits: [
           {
             id: '019ab584-d30d-777f-bfb2-2f6d845ee89f',

--- a/packages/botonic-plugin-flow-builder/tests/tracking/track-webview-action-triggered.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/tracking/track-webview-action-triggered.test.ts
@@ -52,6 +52,8 @@ describe('Track webview action triggered', () => {
         webviewParams: {
           bookingId: '12345',
           source: 'confirmation',
+          t: expect.any(String),
+          webviewId: '0199102d-90b9-771d-a927-7329bd348a5e',
         },
       }
     )
@@ -99,6 +101,8 @@ describe('Track webview action triggered', () => {
         webviewParams: {
           bookingId: '12345',
           source: 'confirmation',
+          t: expect.any(String),
+          webviewId: '0199102d-90b9-771d-a927-7329bd348a5e',
         },
       }
     )

--- a/packages/botonic-plugin-flow-builder/tests/tracking/track-webview-action-triggered.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/tracking/track-webview-action-triggered.test.ts
@@ -1,5 +1,5 @@
 import { EventAction, INPUT } from '@botonic/core'
-import { describe, test } from '@jest/globals'
+import { beforeEach, describe, expect, test } from '@jest/globals'
 
 import { FlowCarousel, FlowText } from '../../src/content-fields/index'
 import { ProcessEnvNodeEnvs } from '../../src/types'
@@ -49,6 +49,10 @@ describe('Track webview action triggered', () => {
         flowThreadId: expect.anything(),
         webviewName: 'TestWebview',
         webviewTargetId: '0199102d-90b9-771d-a927-7329bd348a5e',
+        webviewParams: {
+          bookingId: '12345',
+          source: 'confirmation',
+        },
       }
     )
   })
@@ -92,6 +96,10 @@ describe('Track webview action triggered', () => {
         flowThreadId: expect.anything(),
         webviewName: 'TestWebview',
         webviewTargetId: '0199102d-90b9-771d-a927-7329bd348a5e',
+        webviewParams: {
+          bookingId: '12345',
+          source: 'confirmation',
+        },
       }
     )
   })

--- a/packages/botonic-plugin-hubtype-analytics/package.json
+++ b/packages/botonic-plugin-hubtype-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-hubtype-analytics",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "description": "Plugin for tracking in the Hubtype backend to see the results in the Hubtype Dashbord",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/core": "^0.52.0-alpha.0",
+    "@botonic/core": "^0.52.0-alpha.1",
     "axios": "^1.15.2"
   },
   "devDependencies": {

--- a/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-webview-action-triggered.ts
+++ b/packages/botonic-plugin-hubtype-analytics/src/event-models/ht-event-webview-action-triggered.ts
@@ -15,6 +15,7 @@ export class HtEventWebviewActionTriggered extends HtEvent {
   flow_node_is_meaningful: boolean
   webview_name: string
   webview_target_id: string
+  webview_params?: Record<string, string>
 
   constructor(event: EventWebviewActionTriggered, requestData: RequestData) {
     super(event, requestData)
@@ -28,5 +29,6 @@ export class HtEventWebviewActionTriggered extends HtEvent {
     this.flow_node_is_meaningful = event.flowNodeIsMeaningful
     this.webview_name = event.webviewName
     this.webview_target_id = event.webviewTargetId
+    this.webview_params = event.webviewParams
   }
 }

--- a/packages/botonic-plugin-hubtype-analytics/tests/event-webview.test.ts
+++ b/packages/botonic-plugin-hubtype-analytics/tests/event-webview.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import {
   createHtEvent,
   EventAction,
@@ -19,6 +20,10 @@ describe('Create webview events', () => {
       flowNodeIsMeaningful: false,
       webviewTargetId: 'webviewTargetIdTest',
       webviewName: 'ADD_A_BAG',
+      webviewParams: {
+        param1: 'value1',
+        param2: 'value2',
+      },
     })
 
     expect(htEvent).toEqual({
@@ -38,6 +43,10 @@ describe('Create webview events', () => {
       webview_name: 'ADD_A_BAG',
       bot_interaction_id: 'testInteractionId',
       type: EventType.BotEvent,
+      webview_params: {
+        param1: 'value1',
+        param2: 'value2',
+      },
     })
   })
 

--- a/packages/botonic-plugin-knowledge-bases/package.json
+++ b/packages/botonic-plugin-knowledge-bases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-knowledge-bases",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "description": "Use a Hubtype to make the bot respond through a knowledge base.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/core": "^0.52.0-alpha.0",
+    "@botonic/core": "^0.52.0-alpha.1",
     "axios": "^1.15.2"
   },
   "devDependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.52.0-alpha.0",
+  "version": "0.52.0-alpha.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",
@@ -20,7 +20,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.52.0-alpha.0",
+    "@botonic/core": "^0.52.0-alpha.1",
     "axios": "^1.15.2",
     "emoji-picker-react": "^4.12.0",
     "lodash.merge": "^4.6.2",

--- a/packages/botonic-react/src/components/system-debug-trace/events/webview-action-triggered.tsx
+++ b/packages/botonic-react/src/components/system-debug-trace/events/webview-action-triggered.tsx
@@ -1,14 +1,36 @@
 import { EventAction } from '@botonic/core'
 
 import { WindowRestoreSvg } from '../icons/window-restore'
+import {
+  StyledDebugDetail,
+  StyledDebugLabel,
+  StyledDebugValue,
+} from '../styles'
 import type { DebugEventConfig } from '../types'
 
 export interface WebviewActionTriggeredDebugEvent {
   action: EventAction.WebviewActionTriggered
   webview_target_id: string
   webview_name: string
+  webview_params?: Record<string, string>
 }
 
+export const WebviewActionTriggered = (
+  props: WebviewActionTriggeredDebugEvent
+) => {
+  return (
+    <>
+      {Object.keys(props.webview_params ?? {}).length > 0
+        ? Object.entries(props.webview_params ?? {}).map(([key, value]) => (
+            <StyledDebugDetail key={key}>
+              <StyledDebugLabel>{key}</StyledDebugLabel>
+              <StyledDebugValue>{value}</StyledDebugValue>
+            </StyledDebugDetail>
+          ))
+        : 'Webview without params'}
+    </>
+  )
+}
 export const getWebviewActionTriggeredEventConfig = (
   data: WebviewActionTriggeredDebugEvent
 ): DebugEventConfig => {
@@ -21,8 +43,8 @@ export const getWebviewActionTriggeredEventConfig = (
   return {
     action: EventAction.WebviewActionTriggered,
     title,
-    component: null,
+    component: WebviewActionTriggered,
     icon: <WindowRestoreSvg />,
-    collapsible: false,
+    collapsible: true,
   }
 }

--- a/packages/botonic-react/tests/components/system-debug-trace.test.jsx
+++ b/packages/botonic-react/tests/components/system-debug-trace.test.jsx
@@ -521,8 +521,8 @@ describe('SystemDebugTrace Component', () => {
       const config = getWebviewActionTriggeredEventConfig(data)
 
       expect(config.action).toBe(EventAction.WebviewActionTriggered)
-      expect(config.component).toBeNull()
-      expect(config.collapsible).toBe(false)
+      expect(config.component).toBeTruthy()
+      expect(config.collapsible).toBe(true)
       expect(config.icon).toBeTruthy()
       expect(config.title).toBeTruthy()
     })


### PR DESCRIPTION
## Description

Add optional webview parameters to the `WebviewActionTriggered` analytics event so Flow Builder webview actions can report the parameters used to open the webview.

## Context

Webview trigger parameters are useful for understanding the context in which a webview was opened and for correlating analytics with the data passed to the webview. The field is optional to preserve compatibility with existing webview events that do not provide parameters.

## Approach taken / Explain the design

- Add `webviewParams` as an optional `Record<string, string>` to the shared `EventWebviewActionTriggered` model.
- Pass `FlowWebview.webviewParams` to the analytics tracking event.
- Map the property to the snake_case `webview_params` field in `HtEventWebviewActionTriggered`.
- Keep the property optional so existing event producers and consumers remain compatible.

## To document / Usage example

When a webview is triggered with parameters:

```ts
{
  webviewTargetId: 'booking-webview',
  webviewName: 'BOOKING',
  webviewParams: {
    bookingId: '12345',
    source: 'confirmation',
  },
}
```

The analytics event includes:

```ts
{
  webview_target_id: 'booking-webview',
  webview_name: 'BOOKING',
  webview_params: {
    bookingId: '12345',
    source: 'confirmation',
  },
}
```

## Testing

The pull request...

- has unit tests covering the propagation of webview parameters from the event model to the analytics event.
- doesn't have integration tests because this change is limited to event data mapping and is covered by the unit test suite.
