### PR TITLE
feat: add RequestContactInfo message type and schema, to use it in ai agent #BLT-2622

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23613,7 +23613,7 @@
     },
     "packages/botonic-cli": {
       "name": "@botonic/cli",
-      "version": "0.55.0",
+      "version": "0.56.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.8.6",
@@ -23658,7 +23658,7 @@
     },
     "packages/botonic-core": {
       "name": "@botonic/core",
-      "version": "0.55.1",
+      "version": "0.56.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
@@ -23679,7 +23679,7 @@
     },
     "packages/botonic-dx": {
       "name": "@botonic/dx",
-      "version": "0.55.0",
+      "version": "0.56.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-modules-commonjs": "^7.27.1",
@@ -23687,8 +23687,8 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
-        "@botonic/dx-bundler-rspack": "^0.55.0",
-        "@botonic/eslint-config": "^0.55.0",
+        "@botonic/dx-bundler-rspack": "^0.56.0-alpha.0",
+        "@botonic/eslint-config": "^0.56.0-alpha.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.19.1",
         "babel-loader": "^8.4.1",
@@ -23716,7 +23716,7 @@
     },
     "packages/botonic-dx-bundler-rspack": {
       "name": "@botonic/dx-bundler-rspack",
-      "version": "0.55.0",
+      "version": "0.56.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@rspack/cli": "^1.6.1",
@@ -23904,7 +23904,7 @@
     },
     "packages/botonic-eslint-config": {
       "name": "@botonic/eslint-config",
-      "version": "0.55.0",
+      "version": "0.56.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -23923,9 +23923,9 @@
     },
     "packages/botonic-plugin-ai-agents": {
       "name": "@botonic/plugin-ai-agents",
-      "version": "0.55.0",
+      "version": "0.56.0-alpha.0",
       "dependencies": {
-        "@botonic/core": "^0.55.0",
+        "@botonic/core": "^0.56.0-alpha.0",
         "@openai/agents": "^0.10.1",
         "axios": "^1.18.1",
         "openai": "^6.36.0",
@@ -23955,9 +23955,9 @@
     },
     "packages/botonic-plugin-flow-builder": {
       "name": "@botonic/plugin-flow-builder",
-      "version": "0.55.2",
+      "version": "0.56.0-alpha.0",
       "dependencies": {
-        "@botonic/react": "^0.55.1",
+        "@botonic/react": "^0.56.0-alpha.0",
         "axios": "^1.18.1",
         "uuid": "^10.0.0"
       },
@@ -23984,11 +23984,11 @@
     },
     "packages/botonic-plugin-hubtype-analytics": {
       "name": "@botonic/plugin-hubtype-analytics",
-      "version": "0.55.0",
+      "version": "0.56.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@botonic/core": "^0.55.0",
+        "@botonic/core": "^0.56.0-alpha.0",
         "axios": "^1.18.1"
       },
       "devDependencies": {
@@ -24019,10 +24019,10 @@
     },
     "packages/botonic-react": {
       "name": "@botonic/react",
-      "version": "0.55.1",
+      "version": "0.56.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@botonic/core": "^0.55.1",
+        "@botonic/core": "^0.56.0-alpha.0",
         "axios": "^1.18.1",
         "emoji-picker-react": "^4.12.0",
         "lodash.merge": "^4.6.2",

--- a/packages/botonic-cli/package.json
+++ b/packages/botonic-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botonic/cli",
   "description": "Build Chatbots Using React",
-  "version": "0.55.0",
+  "version": "0.56.0-alpha.0",
   "license": "MIT",
   "bin": {
     "botonic": "./bin/run.js"

--- a/packages/botonic-core/CHANGELOG.md
+++ b/packages/botonic-core/CHANGELOG.md
@@ -10,11 +10,12 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.55.0] - 2026-mm-dd
+## [0.56.0] - 2026-mm-dd
 
 ### Added
 
 - [PR-3269](https://github.com/hubtype/botonic/pull/3269): Add `INPUT.WHATSAPP_REQUEST_CONTACT_INFO` message type and `origin` field on `Input` for contact request inbounds.
+- [PR-3273](https://github.com/hubtype/botonic/pull/3273): Add `requestContactInfo` output message type and `RequestContactInfoMessage` interface for AI agents.
 
 ### Changed
 

--- a/packages/botonic-core/package.json
+++ b/packages/botonic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/core",
-  "version": "0.55.1",
+  "version": "0.56.0-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs/index.js",

--- a/packages/botonic-core/src/models/ai-agents.ts
+++ b/packages/botonic-core/src/models/ai-agents.ts
@@ -5,6 +5,7 @@ export enum OutputMessageType {
   TextWithButtons = 'textWithButtons',
   BotExecutor = 'botExecutor',
   Carousel = 'carousel',
+  RequestContactInfo = 'requestContactInfo',
   Exit = 'exit',
 }
 
@@ -61,6 +62,13 @@ export interface CarouselMessage extends BaseMessage {
   }
 }
 
+export interface RequestContactInfoMessage extends BaseMessage {
+  type: OutputMessageType.RequestContactInfo
+  content: {
+    text: string
+  }
+}
+
 export interface ExitMessage extends BaseMessage {
   type: OutputMessageType.Exit
 }
@@ -70,6 +78,7 @@ export type OutputMessage<Extra extends BaseMessage<string> = never> =
   | TextWithButtonsMessage
   | BotExecutorMessage
   | CarouselMessage
+  | RequestContactInfoMessage
   | ExitMessage
   | Extra
 

--- a/packages/botonic-dx-bundler-rspack/package.json
+++ b/packages/botonic-dx-bundler-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx-bundler-rspack",
-  "version": "0.55.0",
+  "version": "0.56.0-alpha.0",
   "description": "Build Botonic bots with RSPack",
   "scripts": {
     "build": "echo Skipping build...",

--- a/packages/botonic-dx/package.json
+++ b/packages/botonic-dx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/dx",
-  "version": "0.55.0",
+  "version": "0.56.0-alpha.0",
   "description": "Continuous integration for botonic packages",
   "scripts": {
     "build": "echo Skipping build..."
@@ -18,8 +18,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
-    "@botonic/dx-bundler-rspack": "^0.55.0",
-    "@botonic/eslint-config": "^0.55.0",
+    "@botonic/dx-bundler-rspack": "^0.56.0-alpha.0",
+    "@botonic/eslint-config": "^0.56.0-alpha.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.19.1",
     "babel-loader": "^8.4.1",

--- a/packages/botonic-eslint-config/package.json
+++ b/packages/botonic-eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/eslint-config",
-  "version": "0.55.0",
+  "version": "0.56.0-alpha.0",
   "description": "Eslint config for botonic packages",
   "main": "index.js",
   "scripts": {

--- a/packages/botonic-plugin-ai-agents/CHANGELOG.md
+++ b/packages/botonic-plugin-ai-agents/CHANGELOG.md
@@ -10,9 +10,11 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
 
-## [0.55.x] - 2026-mm-dd
+## [0.56.x] - 2026-mm-dd
 
 ### Added
+
+- [PR-3273](https://github.com/hubtype/botonic/pull/3273): Add `requestContactInfo` message to the AI agent structured output schema.
 
 ### Changed
 

--- a/packages/botonic-plugin-ai-agents/package.json
+++ b/packages/botonic-plugin-ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-ai-agents",
-  "version": "0.55.0",
+  "version": "0.56.0-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use AI Agents to generate your contents",
@@ -14,7 +14,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.55.0",
+    "@botonic/core": "^0.56.0-alpha.0",
     "@openai/agents": "^0.10.1",
     "axios": "^1.18.1",
     "openai": "^6.36.0",

--- a/packages/botonic-plugin-ai-agents/src/structured-output/index.ts
+++ b/packages/botonic-plugin-ai-agents/src/structured-output/index.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { BotExecutorSchema } from './bot-executor'
 import { CarouselSchema } from './carousel'
 import { ExitSchema } from './exit'
+import { RequestContactInfoSchema } from './request-contact-info'
 import { TextSchema } from './text'
 import { TextWithButtonsSchema } from './text-with-buttons'
 
@@ -16,6 +17,7 @@ const baseMessageSchemas = [
   CarouselSchema,
   ExitSchema,
   BotExecutorSchema,
+  RequestContactInfoSchema,
 ] as const
 export const OutputSchema = z
   .object({

--- a/packages/botonic-plugin-ai-agents/src/structured-output/request-contact-info.ts
+++ b/packages/botonic-plugin-ai-agents/src/structured-output/request-contact-info.ts
@@ -1,0 +1,18 @@
+import {
+  OutputMessageType,
+  type RequestContactInfoMessage,
+} from '@botonic/core'
+import { z } from 'zod'
+
+export type { RequestContactInfoMessage }
+
+export const RequestContactInfoSchema = z
+  .object({
+    type: z.literal(OutputMessageType.RequestContactInfo),
+    content: z.object({
+      text: z.string().describe('The text of the message'),
+    }),
+  })
+  .describe(
+    'A message to request phone number from the user. Use it only when asked explicitly in the prompt.'
+  )

--- a/packages/botonic-plugin-ai-agents/tests/agent-builder.test.ts
+++ b/packages/botonic-plugin-ai-agents/tests/agent-builder.test.ts
@@ -268,6 +268,43 @@ describe('WorkerAgent', () => {
       const result = OutputSchema.safeParse(invalidOutput)
       expect(result.success).toBe(false)
     })
+
+    it('should validate requestContactInfo message', () => {
+      const validOutput = {
+        messages: [
+          {
+            type: 'requestContactInfo',
+            content: { text: 'Please share your phone number' },
+          },
+        ],
+      }
+
+      const result = OutputSchema.safeParse(validOutput)
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject requestContactInfo without content', () => {
+      const invalidOutput = {
+        messages: [{ type: 'requestContactInfo' }],
+      }
+
+      const result = OutputSchema.safeParse(invalidOutput)
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject requestContactInfo without text', () => {
+      const invalidOutput = {
+        messages: [
+          {
+            type: 'requestContactInfo',
+            content: {},
+          },
+        ],
+      }
+
+      const result = OutputSchema.safeParse(invalidOutput)
+      expect(result.success).toBe(false)
+    })
   })
 
   describe('Contact info prompt format', () => {
@@ -648,6 +685,14 @@ describe('WorkerAgent', () => {
           ],
         },
         { messages: [{ type: 'exit' }] },
+        {
+          messages: [
+            {
+              type: 'requestContactInfo',
+              content: { text: 'Please share your phone number' },
+            },
+          ],
+        },
       ]
 
       for (const msg of testMessages) {

--- a/packages/botonic-plugin-flow-builder/CHANGELOG.md
+++ b/packages/botonic-plugin-flow-builder/CHANGELOG.md
@@ -4,14 +4,6 @@ All notable changes to Botonic will be documented in this file.
 
 ## [Unreleased]
 
-### Added
-
-- [PR-3268](https://github.com/hubtype/botonic/pull/3268): Add support for `REQUEST_CONTACT_INFO` button in WhatsApp templates.
-- [PR-3272](https://github.com/hubtype/botonic/pull/3272): Add support for reading `whatsapp-request-contact-info` nodes from Flow Builder.
-
-### Fixed
-
-- Do not invoke the AI agent twice on first interaction when the start node already goes to an AI Agent flow.
 
 <details>
   <summary>
@@ -19,9 +11,13 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
   
-## [0.55.0] - 2026-mm-dd
+## [0.56.0] - 2026-mm-dd
 
 ### Added
+
+- [PR-3268](https://github.com/hubtype/botonic/pull/3268): Add support for `REQUEST_CONTACT_INFO` button in WhatsApp templates.
+- [PR-3272](https://github.com/hubtype/botonic/pull/3272): Add support for reading `whatsapp-request-contact-info` nodes from Flow Builder.
+- [PR-3273](https://github.com/hubtype/botonic/pull/3273):Add AI agent support for `requestContactInfo` messages: render from structured output, include CMS nodes in conversation history, and fall back to `Text` on non-WhatsApp channels.
 
 ### Changed
 

--- a/packages/botonic-plugin-flow-builder/package.json
+++ b/packages/botonic-plugin-flow-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-flow-builder",
-  "version": "0.55.2",
+  "version": "0.56.0-alpha.0",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "description": "Use Flow Builder to show your contents",
@@ -15,7 +15,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/react": "^0.55.1",
+    "@botonic/react": "^0.56.0-alpha.0",
     "axios": "^1.18.1",
     "uuid": "^10.0.0"
   },

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent-base.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-ai-agent-base.tsx
@@ -16,6 +16,7 @@ import { HubtypeAssistantContent } from '../utils/hubtype-assistant-content'
 import { ContentFieldsBase } from './content-fields-base'
 import { FlowCarousel } from './flow-carousel'
 import { FlowText } from './flow-text'
+import { FlowWhatsappRequestContactInfoNode } from './flow-whatsapp-request-contact-info'
 import type { HtInputGuardrailRule, HtNodeWithContent } from './hubtype-fields'
 import type { FlowContent } from './index'
 
@@ -86,6 +87,16 @@ export abstract class FlowAiAgentBase extends ContentFieldsBase {
       if (message.type === OutputMessageType.Carousel) {
         this.jsxElements.push(
           FlowCarousel.fromAIAgent(this.id, message, botContext)
+        )
+      }
+
+      if (message.type === OutputMessageType.RequestContactInfo) {
+        this.jsxElements.push(
+          FlowWhatsappRequestContactInfoNode.fromAIAgent(
+            this.id,
+            message,
+            botContext
+          )
         )
       }
 

--- a/packages/botonic-plugin-flow-builder/src/content-fields/flow-whatsapp-request-contact-info.tsx
+++ b/packages/botonic-plugin-flow-builder/src/content-fields/flow-whatsapp-request-contact-info.tsx
@@ -1,4 +1,8 @@
-import { type BotContext, isWhatsapp } from '@botonic/core'
+import {
+  type BotContext,
+  isWhatsapp,
+  type RequestContactInfoMessage,
+} from '@botonic/core'
 import { Text, WhatsappRequestContactInfo } from '@botonic/react'
 
 import { trackOneContent } from '../tracking'
@@ -24,6 +28,18 @@ export class FlowWhatsappRequestContactInfoNode extends ContentFieldsBase {
     requestContactInfo.followUp = component.follow_up
 
     return requestContactInfo
+  }
+
+  static fromAIAgent(
+    id: string,
+    message: RequestContactInfoMessage,
+    botContext: BotContext
+  ): JSX.Element {
+    if (!isWhatsapp(botContext.session)) {
+      return <Text key={id}>{message.content.text}</Text>
+    }
+
+    return <WhatsappRequestContactInfo key={id} body={message.content.text} />
   }
 
   async trackFlow(botContext: BotContext): Promise<void> {

--- a/packages/botonic-plugin-flow-builder/src/utils/hubtype-assistant-content.ts
+++ b/packages/botonic-plugin-flow-builder/src/utils/hubtype-assistant-content.ts
@@ -6,6 +6,7 @@ import { FlowImage } from '../content-fields/flow-image'
 import { FlowText } from '../content-fields/flow-text'
 import { FlowVideo } from '../content-fields/flow-video'
 import { FlowWhatsappCtaUrlButtonNode } from '../content-fields/flow-whatsapp-cta-url-button'
+import { FlowWhatsappRequestContactInfoNode } from '../content-fields/flow-whatsapp-request-contact-info'
 import { FlowWhatsappTemplate } from '../content-fields/flow-whatsapp-template'
 import { HtButtonStyle } from '../content-fields/hubtype-fields'
 import { FlowWhatsappButtonList } from '../content-fields/whatsapp-button-list/flow-whatsapp-button-list'
@@ -33,6 +34,9 @@ export class HubtypeAssistantContent {
     }
     if (content instanceof FlowWhatsappTemplate) {
       return HubtypeAssistantContent.formatWhatsappTemplateContent(content)
+    }
+    if (content instanceof FlowWhatsappRequestContactInfoNode) {
+      return HubtypeAssistantContent.formatRequestContactInfoContent(content)
     }
     return ''
   }
@@ -204,5 +208,15 @@ export class HubtypeAssistantContent {
   ): string {
     const { name, language } = template.htWhatsappTemplate
     return `WhatsApp Template: ${name} (${language})`
+  }
+
+  private static formatRequestContactInfoContent(
+    requestContactInfo: FlowWhatsappRequestContactInfoNode
+  ): string {
+    const body = requestContactInfo.text?.trim() ?? ''
+    if (!body) {
+      return '[WhatsApp Request Contact Info]'
+    }
+    return requestContactInfo.text
   }
 }

--- a/packages/botonic-plugin-flow-builder/tests/hubtype-assistant-content.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/hubtype-assistant-content.test.ts
@@ -14,6 +14,7 @@ import {
   FlowText,
   FlowVideo,
   FlowWhatsappCtaUrlButtonNode,
+  FlowWhatsappRequestContactInfoNode,
   FlowWhatsappTemplate,
 } from '../src/content-fields/index'
 import {
@@ -195,6 +196,24 @@ describe('HubtypeAssistantContentAdapter', () => {
       whatsappCta.url = 'https://a.com'
       expect(HubtypeAssistantContent.adapt(whatsappCta)).toBe(
         'H\nB\nF\n[Open] (https://a.com)'
+      )
+    })
+  })
+
+  describe('FlowWhatsappRequestContactInfoNode', () => {
+    test('returns text when body is present', () => {
+      const requestContactInfo = new FlowWhatsappRequestContactInfoNode('rci1')
+      requestContactInfo.text = 'Please share your phone number'
+      expect(HubtypeAssistantContent.adapt(requestContactInfo)).toBe(
+        'Please share your phone number'
+      )
+    })
+
+    test('returns placeholder when body is empty', () => {
+      const requestContactInfo = new FlowWhatsappRequestContactInfoNode('rci1')
+      requestContactInfo.text = ''
+      expect(HubtypeAssistantContent.adapt(requestContactInfo)).toBe(
+        '[WhatsApp Request Contact Info]'
       )
     })
   })

--- a/packages/botonic-plugin-flow-builder/tests/messages/flow-whatsapp-request-contact-info.test.ts
+++ b/packages/botonic-plugin-flow-builder/tests/messages/flow-whatsapp-request-contact-info.test.ts
@@ -1,11 +1,15 @@
-import { INPUT, PROVIDER } from '@botonic/core'
+import type { RequestContactInfoMessage } from '@botonic/core'
+import { INPUT, OutputMessageType, PROVIDER } from '@botonic/core'
 import { describe, expect, test } from '@jest/globals'
 import TestRenderer from 'react-test-renderer'
 
-import type { FlowWhatsappRequestContactInfoNode } from '../../src/content-fields/flow-whatsapp-request-contact-info'
+import { FlowWhatsappRequestContactInfoNode } from '../../src/content-fields/flow-whatsapp-request-contact-info'
 import { ProcessEnvNodeEnvs } from '../../src/types'
 import { whatsappRequestContactInfoFlow } from '../helpers/flows/whatsapp-request-contact-info'
-import { createFlowBuilderPluginAndGetContents } from '../helpers/utils'
+import {
+  createFlowBuilderPluginAndGetContents,
+  createRequest,
+} from '../helpers/utils'
 
 const renderToJSON = (sut: JSX.Element) => TestRenderer.create(sut).toJSON()
 
@@ -61,6 +65,44 @@ describe('Check the contents of a whatsapp request contact info node', () => {
     const requestContactInfoContent =
       contents[0] as FlowWhatsappRequestContactInfoNode
     const rendered = requestContactInfoContent.toBotonic(request)
+
+    expect(rendered.props.children).toBe('Please share your phone number')
+  })
+})
+
+describe('FlowWhatsappRequestContactInfoNode.fromAIAgent', () => {
+  const message: RequestContactInfoMessage = {
+    type: OutputMessageType.RequestContactInfo,
+    content: { text: 'Please share your phone number' },
+  }
+
+  test('renders WhatsappRequestContactInfo on WhatsApp', () => {
+    const request = createRequest({
+      input: { data: 'test', type: INPUT.TEXT },
+      provider: PROVIDER.WHATSAPP,
+    })
+    const rendered = renderToJSON(
+      FlowWhatsappRequestContactInfoNode.fromAIAgent('id', message, request)
+    )
+
+    expect(rendered).toMatchInlineSnapshot(`
+<message
+  body="Please share your phone number"
+  type="whatsapp-request-contact-info"
+/>
+`)
+  })
+
+  test('renders text fallback on webchat', () => {
+    const request = createRequest({
+      input: { data: 'test', type: INPUT.TEXT },
+      provider: PROVIDER.WEBCHAT,
+    })
+    const rendered = FlowWhatsappRequestContactInfoNode.fromAIAgent(
+      'id',
+      message,
+      request
+    )
 
     expect(rendered.props.children).toBe('Please share your phone number')
   })

--- a/packages/botonic-plugin-hubtype-analytics/package.json
+++ b/packages/botonic-plugin-hubtype-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/plugin-hubtype-analytics",
-  "version": "0.55.0",
+  "version": "0.56.0-alpha.0",
   "description": "Plugin for tracking in the Hubtype backend to see the results in the Hubtype Dashbord",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.0",
-    "@botonic/core": "^0.55.0",
+    "@botonic/core": "^0.56.0-alpha.0",
     "axios": "^1.18.1"
   },
   "devDependencies": {

--- a/packages/botonic-react/CHANGELOG.md
+++ b/packages/botonic-react/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Botonic will be documented in this file.
     Click to see more.
   </summary>
 
-## [0.55.x] - 2026-mm-dd
+## [0.56.x] - 2026-mm-dd
 
 ### Added
 

--- a/packages/botonic-react/package.json
+++ b/packages/botonic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botonic/react",
-  "version": "0.55.1",
+  "version": "0.56.0-alpha.0",
   "license": "MIT",
   "description": "Build Chatbots using React",
   "main": "./lib/cjs",
@@ -20,7 +20,7 @@
     "format": "biome format --write src/ tests/"
   },
   "dependencies": {
-    "@botonic/core": "^0.55.1",
+    "@botonic/core": "^0.56.0-alpha.0",
     "axios": "^1.18.1",
     "emoji-picker-react": "^4.12.0",
     "lodash.merge": "^4.6.2",


### PR DESCRIPTION
## Description

Adds the `requestContactInfo` output message type so AI agents can ask users for their phone number on WhatsApp. The message is validated through the structured output schema, rendered as a native WhatsApp contact request button, and included in the conversation history sent back to the agent.

## Context

This pull request is part of the **Request Contact Info** feature ([BLT-2622](https://hubtype.atlassian.net/browse/BLT-2622) / [BLT-2623](https://hubtype.atlassian.net/browse/BLT-2623)).

The previous pull request ([#3272](https://github.com/hubtype/botonic/pull/3272)) added support for `whatsapp-request-contact-info` nodes in Flow Builder. This one extends that capability to AI agents: when the agent prompt instructs it to collect the user's phone number, the agent can respond with a `requestContactInfo` message instead of plain text.

## Approach taken / Explain the design

The implementation follows the same pattern as the other AI agent output message types (`text`, `carousel`, `exit`, etc.):

1. **`@botonic/core`**: Adds `OutputMessageType.RequestContactInfo` and the `RequestContactInfoMessage` interface with a `content.text` field.
2. **`@botonic/plugin-ai-agents`**: Adds a Zod schema (`RequestContactInfoSchema`) and registers it in `OutputSchema` so the agent's structured output is validated at runtime.
3. **`@botonic/plugin-flow-builder`**:
   - `FlowAiAgentBase` handles `RequestContactInfo` messages from the agent output and delegates rendering to `FlowWhatsappRequestContactInfoNode.fromAIAgent()`.
   - On **WhatsApp**, it renders the `WhatsappRequestContactInfo` React component (native contact request button).
   - On **other channels** (e.g. webchat), it falls back to a plain `Text` message with the same body.
   - `HubtypeAssistantContent` formats the node for conversation history so the agent sees the request text in subsequent turns.

## To document / Usage example

The AI agent can return a `requestContactInfo` message in its structured output when the prompt explicitly asks to collect the user's phone number:

```json
{
  "messages": [
    {
      "type": "requestContactInfo",
      "content": {
        "text": "Please share your phone number so we can contact you."
      }
    }
  ]
}
```

On WhatsApp, this renders as a native "Share phone number" button. On webchat and other channels, the user sees the text as a regular message.

No additional configuration is required beyond instructing the agent in its prompt to use this message type when phone collection is needed.

## Testing

The pull request...

- [x] has unit tests
- [ ] has integration tests
- [ ] doesn't need tests because... **[provide a description]**

[BLT-2622]: https://hubtype.atlassian.net/browse/BLT-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BLT-2623]: https://hubtype.atlassian.net/browse/BLT-2623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ