### PR TITLE
feat: add new interactive whatsapp message to request contact info #BLT-2621

### DIFF
--- a/packages/botonic-core/CHANGELOG.md
+++ b/packages/botonic-core/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Botonic will be documented in this file.
 
 ### Added
 
+- [PR-3269](https://github.com/hubtype/botonic/pull/3269): Add `INPUT.WHATSAPP_REQUEST_CONTACT_INFO` message type and `origin` field on `Input` for contact request inbounds.
+
 ### Changed
 
 ### Fixed

--- a/packages/botonic-core/src/models/legacy-types.ts
+++ b/packages/botonic-core/src/models/legacy-types.ts
@@ -72,6 +72,7 @@ export enum INPUT {
   CHAT_EVENT = 'chatevent',
   WHATSAPP_BUTTON_LIST = 'whatsapp-button-list',
   WHATSAPP_CTA_URL_BUTTON = 'whatsapp-cta-url-button',
+  WHATSAPP_REQUEST_CONTACT_INFO = 'whatsapp-request-contact-info',
   WHATSAPP_CATALOG = 'whatsapp-catalog',
   WHATSAPP_PRODUCT = 'whatsapp-product',
   WHATSAPP_PRODUCT_LIST = 'whatsapp-product-list',
@@ -113,6 +114,7 @@ export type InputType =
   | INPUT.WHATSAPP_TEMPLATE
   | INPUT.WHATSAPP_BUTTON_LIST
   | INPUT.WHATSAPP_CTA_URL_BUTTON
+  | INPUT.WHATSAPP_REQUEST_CONTACT_INFO
   | INPUT.WHATSAPP_CATALOG
   | INPUT.WHATSAPP_PRODUCT
   | INPUT.WHATSAPP_PRODUCT_LIST
@@ -158,6 +160,7 @@ export interface Input {
     matchedValue: string
     payload?: string
   }
+  origin?: string
 }
 
 export interface CaseEventQueuePositionChangedInput {

--- a/packages/botonic-react/CHANGELOG.md
+++ b/packages/botonic-react/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Botonic will be documented in this file.
 ### Added
 
 - [PR-3268](https://github.com/hubtype/botonic/pull/3268): Add support for `REQUEST_CONTACT_INFO` button in WhatsApp templates.
+- [PR-3269](https://github.com/hubtype/botonic/pull/3269): Add `WhatsappRequestContactInfo` component for WhatsApp session interactive `request_contact_info` messages.
 
 ### Changed
 

--- a/packages/botonic-react/src/components/index.ts
+++ b/packages/botonic-react/src/components/index.ts
@@ -37,10 +37,6 @@ export {
   WhatsappCTAUrlHeaderType,
 } from './whatsapp-cta-url-button'
 export {
-  WhatsappRequestContactInfo,
-  WhatsappRequestContactInfoProps,
-} from './whatsapp-request-contact-info'
-export {
   CardType,
   WhatsappInteractiveMediaCard,
   WhatsappInteractiveMediaCarousel,
@@ -61,5 +57,9 @@ export {
   WhatsappProductListProps,
   WhatsappProductListSection,
 } from './whatsapp-product-list'
+export {
+  WhatsappRequestContactInfo,
+  WhatsappRequestContactInfoProps,
+} from './whatsapp-request-contact-info'
 export { WhatsappTemplate } from './whatsapp-template/index'
 export * from './whatsapp-template/types'

--- a/packages/botonic-react/src/components/index.ts
+++ b/packages/botonic-react/src/components/index.ts
@@ -37,6 +37,10 @@ export {
   WhatsappCTAUrlHeaderType,
 } from './whatsapp-cta-url-button'
 export {
+  WhatsappRequestContactInfo,
+  WhatsappRequestContactInfoProps,
+} from './whatsapp-request-contact-info'
+export {
   CardType,
   WhatsappInteractiveMediaCard,
   WhatsappInteractiveMediaCarousel,

--- a/packages/botonic-react/src/components/whatsapp-request-contact-info.tsx
+++ b/packages/botonic-react/src/components/whatsapp-request-contact-info.tsx
@@ -1,0 +1,38 @@
+import { INPUT } from '@botonic/core'
+
+import { renderComponent } from '../util/react'
+import { convertToMarkdownMeta } from './multichannel/whatsapp/markdown-meta'
+import { WHATSAPP_MAX_BODY_CHARS } from './multichannel/whatsapp/constants'
+import { Text } from './text'
+
+export interface WhatsappRequestContactInfoProps {
+  body: string
+}
+
+const validateBody = (body: string): string => {
+  if (!body) {
+    throw new Error('WhatsappRequestContactInfo: body is required')
+  }
+  if (body.length > WHATSAPP_MAX_BODY_CHARS) {
+    throw new Error(
+      `WhatsappRequestContactInfo: body exceeds maximum length of ${WHATSAPP_MAX_BODY_CHARS} characters`
+    )
+  }
+  return convertToMarkdownMeta(body)
+}
+
+export const WhatsappRequestContactInfo = (
+  props: WhatsappRequestContactInfoProps
+) => {
+  const renderBrowser = () => <Text>{props.body}</Text>
+
+  const renderNode = () => {
+    const body = validateBody(props.body)
+    return (
+      // @ts-expect-error Property 'message' does not exist on type 'JSX.IntrinsicElements'.
+      <message body={body} type={INPUT.WHATSAPP_REQUEST_CONTACT_INFO} />
+    )
+  }
+
+  return renderComponent({ renderBrowser, renderNode })
+}

--- a/packages/botonic-react/src/components/whatsapp-request-contact-info.tsx
+++ b/packages/botonic-react/src/components/whatsapp-request-contact-info.tsx
@@ -1,8 +1,8 @@
 import { INPUT } from '@botonic/core'
 
 import { renderComponent } from '../util/react'
-import { convertToMarkdownMeta } from './multichannel/whatsapp/markdown-meta'
 import { WHATSAPP_MAX_BODY_CHARS } from './multichannel/whatsapp/constants'
+import { convertToMarkdownMeta } from './multichannel/whatsapp/markdown-meta'
 import { Text } from './text'
 
 export interface WhatsappRequestContactInfoProps {

--- a/packages/botonic-react/tests/components/__snapshots__/whatsapp-request-contact-info.test.tsx.snap
+++ b/packages/botonic-react/tests/components/__snapshots__/whatsapp-request-contact-info.test.tsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renders WhatsappRequestContactInfo component 1`] = `
+<message
+  body="Please share your phone number"
+  type="whatsapp-request-contact-info"
+/>
+`;

--- a/packages/botonic-react/tests/components/whatsapp-request-contact-info.test.tsx
+++ b/packages/botonic-react/tests/components/whatsapp-request-contact-info.test.tsx
@@ -13,9 +13,9 @@ test('renders WhatsappRequestContactInfo component', () => {
 })
 
 test('throws when body is empty', () => {
-  expect(() =>
-    renderToJSON(<WhatsappRequestContactInfo body='' />)
-  ).toThrow('WhatsappRequestContactInfo: body is required')
+  expect(() => renderToJSON(<WhatsappRequestContactInfo body='' />)).toThrow(
+    'WhatsappRequestContactInfo: body is required'
+  )
 })
 
 test('throws when body exceeds 1024 characters', () => {

--- a/packages/botonic-react/tests/components/whatsapp-request-contact-info.test.tsx
+++ b/packages/botonic-react/tests/components/whatsapp-request-contact-info.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from '@jest/globals'
+import TestRenderer from 'react-test-renderer'
+
+import { WhatsappRequestContactInfo } from '../../src/components/whatsapp-request-contact-info'
+
+const renderToJSON = (sut: JSX.Element) => TestRenderer.create(sut).toJSON()
+
+test('renders WhatsappRequestContactInfo component', () => {
+  const tree = renderToJSON(
+    <WhatsappRequestContactInfo body='Please share your phone number' />
+  )
+  expect(tree).toMatchSnapshot()
+})
+
+test('throws when body is empty', () => {
+  expect(() =>
+    renderToJSON(<WhatsappRequestContactInfo body='' />)
+  ).toThrow('WhatsappRequestContactInfo: body is required')
+})
+
+test('throws when body exceeds 1024 characters', () => {
+  expect(() =>
+    renderToJSON(<WhatsappRequestContactInfo body={'a'.repeat(1025)} />)
+  ).toThrow(
+    'WhatsappRequestContactInfo: body exceeds maximum length of 1024 characters'
+  )
+})


### PR DESCRIPTION
## Description

Adds support for WhatsApp session interactive `request_contact_info` messages in Botonic. This includes a new `WhatsappRequestContactInfo` React component, the `INPUT.WHATSAPP_REQUEST_CONTACT_INFO` message type in `@botonic/core`, and an optional `origin` field on inbound `Input` messages to identify contact request responses.

## Context

WhatsApp Business API supports interactive session messages that prompt users to share their phone number via a `request_contact_info` button. While [PR-3268](https://github.com/hubtype/botonic/pull/3268) adds support for the same capability in approved WhatsApp templates, bots also need to send this interaction during an active session (outside of templates). Without this change, Botonic could not render or handle this message type, blocking Flow Builder flows and custom bot implementations that rely on it.

Related ticket: BLT-2621

## Approach taken / Explain the design

- **`@botonic/core`**: Added `INPUT.WHATSAPP_REQUEST_CONTACT_INFO` to the `INPUT` enum and `InputType` union. Extended the `Input` interface with an optional `origin` field to carry the source of inbound contact request responses.
- **`@botonic/react`**: Introduced the `WhatsappRequestContactInfo` component following the same pattern as other WhatsApp interactive components (e.g. `WhatsappCTAUrlButton`). It validates the required `body` prop (max 1024 characters), converts it to markdown meta, and renders a `<message>` node with the new input type. In the browser preview, it falls back to a plain `Text` component.
- **Exports**: The component and its props are exported from `@botonic/react` for direct use in bot actions and by downstream packages (e.g. `botonic-plugin-flow-builder`).

## To document / Usage example

Use the component in a bot action to ask the user for their phone number during a WhatsApp session:

```tsx
import { WhatsappRequestContactInfo } from '@botonic/react'

export const RequestContactInfoAction = () => (
  <WhatsappRequestContactInfo body="Please share your phone number so we can contact you." />
)
```

When the user responds, the inbound message will be available as an `Input` with the `origin` field set, allowing the bot to process the shared contact information.

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**