### PR TITLE
feat: add REQUEST_CONTACT_INFO button for Whatsapp template

### DIFF
--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Botonic will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- [PR-3268](https://github.com/hubtype/botonic/pull/3268): Add support for `REQUEST_CONTACT_INFO` button in WhatsApp templates.
+
 ### Fixed
 
 - Do not invoke the AI agent twice on first interaction when the start node already goes to an AI Agent flow.

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-whatsapp-template.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-whatsapp-template.tsx
@@ -13,6 +13,7 @@ import {
   type WhatsappTemplateFlowButton,
   type WhatsappTemplatePhoneNumberButton,
   type WhatsappTemplateQuickReplyButton,
+  type WhatsappTemplateRequestContactInfoButton,
   type WhatsappTemplateUrlButton,
   type WhatsappTemplateVoiceCallButton,
 } from '@botonic/react'
@@ -259,6 +260,10 @@ export class FlowWhatsappTemplate extends ContentFieldsBase {
       return this.createVoiceCallButtonComponent(index)
     }
 
+    if (button.type === WhatsAppTemplateButtonSubType.REQUEST_CONTACT_INFO) {
+      return this.createRequestContactInfoButtonComponent(index)
+    }
+
     if (button.type === WhatsAppTemplateButtonSubType.FLOW) {
       const actionValue = flowButtonActionValues?.[String(index)]
       if (!actionValue) {
@@ -335,6 +340,17 @@ export class FlowWhatsappTemplate extends ContentFieldsBase {
     return {
       type: WhatsAppTemplateComponentType.BUTTON,
       sub_type: WhatsAppTemplateButtonSubType.PHONE_NUMBER,
+      index: index,
+      parameters: [],
+    }
+  }
+
+  private createRequestContactInfoButtonComponent(
+    index: number
+  ): WhatsappTemplateRequestContactInfoButton {
+    return {
+      type: WhatsAppTemplateComponentType.BUTTON,
+      sub_type: WhatsAppTemplateButtonSubType.REQUEST_CONTACT_INFO,
       index: index,
       parameters: [],
     }

--- a/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/whatsapp-template.ts
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/hubtype-fields/whatsapp-template.ts
@@ -38,6 +38,11 @@ type HtWhatsAppTemplateButton =
       index: number
     }
   | {
+      type: WhatsAppTemplateButtonSubType.REQUEST_CONTACT_INFO
+      text?: string
+      index: number
+    }
+  | {
       type: WhatsAppTemplateButtonSubType.FLOW
       text: string
       flow_id: string

--- a/packages/botonic-plugin-flow-builder/tests/helpers/flows/whatsapp-template.ts
+++ b/packages/botonic-plugin-flow-builder/tests/helpers/flows/whatsapp-template.ts
@@ -18,7 +18,9 @@ const WhatsAppTemplateButtonSubType = {
   URL: 'URL',
   QUICK_REPLY: 'QUICK_REPLY',
   PHONE_NUMBER: 'PHONE_NUMBER',
+  VOICE_CALL: 'VOICE_CALL',
   FLOW: 'FLOW',
+  REQUEST_CONTACT_INFO: 'REQUEST_CONTACT_INFO',
 } as const
 
 export const whatsappTemplateFlow = {
@@ -679,6 +681,70 @@ export const whatsappTemplateFlow = {
               date: '2024-01-15',
               time: '10:00 AM',
             },
+            url_variable_values: {},
+          },
+        },
+        buttons: [],
+      },
+    },
+    {
+      id: 'keyword-whatsapp-template-request-contact-info',
+      code: '',
+      is_code_ai_generated: false,
+      meta: { x: 0, y: 700 },
+      follow_up: null,
+      target: {
+        id: 'whatsapp-template-request-contact-info-node',
+        type: 'whatsapp-template',
+      },
+      flow_id: 'main-flow',
+      is_meaningful: false,
+      ai_translated_locales: [],
+      type: 'keyword',
+      content: {
+        title: [],
+        keywords: [{ values: ['templateRequestContactInfo'], locale: 'en' }],
+      },
+    },
+    {
+      id: 'whatsapp-template-request-contact-info-node',
+      code: 'WHATSAPP_TEMPLATE_REQUEST_CONTACT_INFO',
+      is_code_ai_generated: false,
+      meta: { x: 300, y: 700 },
+      follow_up: null,
+      target: null,
+      flow_id: 'main-flow',
+      is_meaningful: false,
+      ai_translated_locales: [],
+      type: 'whatsapp-template',
+      content: {
+        by_locale: {
+          en: {
+            template: {
+              id: 'template-request-contact-info-id',
+              name: 'request_phone_number',
+              language: 'en',
+              status: 'APPROVED',
+              category: 'UTILITY',
+              components: [
+                {
+                  type: WhatsAppTemplateComponentType.BODY,
+                  text: 'Please share your phone number so we can finish your request.',
+                },
+                {
+                  type: WhatsAppTemplateComponentType.BUTTONS,
+                  buttons: [
+                    {
+                      type: WhatsAppTemplateButtonSubType.REQUEST_CONTACT_INFO,
+                      index: 0,
+                    },
+                  ],
+                },
+              ],
+              namespace: 'test-namespace',
+              parameter_format: 'POSITIONAL',
+            },
+            variable_values: {},
             url_variable_values: {},
           },
         },

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-whatsapp-template.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-whatsapp-template.test.ts
@@ -9,6 +9,7 @@ import {
   type WhatsappTemplateHeaderVideoParameter,
   type WhatsappTemplatePhoneNumberButton,
   type WhatsappTemplateQuickReplyButton,
+  type WhatsappTemplateRequestContactInfoButton,
   type WhatsappTemplateUrlButton,
 } from '@botonic/react'
 import { describe, expect, test } from '@jest/globals'
@@ -479,6 +480,42 @@ describe('FlowWhatsappTemplate', () => {
       expect(phoneNumberButton?.index).toBe(2)
       expect(
         (phoneNumberButton as WhatsappTemplatePhoneNumberButton)?.parameters
+      ).toEqual([])
+    })
+
+    test('should create REQUEST_CONTACT_INFO button with empty parameters', async () => {
+      const { contents, request } = await createFlowBuilderPluginAndGetContents(
+        {
+          flowBuilderOptions: { flow: whatsappTemplateFlow },
+          requestArgs: {
+            input: { data: 'templateRequestContactInfo', type: INPUT.TEXT },
+          },
+        }
+      )
+
+      const template = contents[0] as FlowWhatsappTemplate
+      expect(template.htWhatsappTemplate.name).toBe('request_phone_number')
+
+      // @ts-expect-error - accessing private method for testing
+      const buttons = template.getButtons(
+        template.htWhatsappTemplate,
+        template.buttons || [],
+        template.urlVariableValues || {},
+        template.flowButtonActionValues || {},
+        request
+      )
+
+      expect(buttons?.type).toBe(WhatsAppTemplateComponentType.BUTTONS)
+      expect(buttons?.buttons).toHaveLength(1)
+
+      const requestContactInfoButton = buttons?.buttons[0]
+      expect(requestContactInfoButton?.sub_type).toBe(
+        WhatsAppTemplateButtonSubType.REQUEST_CONTACT_INFO
+      )
+      expect(requestContactInfoButton?.index).toBe(0)
+      expect(
+        (requestContactInfoButton as WhatsappTemplateRequestContactInfoButton)
+          .parameters
       ).toEqual([])
     })
 

--- a/packages/botonic-react/CHANGELOG.md
+++ b/packages/botonic-react/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Botonic will be documented in this file.
 
 ### Added
 
+- [PR-3268](https://github.com/hubtype/botonic/pull/3268): Add support for `REQUEST_CONTACT_INFO` button in WhatsApp templates.
+
 ### Changed
 
 ### Fixed

--- a/packages/botonic-react/src/components/whatsapp-template/types.ts
+++ b/packages/botonic-react/src/components/whatsapp-template/types.ts
@@ -4,6 +4,7 @@ export enum WhatsAppTemplateButtonSubType {
   PHONE_NUMBER = 'PHONE_NUMBER',
   VOICE_CALL = 'VOICE_CALL',
   FLOW = 'FLOW',
+  REQUEST_CONTACT_INFO = 'REQUEST_CONTACT_INFO',
 }
 
 export enum WhatsAppTemplateParameterType {
@@ -111,6 +112,13 @@ export interface WhatsappTemplatePhoneNumberButton {
   parameters: []
 }
 
+export interface WhatsappTemplateRequestContactInfoButton {
+  type: WhatsAppTemplateComponentType.BUTTON
+  sub_type: WhatsAppTemplateButtonSubType.REQUEST_CONTACT_INFO
+  index: number
+  parameters: []
+}
+
 export interface WhatsappTemplateFlowAction {
   flow_token: string
   flow_action_data?: Record<string, string>
@@ -133,4 +141,5 @@ export type WhatsappTemplateButton =
   | WhatsappTemplateUrlButton
   | WhatsappTemplateVoiceCallButton
   | WhatsappTemplatePhoneNumberButton
+  | WhatsappTemplateRequestContactInfoButton
   | WhatsappTemplateFlowButton

--- a/packages/botonic-react/tests/components/__snapshots__/whatsapp-template.test.tsx.snap
+++ b/packages/botonic-react/tests/components/__snapshots__/whatsapp-template.test.tsx.snap
@@ -18,6 +18,15 @@ exports[`WhatsappTemplate Component renders WhatsappTemplate with FLOW button wi
 />
 `;
 
+exports[`WhatsappTemplate Component renders WhatsappTemplate with REQUEST_CONTACT_INFO button 1`] = `
+<message
+  buttons="{"type":"BUTTONS","buttons":[{"type":"BUTTON","sub_type":"REQUEST_CONTACT_INFO","index":0,"parameters":[]}]}"
+  language="en"
+  name="request_phone_number"
+  type="whatsapptemplate"
+/>
+`;
+
 exports[`WhatsappTemplate Component renders WhatsappTemplate with URL button 1`] = `
 <message
   buttons="{"type":"BUTTONS","buttons":[{"type":"BUTTON","sub_type":"URL","index":0,"parameters":[{"type":"TEXT","text":"order-123"}]}]}"

--- a/packages/botonic-react/tests/components/whatsapp-template.test.tsx
+++ b/packages/botonic-react/tests/components/whatsapp-template.test.tsx
@@ -220,6 +220,27 @@ describe('WhatsappTemplate Component', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('renders WhatsappTemplate with REQUEST_CONTACT_INFO button', () => {
+    const props = {
+      name: 'request_phone_number',
+      language: 'en',
+      buttons: {
+        type: WhatsAppTemplateComponentType.BUTTONS,
+        buttons: [
+          {
+            type: WhatsAppTemplateComponentType.BUTTON,
+            sub_type: WhatsAppTemplateButtonSubType.REQUEST_CONTACT_INFO,
+            index: 0,
+            parameters: [],
+          },
+        ],
+      },
+    }
+
+    const tree = renderToJSON(<WhatsappTemplate {...props} />)
+    expect(tree).toMatchSnapshot()
+  })
+
   test('renders WhatsappTemplate with all components (header, body, buttons)', () => {
     const props = {
       name: 'support_ticket',
@@ -290,6 +311,9 @@ describe('WhatsApp Template Types', () => {
     expect(WhatsAppTemplateButtonSubType.PHONE_NUMBER).toBe('PHONE_NUMBER')
     expect(WhatsAppTemplateButtonSubType.VOICE_CALL).toBe('VOICE_CALL')
     expect(WhatsAppTemplateButtonSubType.FLOW).toBe('FLOW')
+    expect(WhatsAppTemplateButtonSubType.REQUEST_CONTACT_INFO).toBe(
+      'REQUEST_CONTACT_INFO'
+    )
   })
 
   test('WhatsAppTemplateParameterType has correct values', () => {


### PR DESCRIPTION
## Description

Adds support for the `REQUEST_CONTACT_INFO` button type in WhatsApp templates across `botonic-react` and `botonic-plugin-flow-builder`. This enables bots to send approved WhatsApp templates that include a button prompting users to share their contact information (phone number).

## Context

WhatsApp Business API supports a `REQUEST_CONTACT_INFO` button in message templates, allowing businesses to collect a user's phone number directly from the chat. Botonic already supported other template button types (URL, Quick Reply, Phone Number, Voice Call, and Flow), but this new button type was missing, preventing Flow Builder templates that use it from being rendered correctly.

## Approach taken / Explain the design

- **`botonic-react`**: Added `REQUEST_CONTACT_INFO` to the `WhatsAppTemplateButtonSubType` enum and introduced the `WhatsappTemplateRequestContactInfoButton` interface. This button has no parameters (empty `parameters` array), consistent with other parameter-less buttons like `PHONE_NUMBER` and `VOICE_CALL`.
- **`botonic-plugin-flow-builder`**: Extended the Hubtype WhatsApp template button type union and added a `createRequestContactInfoButtonComponent` method in `FlowWhatsappTemplate` to map Flow Builder button definitions to the Botonic WhatsApp template format.

## To document / Usage example

When defining a WhatsApp template with a `REQUEST_CONTACT_INFO` button in Flow Builder, the button is automatically mapped to the correct WhatsApp API format:

```tsx
import {
  WhatsAppTemplateButtonSubType,
  WhatsAppTemplateComponentType,
  WhatsappTemplate,
} from '@botonic/react'

<WhatsappTemplate
  name="request_phone_number"
  language="en"
  buttons={{
    type: WhatsAppTemplateComponentType.BUTTONS,
    buttons: [
      {
        type: WhatsAppTemplateComponentType.BUTTON,
        sub_type: WhatsAppTemplateButtonSubType.REQUEST_CONTACT_INFO,
        index: 0,
        parameters: [],
      },
    ],
  }}
/>
```

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**