### PR TITLE
feat(bot-config): add more variables in BASE_SESSION_VARIABLES

### DIFF
--- a/packages/botonic-core/src/utils/bot-config.ts
+++ b/packages/botonic-core/src/utils/bot-config.ts
@@ -3,15 +3,29 @@ import { type VariableConfigJSON, VariableType } from '../models/index'
 
 const SESSION_USER_EXTRA_DATA_PREFIX = 'session.user.extra_data'
 
-const BASE_SESSION_VARIABLES: VariableConfigJSON[] = [
+export const BASE_SESSION_VARIABLES: VariableConfigJSON[] = [
   { key_path: 'input.data', type: VariableType.String },
   { key_path: 'input.type', type: VariableType.String },
+  {
+    key_path: 'session.is_first_interaction',
+    type: VariableType.Boolean,
+  },
+  {
+    key_path: 'session.is_test_integration',
+    type: VariableType.Boolean,
+  },
+  { key_path: 'session._shadowing', type: VariableType.Boolean },
   { key_path: 'session.user.locale', type: VariableType.String },
   {
     key_path: 'session.user.country',
     type: VariableType.String,
   },
   { key_path: 'session.user.system_locale', type: VariableType.String },
+  { key_path: 'session.user.username', type: VariableType.String },
+  {
+    key_path: 'session.user.unformatted_phone_number',
+    type: VariableType.String,
+  },
 ]
 
 export function getSessionVariables(


### PR DESCRIPTION
## Description

This commit exports the `BASE_SESSION_VARIABLES` constant in `bot-config.ts` and adds new session variable definitions, including `session.is_first_interaction`, `session.is_test_integration`, and `session.user.username`. These additions enhance the bot's ability to manage user session data effectively.