### PR TITLE
feat(plugin-ai-agents): review that new models work for ai agents #BLT-2493 

### DIFF
--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
 
+## [0.54.x] - 2026-mm-dd
+
+### Added
+
+### Changed
+
+- [PR-3259](https://github.com/hubtype/botonic/pull/3259): Simplify reasoning effort in LLMConfig.
+
+### Fixed
+
 </details>
 
 ## [0.52.1] - 2026-07-14

--- a/packages/botonic-plugin-ai-agents/src/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/index.ts
@@ -290,10 +290,6 @@ export default class BotonicPluginAiAgents<
     inferenceId: string,
     llmConfig: LLMConfig
   ) {
-    console.log(
-      'getSpecialistAgentAndTools llmConfig.reasoning',
-      llmConfig.modelSettings.reasoning
-    )
     // Build tools
     const tools = this.buildTools(aiAgentArgs)
 

--- a/packages/botonic-plugin-ai-agents/src/llm-config.ts
+++ b/packages/botonic-plugin-ai-agents/src/llm-config.ts
@@ -1,4 +1,8 @@
-import { type BotContext, ReasoningEffort, VerbosityLevel } from '@botonic/core'
+import {
+  type BotContext,
+  type ReasoningEffort,
+  VerbosityLevel,
+} from '@botonic/core'
 import {
   type Model,
   type ModelProvider,
@@ -54,7 +58,6 @@ export class LLMConfig {
       verbosity,
       reasoningEffort
     )
-    console.log('new LLMConfig reasoningEffort', reasoningEffort)
   }
 
   async getModel(): Promise<Model> {
@@ -147,30 +150,6 @@ export class LLMConfig {
     verbosity: VerbosityLevel,
     reasoningEffort?: ReasoningEffort
   ): ModelSettings {
-    // By default, we use low reasoning effort for chat models because they not accept the reasoning effort set as none.
-    if (model.includes('chat')) {
-      return {
-        reasoning: { effort: reasoningEffort ?? ReasoningEffort.Low },
-        temperature: 1,
-        text: { verbosity },
-      }
-    }
-
-    if (model.includes('luna')) {
-      return {
-        temperature: 1,
-        text: { verbosity },
-      }
-    }
-
-    if (model.includes('gpt-5')) {
-      return {
-        reasoning: { effort: reasoningEffort ?? ReasoningEffort.None },
-        temperature: 1,
-        text: { verbosity },
-      }
-    }
-
     if (model.includes('gpt-4')) {
       return {
         temperature: 0,
@@ -178,9 +157,15 @@ export class LLMConfig {
       }
     }
 
-    // LiteLLM can proxy any model — fall back to reasoning settings
+    if (reasoningEffort) {
+      return {
+        reasoning: { effort: reasoningEffort },
+        temperature: 1,
+        text: { verbosity },
+      }
+    }
+
     return {
-      reasoning: { effort: ReasoningEffort.None },
       temperature: 1,
       text: { verbosity },
     }

--- a/packages/botonic-plugin-ai-agents/tests/llm-config.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/llm-config.test.ts
@@ -1,6 +1,13 @@
-import { VerbosityLevel } from '@botonic/core'
+import { ReasoningEffort, VerbosityLevel } from '@botonic/core'
 import { createTestBotContext } from '@botonic/core/testing'
-import { afterEach, beforeEach, describe, expect, it } from '@jest/globals'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals'
 
 import { LLMConfig } from '../src/llm-config'
 
@@ -13,22 +20,20 @@ const mockResolvedModel = { id: 'resolved-model' }
 
 jest.mock('openai', () => ({
   __esModule: true,
-  default: jest.fn().mockImplementation((config: Record<string, unknown>) => {
+  default: jest.fn((config: Record<string, unknown>) => {
     capturedOpenAIConfig = config
     return { type: 'openai' }
   }),
-  AzureOpenAI: jest
-    .fn()
-    .mockImplementation((config: Record<string, unknown>) => {
-      capturedAzureConfig = config
-      return { type: 'azure' }
-    }),
+  AzureOpenAI: jest.fn((config: Record<string, unknown>) => {
+    capturedAzureConfig = config
+    return { type: 'azure' }
+  }),
 }))
 
 jest.mock('@openai/agents', () => ({
-  OpenAIProvider: jest.fn().mockImplementation(() => ({
+  OpenAIProvider: jest.fn(() => ({
     type: 'provider',
-    getModel: jest.fn().mockResolvedValue(mockResolvedModel),
+    getModel: jest.fn(async () => mockResolvedModel),
   })),
 }))
 
@@ -125,54 +130,38 @@ describe('LLMConfig', () => {
       mockConstants.LLM_PROVIDER = 'azure'
     })
 
-    it('returns gpt-4 style settings for gpt-4 model', () => {
+    it('gpt-4 models: temperature 0 and hardcoded Medium verbosity (ignores passed verbosity)', () => {
       const config = new LLMConfig({
         maxRetries: DEFAULT_MAX_RETRIES,
         timeout: DEFAULT_TIMEOUT,
         modelName: 'gpt-4.1-mini',
-        verbosity: VerbosityLevel.Medium,
+        verbosity: VerbosityLevel.High,
         botContext: makeBotContext(),
       })
 
       expect(config.modelSettings).toEqual({
         temperature: 0,
-        text: { verbosity: 'medium' },
+        text: { verbosity: VerbosityLevel.Medium },
       })
     })
 
-    it('returns gpt-5 style settings for gpt-5 model', () => {
+    it('gpt-4 models: ignores reasoningEffort', () => {
       const config = new LLMConfig({
         maxRetries: DEFAULT_MAX_RETRIES,
         timeout: DEFAULT_TIMEOUT,
-        modelName: 'gpt-5-mini',
+        modelName: 'gpt-4.1-mini',
         verbosity: VerbosityLevel.High,
         botContext: makeBotContext(),
+        reasoningEffort: ReasoningEffort.High,
       })
 
       expect(config.modelSettings).toEqual({
-        reasoning: { effort: 'none' },
-        temperature: 1,
-        text: { verbosity: 'high' },
+        temperature: 0,
+        text: { verbosity: VerbosityLevel.Medium },
       })
     })
 
-    it('returns gpt-chat style settings for gpt-chat model', () => {
-      const config = new LLMConfig({
-        maxRetries: DEFAULT_MAX_RETRIES,
-        timeout: DEFAULT_TIMEOUT,
-        modelName: 'gpt-chat-latest',
-        verbosity: VerbosityLevel.High,
-        botContext: makeBotContext(),
-      })
-
-      expect(config.modelSettings).toEqual({
-        reasoning: { effort: 'low' },
-        temperature: 1,
-        text: { verbosity: 'high' },
-      })
-    })
-
-    it('returns reasoning settings for unknown model (LiteLLM fallback)', () => {
+    it('non-gpt-4 models without reasoningEffort: plain settings with passed verbosity', () => {
       const config = new LLMConfig({
         maxRetries: DEFAULT_MAX_RETRIES,
         timeout: DEFAULT_TIMEOUT,
@@ -182,9 +171,25 @@ describe('LLMConfig', () => {
       })
 
       expect(config.modelSettings).toEqual({
-        reasoning: { effort: 'none' },
         temperature: 1,
         text: { verbosity: 'high' },
+      })
+    })
+
+    it('non-gpt-4 models with reasoningEffort: reasoning settings with passed verbosity', () => {
+      const config = new LLMConfig({
+        maxRetries: DEFAULT_MAX_RETRIES,
+        timeout: DEFAULT_TIMEOUT,
+        modelName: 'claude-3-5-sonnet',
+        verbosity: VerbosityLevel.Low,
+        botContext: makeBotContext(),
+        reasoningEffort: ReasoningEffort.Low,
+      })
+
+      expect(config.modelSettings).toEqual({
+        reasoning: { effort: 'low' },
+        temperature: 1,
+        text: { verbosity: 'low' },
       })
     })
   })


### PR DESCRIPTION
## Description

Simplifies `LLMConfig.getModelSettings()` so new models routed through LiteLLM work without model-specific branches, and removes leftover debug `console.log` statements from the AI agents plugin.

## Context

Part of [BLT-2493](https://hubtype.atlassian.net/browse/BLT-2493) — review that new models work for AI agents.

The previous `LLMConfig.getModelSettings()` implementation hard-coded branches for `chat`, `luna`, `gpt-5` and `gpt-4` model name substrings, defaulting any unknown model to `ReasoningEffort.None`. That meant every new model added through LiteLLM needed an ad-hoc branch, and models that don't accept `reasoning.effort` could receive an invalid setting. Two debug `console.log` statements had also been left in the production path (`llm-config.ts` constructor and `getSpecialistAgentAndTools` in `index.ts`).

## Approach taken / Explain the design

`LLMConfig.getModelSettings()` is reduced to three cases:

- `gpt-4*` models keep the existing deterministic settings: `temperature: 0` and `text.verbosity: VerbosityLevel.Medium`, ignoring both `verbosity` and `reasoningEffort`.
- For any other model, when `reasoningEffort` is provided by the caller, the settings are `{ reasoning: { effort: reasoningEffort }, temperature: 1, text: { verbosity } }`.
- For any other model without `reasoningEffort`, the settings fall back to `{ temperature: 1, text: { verbosity } }` with no `reasoning` block, letting the provider apply its own defaults.

This removes the `chat`/`luna`/`gpt-5`/fallback branches and the implicit `ReasoningEffort.None` default, so new LiteLLM-proxied models work out of the box and only opt into reasoning when explicitly requested.

Two debug `console.log` statements are removed from `llm-config.ts` and `index.ts`.

## To document / Usage example

No public API changes. Behavior change callers may notice:

- Models whose name does not contain `gpt-4` no longer receive `reasoning: { effort: 'none' }` by default; they only get a `reasoning` block when `reasoningEffort` is explicitly passed to `LLMConfig`.

## Testing

The pull request...

- has unit tests

Updated `llm-config.test.ts` to cover the new `gpt-4*` (ignores verbosity and `reasoningEffort`) and non-`gpt-4*` (with/without `reasoningEffort`) branches.

[BLT-2493]: https://hubtype.atlassian.net/browse/BLT-2493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ