### PR TITLE
fix: prevent duplicate AI agent invocation on first interaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23955,7 +23955,7 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.55.1",
+      "version": "0.55.2",
       "dependencies": {
         "@botonic/react": "^0.55.1",
         "axios": "^1.18.1",

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -24,6 +24,12 @@ All notable changes to Botonic will be documented in this file.
 
 </details>
 
+## [0.55.2] - 2026-09-03
+
+### Fixed
+
+- [PR-3267](https://github.com/hubtype/botonic/pull/3267): Fix first interaction duplicated ai agent response.
+
 ## [0.55.0] - 2026-08-14
 
 ### Changed

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Botonic will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not invoke the AI agent twice on first interaction when the start node already goes to an AI Agent flow.
+
 <details>
   <summary>
     Changes that have landed in master-lts but are not yet released.

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",

--- a/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
@@ -62,6 +62,7 @@ function startContentsAlreadyHandleUserInput(contents: FlowContent[]): boolean {
     return true
   }
 
+  // To avoid duplicated ai agent response, we check if there is an ai agent or ai agent router in the first interaction contents.
   return contents.some(
     content =>
       content instanceof FlowAiAgent || content instanceof FlowAiAgentRouter

--- a/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
+++ b/packages/botonic-plugin-flow-builder/src/action/first-interaction.ts
@@ -1,6 +1,11 @@
 import type { FlowBuilderApi } from '../api'
 import { MAIN_FLOW_NAME } from '../constants'
-import { FlowBotAction, type FlowContent } from '../content-fields'
+import {
+  FlowAiAgent,
+  FlowAiAgentRouter,
+  FlowBotAction,
+  type FlowContent,
+} from '../content-fields'
 import type BotonicPluginFlowBuilder from '../index'
 import { inputHasTextOrTranscript } from '../utils/input'
 import { getContentsByAiAgentFromUserInput } from './ai-agent-from-user-input'
@@ -36,10 +41,10 @@ export async function getContentsByFirstInteraction(
     }
   }
 
-  /* If the first interaction has a FlowBotAction, it should be the last content
-   * and avoid to render the match with keywords or intents
-   */
-  if (firstInteractionContents.at(-1) instanceof FlowBotAction) {
+  // Bot actions and AI agents already consume the user input. Matching
+  // keywords/intents/KB/AI-agent-from-user-input on top would duplicate replies
+  // (e.g. Main start → Go to flow → AI Agents).
+  if (startContentsAlreadyHandleUserInput(firstInteractionContents)) {
     return firstInteractionContents
   }
 
@@ -50,6 +55,17 @@ export async function getContentsByFirstInteraction(
   }
 
   return firstInteractionContents
+}
+
+function startContentsAlreadyHandleUserInput(contents: FlowContent[]): boolean {
+  if (contents.at(-1) instanceof FlowBotAction) {
+    return true
+  }
+
+  return contents.some(
+    content =>
+      content instanceof FlowAiAgent || content instanceof FlowAiAgentRouter
+  )
 }
 
 async function getContentsByUserInput(

--- a/packages/botonic-plugin-flow-builder/tests/first-interaction.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/first-interaction.test.ts
@@ -2,13 +2,16 @@ import { INPUT, type InferenceResponse, OutputMessageType } from '@botonic/core'
 import { describe, test } from '@jest/globals'
 
 import { FlowBuilderAction } from '../src/action/index'
-import type { FlowAiAgent, FlowText } from '../src/content-fields/index'
+import { FlowAiAgent, type FlowText } from '../src/content-fields/index'
 import { ProcessEnvNodeEnvs } from '../src/types'
 // eslint-disable-next-line jest/no-mocks-import
 import { mockAiAgentResponse } from './__mocks__/ai-agent'
 // eslint-disable-next-line jest/no-mocks-import
 import { mockSmartIntent } from './__mocks__/smart-intent'
-import { aiAgentTestFlow } from './helpers/flows/ai-agent'
+import {
+  aiAgentMainStartGoToFlowTestFlow,
+  aiAgentTestFlow,
+} from './helpers/flows/ai-agent'
 import { basicFlow } from './helpers/flows/basic'
 import {
   createFlowBuilderPlugin,
@@ -222,6 +225,37 @@ describe('Check the contents returned by the plugin in first interaction with AI
     expect(aiAgentMock).toHaveBeenCalled()
     expect((contents[0] as FlowText).text).toBe('Welcome')
     expect(contents.length).toBe(2)
+  })
+
+  test('When Main start is a go-to-flow to AI Agents, the AI agent responds once on first interaction', async () => {
+    const aiAgentMock = mockAiAgentResponse(mockResponse)
+
+    const { contents } = await createFlowBuilderPluginAndGetContents({
+      flowBuilderOptions: {
+        flow: aiAgentMainStartGoToFlowTestFlow,
+        getAiAgentResponse: aiAgentMock,
+      },
+      requestArgs: {
+        input: {
+          data: 'hola',
+          type: INPUT.TEXT,
+        },
+        isFirstInteraction: true,
+      },
+    })
+
+    const aiAgentContents = contents.filter(
+      content => content instanceof FlowAiAgent
+    )
+
+    expect(aiAgentMock).toHaveBeenCalledTimes(1)
+    expect(aiAgentContents).toHaveLength(1)
+    expect((aiAgentContents[0] as FlowAiAgent).messages[0]).toEqual({
+      type: 'text',
+      content: {
+        text: 'AI agent response in first interaction',
+      },
+    })
   })
 
   test('When disableAIAgentInFirstInteraction is true but it is not first interaction, the AI agent still responds', async () => {

--- a/packages/botonic-plugin-flow-builder/tests/helpers/flows/ai-agent.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/flows/ai-agent.ts
@@ -212,3 +212,13 @@ export const aiAgentGoToFlowTestFlow = {
     },
   ],
 }
+
+export const aiAgentMainStartGoToFlowTestFlow = {
+  ...aiAgentGoToFlowTestFlow,
+  start_node_id: GO_TO_AI_AGENTS_NODE_ID,
+  flows: aiAgentGoToFlowTestFlow.flows.map(flow =>
+    flow.name === 'Main'
+      ? { ...flow, start_node_id: GO_TO_AI_AGENTS_NODE_ID }
+      : flow
+  ),
+}


### PR DESCRIPTION
## Description

On the first interaction, Flow Builder no longer appends a second AI Agent resolution when the start contents already handle the user input (a Bot Action as the last node, or an AI Agent / AI Agent Router anywhere in the start chain). The user message is still processed once by the agent already reached from the start flow.

## Context

When `session.is_first_interaction` is true, `getContentsByFirstInteraction` always resolved the Main start contents and then, if the user sent text, concatenated `getContentsByAiAgentFromUserInput`.

A common layout is: Main start node → go-to-flow → AI Agents. `getStartContents()` already follows that go-to-flow and includes the AI Agent. Concatenating the user-input AI Agent path invoked inference twice and returned two `FlowAiAgent` contents with the same greeting, so WhatsApp (and other channels) showed two identical messages.

This only happened on the first interaction. Later turns use `getContents()` without that concatenation, so the agent answered once as expected.

The same first-interaction path already skipped extra matching when the last start content was a Bot Action. AI Agent / AI Agent Router were not covered.

## Approach taken / Explain the design

`startContentsAlreadyHandleUserInput` decides whether start contents already consume the user message:

- **Bot Action**: only if it is the last content (existing behaviour).
- **AI Agent or AI Agent Router**: if either appears anywhere in the start contents (the go-to-flow may not leave the agent as the last item in the array).

If that helper returns true, first interaction returns only the start contents. `FlowBuilderAction.prepareContentsToRender` still runs inference once on the agent already in that list, using the current user input.

If the start chain is only welcome text (no agent), behaviour is unchanged: keywords / intents / AI Agent from user input are still appended after the start contents.

## To document / Usage example

No public API change. Bots whose Main start goes to the AI Agents flow no longer need a workaround on first interaction.

No extra configuration is required. `disableAIAgentInFirstInteraction` still disables the *appended* user-input AI Agent path when start contents do not already include an agent.

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**

Added a first-interaction test with Main start = go-to-flow to AI Agents and user text `hola`: `getAiAgentResponse` is called once and contents contain a single `FlowAiAgent`. Existing first-interaction tests (welcome + agent, `disableAIAgentInFirstInteraction`) still pass.