### PR TITLE
feat(plugin-flow-builder): add is_active field to smart intent node

### DIFF
--- a/examples/blank-typescript/package.json
+++ b/examples/blank-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/example-blank-typescript",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "scripts": {
     "build": "ENVIRONMENT=production NODE_ENV=production rspack build --env target=all --mode=production",
     "start": "ENVIRONMENT=local NODE_ENV=development rspack serve --env target=dev --mode=development",
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/react": "^0.53.0"
+    "@botonic/react": "^0.54.0"
   },
   "devDependencies": {
-    "@botonic/dx": "^0.53.0"
+    "@botonic/dx": "^0.54.0"
   },
   "engines": {
     "node": ">=22.19.0",

--- a/examples/blank/package.json
+++ b/examples/blank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/example-blank",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "scripts": {
     "build": "ENVIRONMENT=production NODE_ENV=production rspack build --env target=all --mode=production",
     "start": "ENVIRONMENT=local NODE_ENV=development rspack serve --env target=dev --mode=development",
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/react": "^0.53.0"
+    "@botonic/react": "^0.54.0"
   },
   "devDependencies": {
-    "@botonic/dx": "^0.53.0"
+    "@botonic/dx": "^0.54.0"
   },
   "engines": {
     "node": ">=22.19.0",

--- a/examples/flow-builder-typescript/package.json
+++ b/examples/flow-builder-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/example-flow-builder-typescript",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "scripts": {
     "build": "ENVIRONMENT=production NODE_ENV=production rspack build --env target=all --mode=production",
     "lint": "npm run lint-core -- --fix && npm run prettier",
@@ -13,12 +13,12 @@
     "preversion": "npm run lint-ci"
   },
   "dependencies": {
-    "@botonic/core": "^0.53.0",
-    "@botonic/plugin-ai-agents": "^0.53.0",
-    "@botonic/plugin-flow-builder": "^0.53.0",
-    "@botonic/plugin-hubtype-analytics": "^0.53.0",
-    "@botonic/plugin-knowledge-bases": "^0.53.0",
-    "@botonic/react": "^0.53.0",
+    "@botonic/core": "^0.54.0",
+    "@botonic/plugin-ai-agents": "^0.54.0",
+    "@botonic/plugin-flow-builder": "^0.54.0",
+    "@botonic/plugin-hubtype-analytics": "^0.54.0",
+    "@botonic/plugin-knowledge-bases": "^0.54.0",
+    "@botonic/react": "^0.54.0",
     "@reduxjs/toolkit": "1.9.7",
     "axios": "^1.18.1",
     "dotenv": "^17.2.0",
@@ -31,7 +31,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@botonic/dx": "^0.53.0",
+    "@botonic/dx": "^0.54.0",
     "@types/react": "18.3.13",
     "@types/react-dom": "18.3.1",
     "@types/react-redux": "^7.1.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23617,7 +23617,7 @@
     },
     "packages/botonic-cli": {
       "name": "@botonic/cli",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.8.6",
@@ -23662,7 +23662,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -23683,7 +23683,7 @@
     },
     "packages/botonic-dx": {
       "name": "@botonic/dx",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-modules-commonjs": "^7.27.1",
@@ -23691,8 +23691,8 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
-        "@botonic/dx-bundler-rspack": "^0.53.0",
-        "@botonic/eslint-config": "^0.53.0",
+        "@botonic/dx-bundler-rspack": "^0.54.0",
+        "@botonic/eslint-config": "^0.54.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.19.1",
         "babel-loader": "^8.4.1",
@@ -23720,7 +23720,7 @@
     },
     "packages/botonic-dx-bundler-rspack": {
       "name": "@botonic/dx-bundler-rspack",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
         "@rspack/cli": "^1.6.1",
@@ -23908,7 +23908,7 @@
     },
     "packages/botonic-eslint-config": {
       "name": "@botonic/eslint-config",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -23927,9 +23927,9 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "dependencies": {
-        "@botonic/core": "^0.53.0",
+        "@botonic/core": "^0.54.0",
         "@openai/agents": "^0.10.1",
         "axios": "^1.18.1",
         "openai": "^6.36.0",
@@ -23959,9 +23959,9 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "dependencies": {
-        "@botonic/react": "^0.53.0",
+        "@botonic/react": "^0.54.0",
         "axios": "^1.18.1",
         "uuid": "^10.0.0"
       },
@@ -23988,11 +23988,11 @@
     },
     "packages/botonic-plugin-hubtype-analytics": {
       "name": "@botonic/plugin-hubtype-analytics",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@botonic/core": "^0.53.0",
+        "@botonic/core": "^0.54.0",
         "axios": "^1.18.1"
       },
       "devDependencies": {
@@ -24005,11 +24005,11 @@
     },
     "packages/botonic-plugin-knowledge-bases": {
       "name": "@botonic/plugin-knowledge-bases",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@botonic/core": "^0.53.0",
+        "@botonic/core": "^0.54.0",
         "axios": "^1.18.1"
       },
       "devDependencies": {
@@ -24022,10 +24022,10 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
-        "@botonic/core": "^0.53.0",
+        "@botonic/core": "^0.54.0",
         "axios": "^1.18.1",
         "emoji-picker-react": "^4.12.0",
         "lodash.merge": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "botonic",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "scripts": {
     "clean": "rimraf packages/**/lib"
   },

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "license": "MIT",
   "bin": {
     "botonic": "./bin/run.js"

--- a/packages/botonic-cli/src/botonic-examples.ts
+++ b/packages/botonic-cli/src/botonic-examples.ts
@@ -6,7 +6,7 @@ import type { BotonicProject } from './interfaces.js'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const exampleTestPath = path.resolve(__dirname, '..', '..', '..', 'examples')
-const exampleVersion = '0.53.0'
+const exampleVersion = '0.54.0'
 
 export const EXAMPLES: BotonicProject[] = [
   {

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-dx-bundler-rspack/package.json
+++ b/packages/botonic-dx-bundler-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx-bundler-rspack",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Build Botonic bots with RSPack",
   "scripts": {
     "build": "echo Skipping build...",

--- a/packages/botonic-dx/package.json
+++ b/packages/botonic-dx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Continuous integration for botonic packages",
   "scripts": {
     "build": "echo Skipping build..."
@@ -18,8 +18,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
-    "@botonic/dx-bundler-rspack": "^0.53.0",
-    "@botonic/eslint-config": "^0.53.0",
+    "@botonic/dx-bundler-rspack": "^0.54.0",
+    "@botonic/eslint-config": "^0.54.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.19.1",
     "babel-loader": "^8.4.1",

--- a/packages/botonic-eslint-config/package.json
+++ b/packages/botonic-eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/eslint-config",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Eslint config for botonic packages",
   "main": "index.js",
   "scripts": {

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",
@@ -14,7 +14,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.53.0",
+    "@botonic/core": "^0.54.0",
     "@openai/agents": "^0.10.1",
     "axios": "^1.18.1",
     "openai": "^6.36.0",

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Botonic will be documented in this file.
 
 ### Added
 
+- [PR-3255](https://github.com/hubtype/botonic/pull/3255): Pass deactivate smart intents in inference endpoint.
+
 ### Changed
 
 ### Fixed

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -15,7 +15,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/react": "^0.53.0",
+    "@botonic/react": "^0.54.0",
     "axios": "^1.18.1",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/smart-intent.ts
@@ -4,6 +4,7 @@ import type { HtNodeWithContentType } from './node-types'
 interface SmartIntent {
   title: string
   description: string
+  is_active: boolean
 }
 
 export interface HtSmartIntentNode extends HtBaseNode {

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/smart-intent.ts
@@ -4,7 +4,7 @@ import type { HtNodeWithContentType } from './node-types'
 interface SmartIntent {
   title: string
   description: string
-  is_active: boolean
+  is_active?: boolean
 }
 
 export interface HtSmartIntentNode extends HtBaseNode {

--- a/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
@@ -40,11 +40,16 @@ export class SmartIntentsApi {
       return undefined
     }
 
+    const disabledSmartIntentTitles = smartIntentNodes
+      .filter(smartIntentNode => !smartIntentNode.content.is_active)
+      .map(smartIntentNode => smartIntentNode.content.title)
+
     const params = {
       bot_id: this.currentRequest.session.bot.id,
       text: this.userTextOrTranscript,
       num_smart_intents_to_use: this.smartIntentsConfig.numSmartIntentsToUse,
       use_latest: this.resolveUseLatest(),
+      disabled_smart_intent_titles: disabledSmartIntentTitles,
     }
 
     try {

--- a/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/src/user-input/smart-intent.ts
@@ -16,6 +16,7 @@ export interface SmartIntentsInferenceParams {
   text: string
   num_smart_intents_to_use?: number
   use_latest: boolean
+  disabled_smart_intent_titles: string[]
 }
 
 export interface SmartIntentsInferenceConfig {
@@ -41,7 +42,7 @@ export class SmartIntentsApi {
     }
 
     const disabledSmartIntentTitles = smartIntentNodes
-      .filter(smartIntentNode => !smartIntentNode.content.is_active)
+      .filter(smartIntentNode => smartIntentNode.content.is_active === false)
       .map(smartIntentNode => smartIntentNode.content.title)
 
     const params = {

--- a/packages/botonic-plugin-flow-builder/tests/__mocks__/smart-intent.ts
+++ b/packages/botonic-plugin-flow-builder/tests/__mocks__/smart-intent.ts
@@ -2,15 +2,17 @@ import { jest } from '@jest/globals'
 
 import { SmartIntentsApi } from '../../src/user-input/smart-intent'
 
+export let smartIntentInferenceSpy: jest.SpiedFunction<
+  (inferenceParams: unknown) => Promise<unknown>
+>
+
 export function mockSmartIntent(intentName?: string) {
-  // Spy on the private function getInference
-  const getInferenceSpy = jest.spyOn(
+  smartIntentInferenceSpy = jest.spyOn(
     SmartIntentsApi.prototype as any,
     'getInference'
   )
 
-  // Change the implementation of getInference
-  getInferenceSpy.mockImplementation(async () => {
+  smartIntentInferenceSpy.mockImplementation(async () => {
     return intentName
       ? {
           data: {

--- a/packages/botonic-plugin-flow-builder/tests/helpers/flows/smart-intents.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/flows/smart-intents.ts
@@ -461,6 +461,7 @@ export const smartIntentsFlow = {
       content: {
         title: 'Select a seat',
         description: 'The user wants to select a seat',
+        is_active: false,
       },
     },
   ],

--- a/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, test } from '@jest/globals'
 import type { FlowText } from '../src/index'
 import { ProcessEnvNodeEnvs } from '../src/types'
 // eslint-disable-next-line jest/no-mocks-import
-import { mockSmartIntent, smartIntentInferenceSpy } from './__mocks__/smart-intent'
+import {
+  mockSmartIntent,
+  smartIntentInferenceSpy,
+} from './__mocks__/smart-intent'
 import { smartIntentsFlow } from './helpers/flows/smart-intents'
 import { createFlowBuilderPluginAndGetContents } from './helpers/utils'
 

--- a/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/smart-intent.test.ts
@@ -1,17 +1,77 @@
 import { INPUT } from '@botonic/core'
-import { describe, test } from '@jest/globals'
+import { beforeEach, describe, expect, test } from '@jest/globals'
 
 import type { FlowText } from '../src/index'
 import { ProcessEnvNodeEnvs } from '../src/types'
 // eslint-disable-next-line jest/no-mocks-import
-import { mockSmartIntent } from './__mocks__/smart-intent'
+import { mockSmartIntent, smartIntentInferenceSpy } from './__mocks__/smart-intent'
 import { smartIntentsFlow } from './helpers/flows/smart-intents'
 import { createFlowBuilderPluginAndGetContents } from './helpers/utils'
+
+describe('Check smart intent inference params', () => {
+  process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
+
+  test('Passes inactive smart intent titles as disabled_smart_intent_titles to inference API', async () => {
+    mockSmartIntent('Add a bag')
+
+    await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: { flow: smartIntentsFlow },
+      requestArgs: {
+        input: {
+          data: 'I want to add a bag to my flight booking',
+          type: INPUT.TEXT,
+        },
+      },
+    })
+
+    expect(smartIntentInferenceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disabled_smart_intent_titles: ['Select a seat'],
+      })
+    )
+  })
+
+  test('Passes an empty disabled_smart_intent_titles list when smart intents have no is_active field', async () => {
+    const flowWithLegacySmartIntents = {
+      ...smartIntentsFlow,
+      nodes: smartIntentsFlow.nodes.map(node =>
+        node.type === 'smart-intent'
+          ? {
+              ...node,
+              content: {
+                title: node.content.title,
+                description: node.content.description,
+              },
+            }
+          : node
+      ),
+    }
+    mockSmartIntent('Add a bag')
+
+    await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: { flow: flowWithLegacySmartIntents },
+      requestArgs: {
+        input: {
+          data: 'I want to add a bag to my flight booking',
+          type: INPUT.TEXT,
+        },
+      },
+    })
+
+    expect(smartIntentInferenceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disabled_smart_intent_titles: [],
+      })
+    )
+  })
+})
 
 describe('Check the contents returned by the plugin when match a smart intent', () => {
   process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
 
-  beforeEach(() => mockSmartIntent('Add a bag'))
+  beforeEach(() => {
+    mockSmartIntent('Add a bag')
+  })
 
   test('When the smart intent inference returns the intent_name Add a bag, the contents of the add a bag use case are displayed', async () => {
     const { contents, request, flowBuilderPluginPost } =
@@ -82,7 +142,9 @@ describe('Check the contents returned by the plugin when match a smart intent', 
 describe('Check the contents returned when smart intent matches an AUDIO message with transcript', () => {
   process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
 
-  beforeEach(() => mockSmartIntent('Add a bag'))
+  beforeEach(() => {
+    mockSmartIntent('Add a bag')
+  })
 
   test('When the smart intent inference matches the transcript of an AUDIO message, the intent contents are displayed', async () => {
     const { contents, request, flowBuilderPluginPost } =
@@ -128,7 +190,9 @@ describe('Check the contents returned when smart intent matches an AUDIO message
 describe('Check the contents returned by the plugin when no match a smart intent', () => {
   process.env.NODE_ENV = ProcessEnvNodeEnvs.PRODUCTION
 
-  beforeEach(() => mockSmartIntent('Other'))
+  beforeEach(() => {
+    mockSmartIntent('Other')
+  })
 
   test('When the smart intent inference returns the intent_name Other, fallback content are displayed', async () => {
     const { contents, request } = await createFlowBuilderPluginAndGetContents({

--- a/packages/botonic-plugin-hubtype-analytics/package.json
+++ b/packages/botonic-plugin-hubtype-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-hubtype-analytics",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Plugin for tracking in the Hubtype backend to see the results in the Hubtype Dashbord",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/core": "^0.53.0",
+    "@botonic/core": "^0.54.0",
     "axios": "^1.18.1"
   },
   "devDependencies": {

--- a/packages/botonic-plugin-knowledge-bases/package.json
+++ b/packages/botonic-plugin-knowledge-bases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-knowledge-bases",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "Use a Hubtype to make the bot respond through a knowledge base.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/core": "^0.53.0",
+    "@botonic/core": "^0.54.0",
     "axios": "^1.18.1"
   },
   "devDependencies": {

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",
@@ -20,7 +20,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.53.0",
+    "@botonic/core": "^0.54.0",
     "axios": "^1.18.1",
     "emoji-picker-react": "^4.12.0",
     "lodash.merge": "^4.6.2",


### PR DESCRIPTION
## Description

Add an optional `is_active` field to smart intent nodes in Flow Builder and forward the titles of inactive intents to the smart intent inference API via a new `disabled_smart_intent_titles` parameter.

## Context

- Flow Builder previously had no way to deactivate specific smart intents without removing them from the flow. Disabled intents were still considered during inference.
- This change allows bot builders to temporarily disable smart intents while keeping them in the flow for later reactivation (BLT-2503).
- The smart intent inference endpoint already supports excluding intents by title; this PR wires that capability from the Flow Builder plugin.

## Approach taken / Explain the design

- Extended the `SmartIntent` type with an optional `is_active?: boolean` field.
- In `SmartIntentsApi.getNodeByInput()`, collect titles from smart intent nodes where `is_active === false` and include them in the inference request as `disabled_smart_intent_titles`.
- Smart intents without the `is_active` field are treated as active, preserving backward compatibility with existing flows.

## To document / Usage example

In Flow Builder, set `is_active: false` on a smart intent node to exclude it from inference:

```json
{
  "type": "smart-intent",
  "content": {
    "title": "Select a seat",
    "description": "The user wants to select a seat",
    "is_active": false
  }
}
```

The plugin will automatically send the following parameter to the inference API:

```json
{
  "disabled_smart_intent_titles": ["Select a seat"]
}
```

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**