### PR TITLE
fix: chunks sometimes not visibles, bc useEffect missing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23955,39 +23955,14 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.55.0",
+      "version": "0.55.1-alpha.0",
       "dependencies": {
-        "@botonic/react": "^0.55.0",
+        "@botonic/react": "0.55.1-alpha.0",
         "axios": "^1.18.1",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@types/uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=22.19.0",
-        "npm": ">=10.0.0"
-      }
-    },
-    "packages/botonic-plugin-flow-builder/node_modules/@botonic/react": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@botonic/react/-/react-0.55.0.tgz",
-      "integrity": "sha512-DgWtoK+FnMd9/jpv7Fyn1/fbSr2LsZax4x0ekhHh/gcud8/ozhb2c2LI5uU4QinIWw1w4IfsOTwpYAvmnEm8Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "@botonic/core": "^0.55.0",
-        "axios": "^1.18.1",
-        "emoji-picker-react": "^4.12.0",
-        "lodash.merge": "^4.6.2",
-        "markdown-it": "^12.3.2",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-json-tree": "^0.18.0",
-        "react-router-dom": "^5.3.4",
-        "react-textarea-autosize": "^8.5.5",
-        "styled-components": "^5.3.11",
-        "ua-parser-js": "^1.0.39",
-        "uuid": "^10.0.0"
       },
       "engines": {
         "node": ">=22.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23658,7 +23658,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.55.0",
+      "version": "0.55.1",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -23955,9 +23955,9 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.55.1-alpha.0",
+      "version": "0.55.1",
       "dependencies": {
-        "@botonic/react": "0.55.1-alpha.0",
+        "@botonic/react": "^0.55.1",
         "axios": "^1.18.1",
         "uuid": "^10.0.0"
       },
@@ -24019,10 +24019,10 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.55.1-alpha.0",
+      "version": "0.55.1",
       "license": "MIT",
       "dependencies": {
-        "@botonic/core": "^0.55.0",
+        "@botonic/core": "^0.55.1",
         "axios": "^1.18.1",
         "emoji-picker-react": "^4.12.0",
         "lodash.merge": "^4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23969,6 +23969,31 @@
         "npm": ">=10.0.0"
       }
     },
+    "packages/botonic-plugin-flow-builder/node_modules/@botonic/react": {
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@botonic/react/-/react-0.55.0.tgz",
+      "integrity": "sha512-DgWtoK+FnMd9/jpv7Fyn1/fbSr2LsZax4x0ekhHh/gcud8/ozhb2c2LI5uU4QinIWw1w4IfsOTwpYAvmnEm8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@botonic/core": "^0.55.0",
+        "axios": "^1.18.1",
+        "emoji-picker-react": "^4.12.0",
+        "lodash.merge": "^4.6.2",
+        "markdown-it": "^12.3.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-json-tree": "^0.18.0",
+        "react-router-dom": "^5.3.4",
+        "react-textarea-autosize": "^8.5.5",
+        "styled-components": "^5.3.11",
+        "ua-parser-js": "^1.0.39",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.19.0",
+        "npm": ">=10.0.0"
+      }
+    },
     "packages/botonic-plugin-flow-builder/node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -24019,7 +24044,7 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.55.0",
+      "version": "0.55.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@botonic/core": "^0.55.0",

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.55.1-alpha.0",
+  "version": "0.55.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -15,7 +15,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/react": "0.55.1-alpha.0",
+    "@botonic/react": "^0.55.1",
     "axios": "^1.18.1",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.55.0",
+  "version": "0.55.1-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -15,7 +15,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/react": "^0.55.0",
+    "@botonic/react": "0.55.1-alpha.0",
     "axios": "^1.18.1",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.55.1-alpha.0",
+  "version": "0.55.1",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",
@@ -20,7 +20,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.55.0",
+    "@botonic/core": "^0.55.1",
     "axios": "^1.18.1",
     "emoji-picker-react": "^4.12.0",
     "lodash.merge": "^4.6.2",

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.55.0",
+  "version": "0.55.1-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",

--- a/packages/botonic-react/src/components/system-debug-trace/hooks/use-knowledge-base-info.tsx
+++ b/packages/botonic-react/src/components/system-debug-trace/hooks/use-knowledge-base-info.tsx
@@ -136,7 +136,7 @@ export const useKnowledgeBaseInfo = ({
     }
 
     fetchData()
-  }, [])
+  }, [chunkIds])
 
   return {
     sources,

--- a/packages/botonic-react/tests/components/system-debug-trace-events.test.tsx
+++ b/packages/botonic-react/tests/components/system-debug-trace-events.test.tsx
@@ -264,6 +264,53 @@ describe('System Debug Trace - Event Components', () => {
       })
     })
 
+    test('fetches chunks via getChunkIdsGroupedBySource after rehydration', async () => {
+      const getChunkIdsGroupedBySource = jest.fn().mockResolvedValue([])
+      const getMessageById = jest.fn().mockResolvedValue({
+        event_data: {
+          tools_executed: [
+            {
+              tool_name: 'retrieve_knowledge',
+              tool_arguments: { query: 'return policy' },
+              tool_results: 'result1',
+              knowledgebase_sources_ids: ['src-1'],
+              knowledgebase_chunks_ids: ['chunk-1', 'chunk-2'],
+            },
+          ],
+        },
+      })
+
+      const context = withWebchatContext({
+        previewUtils: { getMessageById, getChunkIdsGroupedBySource },
+      })
+
+      const props = defaultAiAgentProps({
+        truncated: true,
+        hubtype_message_id: 'msg-1',
+      })
+
+      const { container } = render(
+        <WebchatContext.Provider value={context}>
+          <AiAgent {...props} />
+        </WebchatContext.Provider>
+      )
+
+      await waitFor(() => {
+        expect(getMessageById).toHaveBeenCalledWith('msg-1', {
+          includeDebugEvents: true,
+        })
+      })
+
+      await waitFor(() => {
+        expect(getChunkIdsGroupedBySource).toHaveBeenCalledWith([
+          'chunk-1',
+          'chunk-2',
+        ])
+      })
+
+      expect(container).toBeTruthy()
+    })
+
     test('does not fetch when event is not truncated', async () => {
       const getMessageById = jest.fn()
       const context = withWebchatContext({


### PR DESCRIPTION
## Context

Chunks from AI Agent debug events were sometimes not visible in the preview (Ralph Lauren / v1 bots).

## Root cause

- When a Pusher payload exceeds 10 KB, the backend sends a truncated stub (`tools_executed: []`, `truncated: true`) and the frontend rehydrates it via `getMessageById`.
- `useKnowledgeBaseInfo` had an **empty dependency array** (`[]`) on its fetching `useEffect`, so it ran once on mount with `chunkIds = []` and **never re-ran** when rehydration later populated the real chunk IDs → chunks were never fetched.

## Fix

- Added `chunkIds` to the `useEffect` dependency array in `use-knowledge-base-info.tsx` so the fetch re-triggers once rehydration replaces the empty `tools_executed` with the real data.
- Added a regression test verifying `getChunkIdsGroupedBySource` is called with the real chunk IDs after `getMessageById` rehydrates a truncated event.