### PR TITLE
refactor(plugin-flow-builder):  contact info fields serialized as a JSON #BLT-2516

### DIFF
--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
 
+### Added
+
+### Changed
+
+- [PR-3260](https://github.com/hubtype/botonic/pull/3260): Serialize contact info fields as a JSON inside SpecialistAgent.
+
+### Fixed
+
 </details>
 
 ## [0.52.1] - 2026-07-14
@@ -17,7 +25,6 @@ All notable changes to Botonic will be documented in this file.
 ### Added
 
 - [PR-3250](https://github.com/hubtype/botonic/pull/3250): No use reasoning_effort for gpt-5.6-luna.
-
 
 ## [0.51.6] - 2026-07-14
 

--- a/packages/botonic-plugin-ai-agents/src/agents/specialist-agent.ts
+++ b/packages/botonic-plugin-ai-agents/src/agents/specialist-agent.ts
@@ -135,32 +135,25 @@ export class SpecialistAgent<
     contactInfo: ContactInfo[],
     campaignsContext?: CampaignV2[]
   ): string {
-    const instructions = `<instructions>\n${initialInstructions.trim()}\n</instructions>`
-    const metadataInstructions = this.getMetadataInstructions()
-    const contactInfoInstructions = this.getContactInfoInstructions(contactInfo)
-    const campaignInstructions = this.getCampaignInstructions(campaignsContext)
-    return this.addOutputInstructions(
-      `${instructions}\n\n${metadataInstructions}\n\n${contactInfoInstructions}\n\n${campaignInstructions}`
-    )
+    const sections = [
+      `<instructions>\n${initialInstructions.trim()}\n</instructions>`,
+      this.getMetadataInstructions(),
+      this.getContactInfoInstructions(contactInfo),
+      this.getCampaignInstructions(campaignsContext),
+    ].filter(section => section.length > 0)
+
+    return this.addOutputInstructions(sections.join('\n\n'))
   }
 
   private getContactInfoInstructions(contactInfo: ContactInfo[]): string {
-    const structuredContactInfo = contactInfo
-      .map(
-        info =>
-          ` <contact_info>
-              <name>${info.name}</name>
-              <value>${info.value}</value>
-              <type>${info.type}</type>
-              ${
-                info.description
-                  ? `<description>${info.description}</description>`
-                  : ''
-              }
-            </contact_info>`
-      )
-      .join('\n')
-    return `<contact_info_fields>\n${structuredContactInfo}</contact_info_fields>`
+    return `<contact_info_fields>${JSON.stringify(
+      contactInfo.map(info => ({
+        name: info.name,
+        value: info.value,
+      })),
+      null,
+      0
+    )}</contact_info_fields>`
   }
 
   private getMetadataInstructions(): string {

--- a/packages/botonic-plugin-ai-agents/tests/agent-builder.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/agent-builder.test.ts
@@ -1,3 +1,11 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals'
 import { z } from 'zod'
 import type { DebugLogger } from '../src/debug-logger'
 import { OutputSchema } from '../src/structured-output/index'
@@ -20,7 +28,7 @@ let capturedAgentConfig: any = null
 
 // Mock OpenAI Agent class
 jest.mock('@openai/agents', () => ({
-  Agent: jest.fn().mockImplementation(config => {
+  Agent: jest.fn((config: Record<string, unknown>) => {
     capturedAgentConfig = config
     return {
       name: config.name,
@@ -65,6 +73,9 @@ const mockGuardrailTrackingContext: GuardrailTrackingContext = {
   inferenceId: 'test-inference-id',
 }
 
+const toCompactContactJson = (contactInfo: ContactInfo[]) =>
+  JSON.stringify(contactInfo.map(({ name, value }) => ({ name, value })))
+
 // Mock LLMConfig for tests (agents uses modelName and modelSettings for logging)
 const resolvedModel = { id: 'resolved-model' }
 const mockLlmConfig = {
@@ -75,7 +86,7 @@ const mockLlmConfig = {
     toolChoice: undefined as string | undefined,
   },
   modelProvider: {},
-  getModel: jest.fn().mockResolvedValue(resolvedModel),
+  getModel: jest.fn(async () => resolvedModel),
 } as unknown as LLMConfig
 
 describe('WorkerAgent', () => {
@@ -153,23 +164,7 @@ describe('WorkerAgent', () => {
       guardrailTrackingContext: mockGuardrailTrackingContext,
     })
     const workerAgent = worker.getAgent()
-    const structuredContactInfo = contactInfo
-      .map(
-        info =>
-          ` <contact_info>
-              <name>${info.name}</name>
-              <value>${info.value}</value>
-              <type>${info.type}</type>
-              ${
-                info.description
-                  ? `<description>${info.description}</description>`
-                  : ''
-              }
-            </contact_info>`
-      )
-      .join('\n')
-
-    const expectedInstructions = `<instructions>\n${agentInstructions}\n</instructions>\n\n<metadata>\nCurrent Date: 2024-01-01T00:00:00.000Z\n</metadata>\n\n<contact_info_fields>\n${structuredContactInfo}</contact_info_fields>\n\n<campaign_context_1>\nThis is some context coming from campaigns\n</campaign_context_1>\n\n<output>\nReturn a JSON that follows the output schema provided. Never return multiple output schemas concatenated by a line break.\n<example>\n${'{"messages":[{"type":"text","content":{"text":"Hello, how can I help you today?"}}]}'}\n</example>\n</output>`
+    const expectedInstructions = `<instructions>\n${agentInstructions}\n</instructions>\n\n<metadata>\nCurrent Date: 2024-01-01T00:00:00.000Z\n</metadata>\n\n<contact_info_fields>${toCompactContactJson(contactInfo)}</contact_info_fields>\n\n<campaign_context_1>\nThis is some context coming from campaigns\n</campaign_context_1>\n\n<output>\nReturn a JSON that follows the output schema provided. Never return multiple output schemas concatenated by a line break.\n<example>\n${'{"messages":[{"type":"text","content":{"text":"Hello, how can I help you today?"}}]}'}\n</example>\n</output>`
 
     expect(workerAgent.name).toBe(agentName)
     expect(workerAgent.instructions).toBe(expectedInstructions)
@@ -272,6 +267,82 @@ describe('WorkerAgent', () => {
 
       const result = OutputSchema.safeParse(invalidOutput)
       expect(result.success).toBe(false)
+    })
+  })
+
+  describe('Contact info prompt format', () => {
+    const extractContactInfoFields = (instructions: string) =>
+      instructions.match(
+        /<contact_info_fields>([\s\S]*?)<\/contact_info_fields>/
+      )?.[1]
+
+    const createAgent = async (contactInfoOverride: ContactInfo[]) =>
+      (
+        await SpecialistAgent.create({
+          name: agentName,
+          instructions: agentInstructions,
+          llmConfig: mockLlmConfig,
+          tools: [],
+          contactInfo: contactInfoOverride,
+          inputGuardrailRules: [],
+          sourceIds: [],
+          campaignsContext: undefined,
+          logger: mockLogger,
+          guardrailTrackingContext: mockGuardrailTrackingContext,
+        })
+      ).getAgent()
+
+    it('should serialize contact info as compact JSON inside contact_info_fields', async () => {
+      const workerAgent = await createAgent(contactInfo)
+      const contactJson = toCompactContactJson(contactInfo)
+      const contactInfoFields = extractContactInfoFields(
+        workerAgent.instructions as string
+      )
+
+      expect(contactInfoFields).toBe(contactJson)
+      expect(contactInfoFields).not.toContain('<name>')
+      expect(contactInfoFields).not.toMatch(/\n\s+/)
+    })
+
+    it('should include only name and value when description is present', async () => {
+      const contactsWithDescription: ContactInfo[] = [
+        {
+          name: 'email',
+          value: 'user@example.com',
+          type: 'string',
+          description: 'Primary email address',
+        },
+      ]
+      const workerAgent = await createAgent(contactsWithDescription)
+      const contactInfoFields = extractContactInfoFields(
+        workerAgent.instructions as string
+      )
+
+      expect(contactInfoFields).toBe(
+        toCompactContactJson(contactsWithDescription)
+      )
+      expect(contactInfoFields).not.toContain('Primary email address')
+      expect(contactInfoFields).not.toContain('"type"')
+      expect(contactInfoFields).not.toContain('"description"')
+    })
+
+    it('should serialize contacts without description the same way', async () => {
+      const contactsWithoutDescription: ContactInfo[] = [
+        {
+          name: 'phone',
+          value: '+34123456789',
+          type: 'string',
+        },
+      ]
+      const workerAgent = await createAgent(contactsWithoutDescription)
+      const contactInfoFields = extractContactInfoFields(
+        workerAgent.instructions as string
+      )
+
+      expect(contactInfoFields).toBe(
+        toCompactContactJson(contactsWithoutDescription)
+      )
+      expect(contactInfoFields).not.toContain('"description"')
     })
   })
 


### PR DESCRIPTION
## Description

Refactors how contact info fields are injected into the `SpecialistAgent` system prompt. Instead of a verbose XML-like structure per field, contact data is now serialized as compact JSON inside the `<contact_info_fields>` tag, including only `name` and `value` for each entry.

## Context

The previous contact info format in the AI agent prompt used nested XML tags (`<contact_info>`, `<name>`, `<value>`, `<type>`, `<description>`) for every field. This added unnecessary tokens to the prompt and included metadata (`type`, `description`) that the agent does not need to reason about user contact data.

This change simplifies the prompt structure, reduces token usage, and makes the contact info section easier for the language model to parse.

Related issue: #BLT-2516

## Approach taken / Explain the design

- **`getContactInfoInstructions`**: Replaced the XML template with `JSON.stringify` of an array of `{ name, value }` objects. The `type` and `description` properties from `ContactInfo` are intentionally excluded since they are not relevant for the agent's context.
- **`addExtraInstructions`**: Refactored prompt assembly to build an array of sections (`instructions`, `metadata`, `contact_info_fields`, `campaign_context`) and join only non-empty ones. This keeps the composition logic cleaner and consistent across sections.

**Before:**
```xml
<contact_info_fields>
 <contact_info>
    <name>email</name>
    <value>user@example.com</value>
    <type>string</type>
    <description>Primary email address</description>
 </contact_info>
</contact_info_fields>
```

**After:**
```xml
<contact_info_fields>[{"name":"email","value":"user@example.com"}]</contact_info_fields>
```

## To document / Usage example

No API or configuration changes are required. Contact info is still passed to `SpecialistAgent.create` via the `contactInfo` parameter as before:

```typescript
await SpecialistAgent.create({
  name: 'my-agent',
  instructions: 'You are a helpful assistant.',
  contactInfo: [
    { name: 'email', value: 'user@example.com', type: 'string', description: 'Primary email' },
    { name: 'phone', value: '+34123456789', type: 'string' },
  ],
  // ...other options
})
```

The agent prompt will automatically include:

```xml
<contact_info_fields>[{"name":"email","value":"user@example.com"},{"name":"phone","value":"+34123456789"}]</contact_info_fields>
```

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because...