### PR TITLE
fix(botonic-core): replace deprecated string conversion with TextDecoder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3079,10 +3079,6 @@
       "resolved": "packages/botonic-plugin-hubtype-analytics",
       "link": true
     },
-    "node_modules/@botonic/plugin-knowledge-bases": {
-      "resolved": "packages/botonic-plugin-knowledge-bases",
-      "link": true
-    },
     "node_modules/@botonic/react": {
       "resolved": "packages/botonic-react",
       "link": true
@@ -23662,7 +23658,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.54.0",
+      "version": "0.54.1",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -24006,6 +24002,7 @@
     "packages/botonic-plugin-knowledge-bases": {
       "name": "@botonic/plugin-knowledge-bases",
       "version": "0.54.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",

--- a/packages/botonic-core/CHANGELOG.md
+++ b/packages/botonic-core/CHANGELOG.md
@@ -10,13 +10,16 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.53.x] - 2026-mm-dd
+## [0.54.1] - 2026-mm-dd
 
 ### Added
 
 ### Changed
 
 ### Fixed
+
+- [PR-3262](https://github.com/hubtype/botonic/pull/3262): Replace deprecated string conversion with TextDecoder to decompress data from pusher. 
+
 
 </details>
 

--- a/packages/botonic-core/CHANGELOG.md
+++ b/packages/botonic-core/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.54.1] - 2026-mm-dd
+## [0.55.0] - 2026-mm-dd
 
 ### Added
 
@@ -18,10 +18,13 @@ All notable changes to Botonic will be documented in this file.
 
 ### Fixed
 
-- [PR-3262](https://github.com/hubtype/botonic/pull/3262): Replace deprecated string conversion with TextDecoder to decompress data from pusher. 
-
-
 </details>
+
+## [0.54.1] - 2026-08-06
+
+### Fixed
+
+- [PR-3262](https://github.com/hubtype/botonic/pull/3262): Replace deprecated string conversion with TextDecoder to decompress data from pusher. 
 
 ## [0.52.1] - 2026-07-23
 

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-core/src/pusher-utils.ts
+++ b/packages/botonic-core/src/pusher-utils.ts
@@ -11,6 +11,5 @@ export function decompressData(compressedData: string): string {
   const charData = strData.split('').map(x => x.charCodeAt(0)) // Convert binary string to character-number array
   const binData = new Uint8Array(charData) // Turn number array into byte-array
   const data = inflate(binData)
-  // @ts-expect-error
-  return String.fromCharCode.apply(null, new Uint8Array(data)) // Convert gunzipped byteArray back to ascii string
+  return new TextDecoder('utf-8').decode(data)
 }

--- a/packages/botonic-core/tests/pusher-utils.test.ts
+++ b/packages/botonic-core/tests/pusher-utils.test.ts
@@ -1,0 +1,45 @@
+import { gzip } from 'pako'
+
+import { decompressData } from '../src/pusher-utils'
+
+function compressData(data: string): string {
+  const compressed = gzip(data)
+  return Buffer.from(compressed).toString('base64')
+}
+
+describe('decompressData', () => {
+  test('decompresses a small JSON payload', () => {
+    const original = '{"message":{"text":"hi"}}'
+    const compressed = compressData(original)
+
+    expect(decompressData(compressed)).toBe(original)
+  })
+
+  test('round-trips a typical debug trace JSON object', () => {
+    const original = {
+      type: 'ai_agent',
+      trace: {
+        steps: [{ name: 'tool_call', input: { query: 'weather' } }],
+        duration_ms: 1234,
+      },
+    }
+    const json = JSON.stringify(original)
+    const compressed = compressData(json)
+
+    expect(JSON.parse(decompressData(compressed))).toEqual(original)
+  })
+
+  test('decompresses UTF-8 content with non-ASCII characters', () => {
+    const original = '{"text":"á ñ emoji 🎉"}'
+    const compressed = compressData(original)
+
+    expect(decompressData(compressed)).toBe(original)
+  })
+
+  test('decompresses a large payload without stack overflow', () => {
+    const original = JSON.stringify({ data: 'x'.repeat(200_000) })
+    const compressed = compressData(original)
+
+    expect(decompressData(compressed)).toBe(original)
+  })
+})


### PR DESCRIPTION
## Description

Fixes `decompressData` so large compressed Pusher payloads can be decompressed without crashing. Replaces `String.fromCharCode.apply()` with `TextDecoder` to convert inflated bytes into a UTF-8 string.

## Context

When Pusher sends `botonic_response_compressed`, the backend compresses a large JSON payload with gzip + base64. After inflate, the decompressed `Uint8Array` can be hundreds of KB.

The previous implementation used `String.fromCharCode.apply(null, new Uint8Array(data))`, which passes each byte as a separate argument to `fromCharCode`. V8 limits the number of arguments (~65k) and throws:

```
RangeError: Maximum call stack size exceeded
```

This caused failures when receiving large bot responses over Pusher (e.g. AI agent debug traces).

## Approach taken / Explain the design

Replace the deprecated `String.fromCharCode.apply()` pattern with the standard `TextDecoder` API:

```ts
return new TextDecoder('utf-8').decode(data)
```

`TextDecoder` converts a `Uint8Array` to a string without argument-count limits and correctly handles multi-byte UTF-8 characters (non-ASCII text, emojis, etc.).

## To document / Usage example

No API changes. `decompressData` still accepts a base64-encoded gzip string and returns the decompressed UTF-8 string:

```ts
import { decompressData } from '@botonic/core'

const json = decompressData(compressedBase64String)
const payload = JSON.parse(json)
```

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because...